### PR TITLE
fix: copy refreshed auth cookies to redirect responses in proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -43,7 +43,11 @@ export async function proxy(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.pathname = "/login";
     url.searchParams.set("next", path);
-    return NextResponse.redirect(url);
+    const redirect = NextResponse.redirect(url);
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      redirect.cookies.set(cookie.name, cookie.value);
+    });
+    return redirect;
   }
 
   // Redirect authenticated users away from login
@@ -52,7 +56,11 @@ export async function proxy(request: NextRequest) {
     const url = request.nextUrl.clone();
     url.pathname = next;
     url.searchParams.delete("next");
-    return NextResponse.redirect(url);
+    const redirect = NextResponse.redirect(url);
+    supabaseResponse.cookies.getAll().forEach((cookie) => {
+      redirect.cookies.set(cookie.name, cookie.value);
+    });
+    return redirect;
   }
 
   return supabaseResponse;


### PR DESCRIPTION
## Summary
- Copies refreshed Supabase auth cookies from `supabaseResponse` onto redirect responses in `src/proxy.ts`
- Prevents infinite redirect loop between `/login` and `/dashboard` when the access token refreshes mid-request

## Root cause
`NextResponse.redirect()` creates a new response object that doesn't carry cookies from `supabaseResponse`. After token refresh, the redirect would lose the new cookies, causing the next request to see a stale token and redirect again — indefinitely.

## Test plan
- [ ] Sign in via GitHub OAuth, wait for token to near expiry (~1 hour), then navigate to app — should land on `/dashboard` without looping
- [ ] Verify unauthenticated users are still redirected from `/dashboard` to `/login`
- [ ] Verify authenticated users are still redirected from `/login` to `/dashboard`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)