### PR TITLE
Add cloud privacy, team model, and auth docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,38 @@ Cloud dashboard and ingest API for [budi](https://github.com/siropkin/budi). Pro
 
 Built with Next.js 16, Supabase, and Tailwind CSS.
 
+## What data the cloud receives
+
+The budi daemon pushes **pre-aggregated daily rollups and session summaries** — numeric metrics only. The cloud never receives prompts, code, AI responses, file paths, email addresses, raw payloads, or tag values. There is no "full upload" mode.
+
+What syncs: token counts, costs, model names, hashed repo IDs, branch names, ticket IDs, session durations, and message counts.
+
+See [ADR-0083](https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md) for the complete privacy contract.
+
+## Transport and trust model
+
+- **HTTPS only** — the daemon refuses to sync over plain HTTP
+- **Push-only** — the daemon initiates all connections; the cloud never reaches back to developer machines. There is no webhook, pull, or remote command channel
+- **Idempotent** — sync uses UPSERT semantics with deterministic keys; retries are safe and produce no duplicates
+
+## Team model (cloud alpha)
+
+The cloud alpha supports small teams (1–20 developers):
+
+| Aspect | Detail |
+|--------|--------|
+| **Roles** | `manager` (view all org data, manage members) and `member` (sync data, view own data) |
+| **Granularity** | Daily aggregates; no per-message, per-hour, or real-time views |
+| **Retention** | 90 days |
+| **Multi-org** | Not supported in v1 — one user belongs to one org |
+| **SSO / SAML** | Not supported in v1 — API key auth for daemon sync, Supabase Auth (GitHub, Google, magic link) for the web dashboard |
+
+## Auth
+
+- **Web dashboard**: Supabase Auth with GitHub, Google, and magic link sign-in
+- **Daemon sync**: API key (`budi_<key>`) in `Authorization: Bearer` header. Keys are stored locally in `~/.config/budi/cloud.toml`
+- **Ingest API**: `POST /v1/ingest` receives the sync payload; `GET /v1/ingest/status` returns watermark and sync health
+
 ## Setup
 
 1. Copy `.env.local.example` to `.env.local` and fill in your Supabase project keys


### PR DESCRIPTION
## Summary

Companion to siropkin/budi#198 (docs review pass for cloud round, issue siropkin/budi#105).

Expands the budi-cloud README with sections required by ADR-0083:
- **What data the cloud receives** — what syncs and what is structurally excluded
- **Transport and trust model** — HTTPS-only, push-only, idempotent
- **Team model** — roles, granularity, retention (90 days), v1 limitations (no multi-org, no SSO/SAML)
- **Auth** — Supabase Auth for web dashboard, API key for daemon sync

### Risks / compatibility notes

Docs-only changes. No code, config, or behavior changes.

### Validation

- `npm run build` — pass