### PR TITLE
[8.0] Enforce member-only data visibility in cloud dashboard

### DIFF
--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -16,7 +16,7 @@ export default async function ModelsPage({
   if (!user?.org_id) return null;
 
   const range = dateRangeFromDays(params.days);
-  const models = await getCostByModel(user.org_id, range);
+  const models = await getCostByModel(user, range);
 
   return (
     <div className="space-y-6">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,8 +18,8 @@ export default async function OverviewPage({
 
   const range = dateRangeFromDays(params.days);
   const [stats, activity] = await Promise.all([
-    getOverviewStats(user.org_id, range),
-    getDailyActivity(user.org_id, range),
+    getOverviewStats(user, range),
+    getDailyActivity(user, range),
   ]);
 
   return (

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -22,9 +22,9 @@ export default async function ReposPage({
 
   const range = dateRangeFromDays(params.days);
   const [repos, branches, tickets] = await Promise.all([
-    getCostByRepo(user.org_id, range),
-    getCostByBranch(user.org_id, range),
-    getCostByTicket(user.org_id, range),
+    getCostByRepo(user, range),
+    getCostByBranch(user, range),
+    getCostByTicket(user, range),
   ]);
 
   return (

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -34,7 +34,7 @@ export default async function SessionsPage({
   if (!user?.org_id) return null;
 
   const range = dateRangeFromDays(params.days);
-  const sessions = await getSessions(user.org_id, range);
+  const sessions = await getSessions(user, range);
 
   return (
     <div className="space-y-6">

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -16,7 +16,7 @@ export default async function TeamPage({
   if (!user?.org_id) return null;
 
   const range = dateRangeFromDays(params.days);
-  const userCosts = await getCostByUser(user.org_id, range);
+  const userCosts = await getCostByUser(user, range);
 
   return (
     <div className="space-y-6">

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -39,13 +39,13 @@ export async function getCurrentUser(): Promise<BudiUser | null> {
 }
 
 /**
- * Get overview stats for the org.
+ * Get overview stats visible to the current user.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getOverviewStats(orgId: string, range: DateRange) {
+export async function getOverviewStats(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
 
-  // Get all device IDs in this org
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) {
     return {
       totalCostCents: 0,
@@ -87,10 +87,11 @@ export async function getOverviewStats(orgId: string, range: DateRange) {
 
 /**
  * Get daily cost activity for charts.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getDailyActivity(orgId: string, range: DateRange) {
+export async function getDailyActivity(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -127,15 +128,17 @@ export async function getDailyActivity(orgId: string, range: DateRange) {
 
 /**
  * Get cost breakdown by user/device.
+ * Manager sees all users; member sees only their own cost (ADR-0083 §6).
  */
-export async function getCostByUser(orgId: string, range: DateRange) {
+export async function getCostByUser(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
 
-  // Get users and their devices
-  const { data: orgUsers } = await admin
-    .from("users")
-    .select("id, display_name, email")
-    .eq("org_id", orgId);
+  // Get users visible to the current user
+  const userFilter =
+    user.role === "manager"
+      ? admin.from("users").select("id, display_name, email").eq("org_id", user.org_id!)
+      : admin.from("users").select("id, display_name, email").eq("id", user.id);
+  const { data: orgUsers } = await userFilter;
 
   if (!orgUsers?.length) return [];
 
@@ -166,8 +169,8 @@ export async function getCostByUser(orgId: string, range: DateRange) {
   // Map device costs to users
   const byUser = new Map<string, { name: string; cost_cents: number }>();
   for (const device of devices ?? []) {
-    const user = orgUsers.find((u) => u.id === device.user_id);
-    const name = user?.display_name || user?.email || device.user_id.slice(0, 8);
+    const owner = orgUsers.find((u) => u.id === device.user_id);
+    const name = owner?.display_name || owner?.email || device.user_id.slice(0, 8);
     const deviceCost = byDevice.get(device.id) ?? 0;
     const existing = byUser.get(device.user_id);
     if (existing) {
@@ -184,10 +187,11 @@ export async function getCostByUser(orgId: string, range: DateRange) {
 
 /**
  * Get cost breakdown by model.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getCostByModel(orgId: string, range: DateRange) {
+export async function getCostByModel(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -219,10 +223,11 @@ export async function getCostByModel(orgId: string, range: DateRange) {
 
 /**
  * Get cost breakdown by repo.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getCostByRepo(orgId: string, range: DateRange) {
+export async function getCostByRepo(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -245,10 +250,11 @@ export async function getCostByRepo(orgId: string, range: DateRange) {
 
 /**
  * Get cost breakdown by branch.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getCostByBranch(orgId: string, range: DateRange) {
+export async function getCostByBranch(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -280,10 +286,11 @@ export async function getCostByBranch(orgId: string, range: DateRange) {
 
 /**
  * Get cost breakdown by ticket.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getCostByTicket(orgId: string, range: DateRange) {
+export async function getCostByTicket(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -309,10 +316,11 @@ export async function getCostByTicket(orgId: string, range: DateRange) {
 
 /**
  * Get sessions list.
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
  */
-export async function getSessions(orgId: string, range: DateRange) {
+export async function getSessions(user: BudiUser, range: DateRange) {
   const admin = createAdminClient();
-  const deviceIds = await getOrgDeviceIds(admin, orgId);
+  const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
   const { data: sessions } = await admin
@@ -342,6 +350,27 @@ export async function getOrgMembers(orgId: string) {
 }
 
 // --- Helpers ---
+
+/**
+ * Get device IDs visible to the current user.
+ * Per ADR-0083 §6:
+ *   - Manager: sees all devices in the org
+ *   - Member: sees only their own devices
+ */
+async function getVisibleDeviceIds(
+  admin: ReturnType<typeof createAdminClient>,
+  user: BudiUser
+): Promise<string[]> {
+  if (user.role === "manager") {
+    return getOrgDeviceIds(admin, user.org_id!);
+  }
+  // Member: own devices only
+  const { data: devices } = await admin
+    .from("devices")
+    .select("id")
+    .eq("user_id", user.id);
+  return (devices ?? []).map((d) => d.id);
+}
 
 async function getOrgDeviceIds(
   admin: ReturnType<typeof createAdminClient>,


### PR DESCRIPTION
## Summary

Per ADR-0083 §6, the dashboard must enforce role-based data visibility:
- **Manager**: sees aggregated cost data across the entire org (unchanged behavior)
- **Member**: sees only data from their own devices

This PR:
- Adds a `getVisibleDeviceIds(admin, user)` helper that returns all org devices for managers, but only the user's own devices for members
- Updates all DAL query functions (`getOverviewStats`, `getDailyActivity`, `getCostByUser`, `getCostByModel`, `getCostByRepo`, `getCostByBranch`, `getCostByTicket`, `getSessions`) to accept `BudiUser` instead of `orgId`
- `getCostByUser` additionally restricts the user list for members (shows only their own cost entry)
- `getOrgMembers` (settings page) is unchanged — members can still see org membership info

Closes siropkin/budi#194

## Risks / Compatibility Notes

- **Breaking change to DAL function signatures**: All data-fetching functions now take `BudiUser` instead of `orgId: string`. All callers in this repo are updated.
- **No migration needed**: The filtering is purely application-level (the admin client bypasses RLS). No SQL migration required.
- **Edge case**: If a member has no registered devices, all data views return empty. This is correct behavior — they'll see data once their daemon syncs.

## Validation

- `npm ci && npm run build` — passes with no TypeScript errors
- Manual review of all 6 changed files confirms correct parameter threading