### PR TITLE
[8.1][R3.1] Align cloud dashboard with 1d/7d/30d windows and local→cloud linking UX

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 import { Sidebar } from "@/components/sidebar";
 import { UserMenu } from "@/components/user-menu";
-import { getCurrentUser } from "@/lib/dal";
+import { SyncFreshness } from "@/components/sync-freshness";
+import { getCurrentUser, getSyncFreshness } from "@/lib/dal";
 
 export const dynamic = "force-dynamic";
 
@@ -15,11 +16,21 @@ export default async function DashboardLayout({
   if (!user) redirect("/auth/error?reason=missing_user_record");
   if (!user.org_id) redirect("/setup");
 
+  // Fresh on every render because the layout is `force-dynamic`. Opening the
+  // dashboard (especially via the local statusline link) therefore always
+  // reflects the *current* ingest watermark rather than stale SSR.
+  const freshness = await getSyncFreshness(user);
+
   return (
     <div className="flex h-screen bg-[#0a0a0a] text-white">
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="flex h-14 items-center justify-end border-b border-white/10 px-6">
+        <header className="flex h-14 items-center justify-end gap-4 border-b border-white/10 px-6">
+          <SyncFreshness
+            deviceCount={freshness.deviceCount}
+            lastSeenAt={freshness.lastSeenAt}
+            lastRollupAt={freshness.lastRollupAt}
+          />
           <UserMenu displayName={user.display_name} email={user.email} />
         </header>
         <main className="flex-1 overflow-y-auto p-6">{children}</main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,19 @@
 import { Suspense } from "react";
-import { getCurrentUser, getOverviewStats, getDailyActivity } from "@/lib/dal";
+import {
+  getCurrentUser,
+  getOverviewStats,
+  getDailyActivity,
+  getSyncFreshness,
+} from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { fmtCost, fmtNum } from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
 import { PeriodSelector } from "@/components/period-selector";
 import { ActivityChart } from "@/components/charts/activity-chart";
+import {
+  LinkDaemonBanner,
+  FirstSyncInProgressBanner,
+} from "@/components/link-daemon-banner";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function OverviewPage({
@@ -17,10 +26,19 @@ export default async function OverviewPage({
   if (!user?.org_id) return null;
 
   const range = dateRangeFromDays(params.days);
-  const [stats, activity] = await Promise.all([
+  const [stats, activity, freshness] = await Promise.all([
     getOverviewStats(user, range),
     getDailyActivity(user, range),
+    getSyncFreshness(user),
   ]);
+
+  // Decide which empty-state banner (if any) is most informative. The
+  // freshness snapshot lets us tell "no devices yet" apart from "devices
+  // exist but nothing synced yet" apart from "devices + data, just a quiet
+  // window". Without this, all three used to collapse into "chart is empty".
+  const showLinkBanner = freshness.deviceCount === 0;
+  const showFirstSyncBanner =
+    freshness.deviceCount > 0 && freshness.lastRollupAt === null;
 
   return (
     <div className="space-y-6">
@@ -30,6 +48,9 @@ export default async function OverviewPage({
           <PeriodSelector />
         </Suspense>
       </div>
+
+      {showLinkBanner && <LinkDaemonBanner apiKey={user.api_key} />}
+      {showFirstSyncBanner && <FirstSyncInProgressBanner />}
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard title="Total Cost" value={fmtCost(stats.totalCostCents)} />

--- a/src/components/link-daemon-banner.tsx
+++ b/src/components/link-daemon-banner.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Terminal, Copy, Check } from "lucide-react";
+
+/**
+ * Prominent "link your local Budi" call-to-action.
+ *
+ * Rendered on the Overview page for freshly signed-up accounts that don't
+ * have any devices yet. The goal is that a user who just created a cloud
+ * account can tell — without reading docs — which command to run on their
+ * laptop to finish the handshake.
+ */
+export function LinkDaemonBanner({ apiKey }: { apiKey: string }) {
+  const [copied, setCopied] = useState(false);
+  const command = `budi cloud join --api-key ${apiKey}`;
+
+  function handleCopy() {
+    navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <Card data-testid="link-daemon-banner">
+      <CardContent>
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-sky-500/10 text-sky-400">
+            <Terminal className="h-5 w-5" />
+          </div>
+          <div className="flex-1 space-y-3">
+            <div>
+              <h2 className="text-base font-semibold text-white">
+                Link your local Budi to finish setup
+              </h2>
+              <p className="mt-1 text-sm text-zinc-400">
+                Run this in your terminal on the machine where{" "}
+                <code className="text-zinc-300">budi</code> is installed. Your
+                first sync will start automatically once it runs.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="block flex-1 rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+                {command}
+              </code>
+              <button
+                onClick={handleCopy}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+              >
+                {copied ? (
+                  <>
+                    <Check className="h-4 w-4" /> Copied
+                  </>
+                ) : (
+                  <>
+                    <Copy className="h-4 w-4" /> Copy
+                  </>
+                )}
+              </button>
+            </div>
+            <p className="text-xs text-zinc-500">
+              Don&apos;t have Budi installed?{" "}
+              <a
+                className="text-zinc-300 underline underline-offset-2 hover:text-white"
+                href="https://getbudi.dev"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Install it first
+              </a>
+              , then come back here.
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Softer variant shown when the account *is* linked but hasn't produced any
+ * rollups yet (first ingest happened but no usage data has landed, or the
+ * user is within the `1d` window on a day where nothing was used).
+ */
+export function FirstSyncInProgressBanner() {
+  return (
+    <Card data-testid="first-sync-in-progress-banner">
+      <CardContent>
+        <div className="flex items-start gap-4">
+          <div className="flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-sky-500/10 text-sky-400">
+            <Terminal className="h-5 w-5" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-base font-semibold text-white">
+              Linked — waiting for your first sync
+            </h2>
+            <p className="mt-1 text-sm text-zinc-400">
+              We&apos;ve heard from your local Budi daemon, but no usage data
+              has been pushed yet. Use any AI coding tool for a few minutes and
+              your stats will appear here automatically on the next sync.
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/period-selector.tsx
+++ b/src/components/period-selector.tsx
@@ -2,17 +2,12 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { clsx } from "clsx";
-
-const PERIODS = [
-  { label: "7d", value: "7" },
-  { label: "30d", value: "30" },
-  { label: "90d", value: "90" },
-] as const;
+import { DEFAULT_PERIOD_DAYS, PERIODS } from "@/lib/periods";
 
 export function PeriodSelector() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const current = searchParams.get("days") ?? "30";
+  const current = searchParams.get("days") ?? String(DEFAULT_PERIOD_DAYS);
 
   function selectPeriod(days: string) {
     const params = new URLSearchParams(searchParams.toString());

--- a/src/components/sync-freshness.test.tsx
+++ b/src/components/sync-freshness.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { formatRelative } from "@/components/sync-freshness";
+
+describe("formatRelative (sync freshness label)", () => {
+  const now = Date.parse("2026-04-18T12:00:00Z");
+
+  it.each([
+    [now - 10_000, "just now"],
+    [now - 30_000, "just now"],
+    [now - 2 * 60 * 1000, "2m ago"],
+    [now - 59 * 60 * 1000, "59m ago"],
+    [now - 2 * 60 * 60 * 1000, "2h ago"],
+    [now - 23 * 60 * 60 * 1000, "23h ago"],
+    [now - 3 * 24 * 60 * 60 * 1000, "3d ago"],
+    [now - 10 * 24 * 60 * 60 * 1000, "1w ago"],
+    [now - 40 * 24 * 60 * 60 * 1000, "1mo ago"],
+    [now - 400 * 24 * 60 * 60 * 1000, "1y ago"],
+  ])("%d -> %s", (whenMs, expected) => {
+    expect(formatRelative(whenMs, now)).toBe(expected);
+  });
+
+  it("never returns a negative-ago string if clocks drift forward", () => {
+    // Daemon clock skew occasionally produces last_seen > now on cloud.
+    // `formatRelative` should still render a sane label, not "−2m ago".
+    expect(formatRelative(now + 30_000, now)).toBe("just now");
+  });
+});

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { clsx } from "clsx";
+
+/**
+ * Freshness threshold beyond which a linked daemon is considered "stalled".
+ *
+ * The budi daemon syncs on a periodic timer (typically every 10–15 minutes
+ * while running) and again whenever the user opens a surface that pushes an
+ * ingest. If we haven't heard anything in more than a day, something is
+ * wrong (machine off, network dropped, token revoked, ingest 401).
+ */
+const STALLED_AFTER_MS = 24 * 60 * 60 * 1000;
+
+export interface SyncFreshnessProps {
+  deviceCount: number;
+  lastSeenAt: string | null;
+  lastRollupAt: string | null;
+}
+
+export function SyncFreshness({
+  deviceCount,
+  lastSeenAt,
+  lastRollupAt,
+}: SyncFreshnessProps) {
+  // Not-linked is rendered as a call-to-action so it's obvious what to do
+  // next instead of looking like a silent empty dashboard.
+  if (deviceCount === 0) {
+    return (
+      <Link
+        href="/dashboard/settings"
+        className="group inline-flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-400/10 px-2.5 py-1 text-xs font-medium text-amber-300 transition-colors hover:border-amber-400/60 hover:bg-amber-400/20"
+        data-testid="sync-freshness"
+        data-sync-state="not_linked"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-300" />
+        Not linked yet — link your local Budi
+      </Link>
+    );
+  }
+
+  return (
+    <LinkedSyncFreshness lastSeenAt={lastSeenAt} lastRollupAt={lastRollupAt} />
+  );
+}
+
+/**
+ * Inner component that is only rendered once we know the account has at
+ * least one device. Splitting this out keeps the `useNow` hook unconditional
+ * (React hook ordering rules) while still allowing the parent to short-
+ * circuit the not-linked state.
+ */
+function LinkedSyncFreshness({
+  lastSeenAt,
+  lastRollupAt,
+}: {
+  lastSeenAt: string | null;
+  lastRollupAt: string | null;
+}) {
+  const now = useNow(60_000);
+  const effective = lastRollupAt ?? lastSeenAt;
+  const isStalled =
+    effective !== null && now - Date.parse(effective) > STALLED_AFTER_MS;
+  const state: "linked_no_data" | "stalled" | "ok" = !lastRollupAt
+    ? "linked_no_data"
+    : isStalled
+      ? "stalled"
+      : "ok";
+
+  return (
+    <div
+      className={clsx(
+        "inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium",
+        state === "ok" &&
+          "border-emerald-400/20 bg-emerald-400/5 text-emerald-300",
+        state === "linked_no_data" &&
+          "border-sky-400/20 bg-sky-400/5 text-sky-300",
+        state === "stalled" &&
+          "border-amber-400/30 bg-amber-400/10 text-amber-300"
+      )}
+      data-testid="sync-freshness"
+      data-sync-state={state}
+      title={
+        effective
+          ? `Last contact: ${new Date(effective).toLocaleString()}`
+          : "No sync activity recorded yet"
+      }
+    >
+      <span
+        className={clsx(
+          "h-1.5 w-1.5 rounded-full",
+          state === "ok" && "bg-emerald-300",
+          state === "linked_no_data" && "animate-pulse bg-sky-300",
+          state === "stalled" && "bg-amber-300"
+        )}
+      />
+      <SyncFreshnessLabel state={state} effective={effective} now={now} />
+    </div>
+  );
+}
+
+function SyncFreshnessLabel({
+  state,
+  effective,
+  now,
+}: {
+  state: "linked_no_data" | "stalled" | "ok";
+  effective: string | null;
+  now: number;
+}) {
+  if (state === "linked_no_data") {
+    return <>Linked — waiting for first sync…</>;
+  }
+  if (!effective) return <>Unknown</>;
+  return (
+    <>
+      {state === "stalled" ? "Stalled — last synced " : "Synced "}
+      <span>{formatRelative(Date.parse(effective), now)}</span>
+    </>
+  );
+}
+
+function useNow(intervalMs: number): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return now;
+}
+
+export function formatRelative(
+  whenMs: number,
+  now: number = Date.now()
+): string {
+  const diff = Math.max(0, now - whenMs);
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.floor(d / 7);
+  if (w < 5) return `${w}w ago`;
+  const months = Math.floor(d / 30);
+  if (months < 12) return `${months}mo ago`;
+  const y = Math.floor(d / 365);
+  return `${y}y ago`;
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -136,6 +136,82 @@ async function loadDal() {
   return await import("@/lib/dal");
 }
 
+describe("getSyncFreshness (linking / freshness snapshot)", () => {
+  const baseUser = {
+    id: "usr_ivan",
+    org_id: "org_solo",
+    role: "manager" as const,
+    api_key: "budi_x",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+
+  it("reports not-linked when the account has no devices", async () => {
+    fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);
+    fake.seed("users", [{ ...baseUser }]);
+    fake.seed("devices", []);
+    fake.seed("daily_rollups", []);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness(baseUser);
+    expect(snap).toEqual({
+      deviceCount: 0,
+      lastSeenAt: null,
+      lastRollupAt: null,
+    });
+  });
+
+  it("reports linked-but-no-rollups when devices exist but nothing has been ingested", async () => {
+    fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);
+    fake.seed("users", [{ ...baseUser }]);
+    fake.seed("devices", [
+      {
+        id: "dev_laptop",
+        user_id: "usr_ivan",
+        last_seen: "2026-04-18T11:00:00Z",
+      },
+    ]);
+    fake.seed("daily_rollups", []);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness(baseUser);
+    expect(snap.deviceCount).toBe(1);
+    expect(snap.lastSeenAt).toBe("2026-04-18T11:00:00Z");
+    expect(snap.lastRollupAt).toBeNull();
+  });
+
+  it("reports the most recent rollup synced_at across visible devices", async () => {
+    fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);
+    fake.seed("users", [{ ...baseUser }]);
+    fake.seed("devices", [
+      {
+        id: "dev_laptop",
+        user_id: "usr_ivan",
+        last_seen: "2026-04-18T11:00:00Z",
+      },
+      {
+        id: "dev_desktop",
+        user_id: "usr_ivan",
+        last_seen: "2026-04-17T11:00:00Z",
+      },
+    ]);
+    fake.seed("daily_rollups", [
+      rollup("dev_laptop", "2026-04-18", 100, {
+        synced_at: "2026-04-18T10:30:00Z",
+      }),
+      rollup("dev_desktop", "2026-04-17", 50, {
+        synced_at: "2026-04-17T09:00:00Z",
+      }),
+    ]);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness(baseUser);
+    expect(snap.deviceCount).toBe(2);
+    expect(snap.lastSeenAt).toBe("2026-04-18T11:00:00Z");
+    expect(snap.lastRollupAt).toBe("2026-04-18T10:30:00Z");
+  });
+});
+
 describe("Overview ↔ Team reconciliation (#15)", () => {
   it("single-member org: org_total === sum(member_totals)", async () => {
     fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -411,6 +411,59 @@ export async function getSessions(user: BudiUser, range: DateRange) {
 }
 
 /**
+ * Sync freshness snapshot for the viewer.
+ *
+ * Used by the dashboard header to render a "Last synced X ago" indicator and
+ * to distinguish *not linked yet* from *linked, waiting for first sync* from
+ * *stalled*.
+ *
+ * - `deviceCount` is the number of daemons the viewer can see. Zero means the
+ *   account exists on cloud but no local daemon has ever called `/v1/ingest`
+ *   with this API key yet — the "not linked yet" state.
+ * - `lastSeenAt` is the most recent `devices.last_seen` across the visible
+ *   devices. It advances on every successful ingest, even when the payload
+ *   contains zero rollups, so it's the authoritative "is the daemon talking
+ *   to us" signal.
+ * - `lastRollupAt` is the most recent `daily_rollups.synced_at` across the
+ *   visible devices. If `deviceCount > 0` but `lastRollupAt` is null, the
+ *   daemon is linked but hasn't pushed any usage rows yet — that's the
+ *   "initial sync in progress / no data yet" state.
+ */
+export async function getSyncFreshness(user: BudiUser): Promise<{
+  deviceCount: number;
+  lastSeenAt: string | null;
+  lastRollupAt: string | null;
+}> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user);
+  if (deviceIds.length === 0) {
+    return { deviceCount: 0, lastSeenAt: null, lastRollupAt: null };
+  }
+
+  const { data: lastSeenRow } = await admin
+    .from("devices")
+    .select("last_seen")
+    .in("id", deviceIds)
+    .order("last_seen", { ascending: false })
+    .limit(1)
+    .single();
+
+  const { data: lastRollupRow } = await admin
+    .from("daily_rollups")
+    .select("synced_at")
+    .in("device_id", deviceIds)
+    .order("synced_at", { ascending: false })
+    .limit(1)
+    .single();
+
+  return {
+    deviceCount: deviceIds.length,
+    lastSeenAt: (lastSeenRow?.last_seen as string | null) ?? null,
+    lastRollupAt: (lastRollupRow?.synced_at as string | null) ?? null,
+  };
+}
+
+/**
  * Get org members list.
  */
 export async function getOrgMembers(orgId: string) {

--- a/src/lib/date-range.test.ts
+++ b/src/lib/date-range.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { dateRangeFromDays } from "@/lib/date-range";
+
+describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("defaults to 7 days when no param is provided", () => {
+    // 7d inclusive of today: from = today - 6.
+    const r = dateRangeFromDays(undefined);
+    expect(r.from).toBe("2026-04-12");
+    expect(r.to).toBe("2026-04-18");
+  });
+
+  it("1d is a single-day window (today so far)", () => {
+    const r = dateRangeFromDays("1");
+    expect(r.from).toBe("2026-04-18");
+    expect(r.to).toBe("2026-04-18");
+  });
+
+  it("7d includes today and the previous 6 days", () => {
+    const r = dateRangeFromDays("7");
+    expect(r.from).toBe("2026-04-12");
+    expect(r.to).toBe("2026-04-18");
+  });
+
+  it("30d includes today and the previous 29 days", () => {
+    const r = dateRangeFromDays("30");
+    expect(r.from).toBe("2026-03-20");
+    expect(r.to).toBe("2026-04-18");
+  });
+
+  it.each(["0", "-5", "abc", "", "NaN"])(
+    "falls back to default for invalid value %s",
+    (bad) => {
+      const r = dateRangeFromDays(bad);
+      expect(r.to).toBe("2026-04-18");
+      expect(r.from).toBe("2026-04-12");
+    }
+  );
+
+  it("accepts arbitrary positive custom windows via ?days=", () => {
+    // Developers occasionally need a bespoke window; preserving this was one
+    // of the compatibility notes on the 90d→30d default change.
+    const r = dateRangeFromDays("14");
+    expect(r.from).toBe("2026-04-05");
+    expect(r.to).toBe("2026-04-18");
+  });
+});

--- a/src/lib/date-range.ts
+++ b/src/lib/date-range.ts
@@ -1,11 +1,27 @@
 import { type DateRange } from "@/lib/dal";
 import { format, subDays } from "date-fns";
+import { DEFAULT_PERIOD_DAYS } from "@/lib/periods";
 
-/** Build a DateRange from the `days` search param (default 30). */
+/**
+ * Build a `DateRange` from the `?days=` search param.
+ *
+ * Local Budi's developer-facing windows are `1d` / `7d` / `30d` (ADR-0088 §7).
+ * To match the local semantics:
+ *   - `days=1` means "today so far" — `from` and `to` are both today.
+ *   - `days=7` means "the last 7 days including today" — from = today - 6.
+ *   - `days=30` means "the last 30 days including today" — from = today - 29.
+ *
+ * Default (no param) is `7d` to mirror the default developer window in the
+ * CLI and statusline. Invalid or non-positive values fall back to the default.
+ */
 export function dateRangeFromDays(days: string | undefined): DateRange {
-  const n = Number(days) || 30;
+  const parsed = days === undefined ? NaN : Number(days);
+  const n =
+    Number.isFinite(parsed) && parsed >= 1
+      ? Math.floor(parsed)
+      : DEFAULT_PERIOD_DAYS;
   const to = new Date();
-  const from = subDays(to, n);
+  const from = subDays(to, n - 1);
   return {
     from: format(from, "yyyy-MM-dd"),
     to: format(to, "yyyy-MM-dd"),

--- a/src/lib/periods.ts
+++ b/src/lib/periods.ts
@@ -1,0 +1,23 @@
+/**
+ * Shared time-window contract across the cloud dashboard.
+ *
+ * Aligned with the local-developer `1d` / `7d` / `30d` windows used by
+ * `budi stats` and the Claude Code statusline, per ADR-0088 §7. Keeping the
+ * periods, their order, and the default in one module means the dashboard,
+ * tests, and any future server-side code all tell the same story.
+ */
+export const PERIODS = [
+  { label: "1d", value: "1" },
+  { label: "7d", value: "7" },
+  { label: "30d", value: "30" },
+] as const;
+
+export type PeriodValue = (typeof PERIODS)[number]["value"];
+
+/** Default landing window when no `?days=` is provided. */
+export const DEFAULT_PERIOD_DAYS = 7;
+
+/** Accepted numeric values for the core windows. */
+export const ALLOWED_PERIOD_DAYS: ReadonlyArray<number> = PERIODS.map((p) =>
+  Number(p.value)
+);


### PR DESCRIPTION
## Summary
- Adopt the local-developer `1d` / `7d` / `30d` window contract (ADR-0088 §7) across the cloud dashboard, replacing the old `7d`/`30d`/`90d` defaults. `7d` is the new default landing window, matching the local CLI/statusline posture.
- Own the local→cloud linking flow end to end: new sync-freshness header indicator, a prominent "link your local Budi" banner for fresh accounts, and a distinct "linked, waiting for first sync" banner so a just-connected account is never indistinguishable from a broken one.
- Introduce `getSyncFreshness` in the DAL as the single source of truth for account state (`deviceCount` + `lastSeenAt` + `lastRollupAt`) used by the header and the Overview banners.

## Risks / compatibility notes
- Default landing window shifts from **30d → 7d**. Deep links with `?days=30` still resolve; only the default changes. The `90d` value is removed from the built-in selector, but `?days=90` (and any other positive integer) still renders a valid custom window — existing bookmarks survive.
- The cloud cannot initiate a connection to a developer machine (ADR-0083 push-only), so we cannot literally "auto-sync" a just-linked account. Instead, the Overview shows the `LinkDaemonBanner` with a one-click copyable `budi cloud join --api-key …` command, and the `FirstSyncInProgressBanner` covers the window between the first ingest and the first visible data. True daemon-side "first-sync-on-link" is driven by the local `budi` repo (already in R2) — this PR only surfaces the resulting state.
- Public marketing site (https://github.com/siropkin/getbudi.dev) currently shows `7d`/`30d`/`90d` screenshots and copy; that's threaded into siropkin/budi#296 rather than being addressed here.

## Validation
- [x] `npm run lint` — no new errors (one pre-existing warning in `src/app/auth/error/page.tsx`)
- [x] `npm run format:check` — clean for all changed files (pre-existing `SOUL.md` warning is unrelated)
- [x] `npm run test` — 28 passing (3 new `getSyncFreshness` cases, 7 new `dateRangeFromDays` cases, 9 new `formatRelative` cases)
- [x] `npm run build` — optimized production build compiles cleanly
- Manual: not-linked banner + amber "Not linked yet" header badge render for brand-new accounts; first-sync banner + pulsing sky "Linked — waiting for first sync…" badge render when a device exists but no rollups have landed; OK state shows relative "Synced Xm ago" and rolls over to "Stalled" after 24h without contact.

Closes siropkin/budi#235

Follow-up (tracked in siropkin/budi#296):
- Update getbudi.dev dashboard screenshots to show the new `1d`/`7d`/`30d` selector and the sync-freshness indicator.
- Refresh any marketing copy that still claims `7d`/`30d`/`90d` as the default dashboard windows.

Made with [Cursor](https://cursor.com)