### PR TITLE
feat: add copy-to-clipboard button with full budi cloud join command

### DIFF
--- a/src/app/dashboard/settings/api-key-section.tsx
+++ b/src/app/dashboard/settings/api-key-section.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export function ApiKeySection({ apiKey }: { apiKey: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const command = `budi cloud join --api-key ${apiKey}`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Your API Key</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="mb-2 text-sm text-zinc-400">
+          Use this key with{" "}
+          <code className="text-zinc-300">budi cloud join</code> on your local
+          machine to start syncing data.
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="block flex-1 rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+            {command}
+          </code>
+          <button
+            onClick={handleCopy}
+            className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+          >
+            {copied ? "Copied!" : "Copy"}
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,6 +1,7 @@
 import { getCurrentUser, getOrgMembers } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { ApiKeySection } from "./api-key-section";
 import { InviteSection } from "./invite-section";
 
 export default async function SettingsPage() {
@@ -40,20 +41,7 @@ export default async function SettingsPage() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Your API Key</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="mb-2 text-sm text-zinc-400">
-            Use this key with <code className="text-zinc-300">budi cloud join</code> on
-            your local machine to start syncing data.
-          </p>
-          <code className="block rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
-            {user.api_key}
-          </code>
-        </CardContent>
-      </Card>
+      <ApiKeySection apiKey={user.api_key} />
 
       <Card>
         <CardHeader>


### PR DESCRIPTION
## Summary
- Extracts the API key card into a new `ApiKeySection` client component
- Displays the full `budi cloud join --api-key <key>` command instead of just the raw key
- Adds a "Copy" button that copies the command to clipboard with brief "Copied!" feedback
- Follows the same UI patterns as the existing `InviteSection` copy button

## Test plan
- [ ] Verify the Settings page shows the full `budi cloud join --api-key ...` command
- [ ] Click "Copy" and verify it copies the full command to clipboard
- [ ] Verify "Copied!" feedback appears and resets after 2 seconds

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)