### PR TITLE
fix: add rewrite so /v1/* routes to /api/v1/* for daemon compatibility

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/v1/:path*",
+        destination: "/api/v1/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Adds a Next.js rewrite rule in `next.config.ts` so that `/v1/:path*` is transparently routed to `/api/v1/:path*`
- This allows the daemon's default endpoint (`https://app.getbudi.dev`) to work without requiring a dedicated `api.getbudi.dev` subdomain or changes to the daemon's URL construction

## Test plan
- [ ] Verify `/v1/ingest` returns the same response as `/api/v1/ingest`
- [ ] Verify existing `/api/v1/ingest` route still works directly

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)