### PR TITLE
fix: handle user insert failure and break dashboard redirect loop

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -49,7 +49,7 @@ export async function GET(request: Request) {
       user.email?.split("@")[0] ||
       "User";
 
-    await admin.from("users").insert({
+    const { error: insertError } = await admin.from("users").insert({
       id: user.id,
       org_id: null, // Will be set when creating/joining an org
       role: "manager", // First user defaults to manager
@@ -57,6 +57,13 @@ export async function GET(request: Request) {
       display_name: displayName,
       email: user.email,
     });
+
+    if (insertError) {
+      console.error("Failed to create user record:", insertError);
+      return NextResponse.redirect(
+        `${origin}/login?error=user_creation_failed`
+      );
+    }
 
     // New user with no org — redirect to setup
     return NextResponse.redirect(`${origin}/dashboard/setup`);

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  missing_user_record:
+    "Your sign-in succeeded, but your account could not be set up. Please sign out and try again. If the problem persists, contact support.",
+};
+
+const DEFAULT_MESSAGE =
+  "Something went wrong during authentication. Please try signing in again.";
+
+export default function AuthErrorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ reason?: string }>;
+}) {
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    window.location.href = "/login";
+  }
+
+  // Use React.use() would be needed for async searchParams in Next 16,
+  // but for a simple client component we read from the URL directly
+  const reason =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("reason")
+      : null;
+
+  const message = (reason && ERROR_MESSAGES[reason]) || DEFAULT_MESSAGE;
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
+      <div className="w-full max-w-sm space-y-6 rounded-xl border border-white/10 bg-white/[0.02] p-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-white">Budi Cloud</h1>
+          <p className="mt-1 text-sm text-zinc-400">Authentication Error</p>
+        </div>
+
+        <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+          {message}
+        </div>
+
+        <div className="space-y-3">
+          <button
+            onClick={handleSignOut}
+            className="w-full rounded-lg bg-white px-4 py-2.5 text-sm font-medium text-black transition-colors hover:bg-zinc-200"
+          >
+            Sign out and try again
+          </button>
+          <a
+            href="/login"
+            className="block w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-white/10"
+          >
+            Back to login
+          </a>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -12,7 +12,7 @@ export default async function DashboardLayout({
 }) {
   const user = await getCurrentUser();
 
-  if (!user) redirect("/login");
+  if (!user) redirect("/auth/error?reason=missing_user_record");
   if (!user.org_id) redirect("/dashboard/setup");
 
   return (


### PR DESCRIPTION
## Summary

Fixes #2 — Auth callback fails to create user record → dashboard redirect loop.

- **Auth callback** (`src/app/auth/callback/route.ts`): The `admin.from("users").insert()` result was not checked for errors. Now captures the error and redirects to `/login?error=user_creation_failed` on failure, with a `console.error` for server-side debugging.
- **Dashboard layout** (`src/app/dashboard/layout.tsx`): When `getCurrentUser()` returns null (auth session exists but no `users` row), previously redirected to `/login` — which the proxy redirected back to `/dashboard` for authenticated users → infinite loop. Now redirects to `/auth/error?reason=missing_user_record` instead, which the proxy does not intercept.
- **New `/auth/error` page** (`src/app/auth/error/page.tsx`): Shows a descriptive error message and provides a "Sign out and try again" button.

## Test plan

- [ ] Sign in via GitHub OAuth with a fresh account → user record should be created in the `users` table and redirect to `/dashboard/setup`
- [ ] Simulate insert failure (e.g., temporarily revoke service_role permissions) → should redirect to `/login?error=user_creation_failed` instead of silently failing
- [ ] If a user has an auth session but no `users` table record, navigating to `/dashboard` should land on `/auth/error` (not an infinite redirect loop)
- [ ] The `/auth/error` page should display the error message and allow signing out
- [ ] `next build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)