### PR TITLE
fix(dal): use .maybeSingle() on optional rollup lookup in getSyncFreshness

### DIFF
--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -98,6 +98,16 @@ class FakeQuery {
     };
   }
 
+  async maybeSingle() {
+    const rows = this.materialize();
+    if (rows.length === 0) return { data: null, error: null };
+    if (rows.length === 1) return { data: rows[0], error: null };
+    return {
+      data: null,
+      error: { message: `expected 0 or 1 row, got ${rows.length}` },
+    };
+  }
+
   then<T>(
     onFulfilled: (r: { data: Row[]; error: null; count: number | null }) => T
   ) {

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -448,13 +448,18 @@ export async function getSyncFreshness(user: BudiUser): Promise<{
     .limit(1)
     .single();
 
+  // `.maybeSingle()` because the "linked but no rollups yet" first-run state
+  // legitimately returns zero rows (covered by `FirstSyncInProgressBanner`).
+  // `.single()` would emit a PGRST116 / HTTP 406 row in production logs on
+  // every freshly-linked-no-data render even though the call site already
+  // tolerates `data: null` (see #22).
   const { data: lastRollupRow } = await admin
     .from("daily_rollups")
     .select("synced_at")
     .in("device_id", deviceIds)
     .order("synced_at", { ascending: false })
     .limit(1)
-    .single();
+    .maybeSingle();
 
   return {
     deviceCount: deviceIds.length,


### PR DESCRIPTION
## Summary

- Swap `.single()` → `.maybeSingle()` on the `daily_rollups.synced_at` lookup in `getSyncFreshness` so the expected "linked but no rollups yet" first-run state stops emitting PGRST116 / HTTP 406 noise into Supabase server logs on every render.
- Behavior is unchanged: the call site already destructures `data` as `null` and coerces to `null`, and the `FirstSyncInProgressBanner` already owns the UX for the empty case.
- Left the sibling `devices.last_seen` query on `.single()` because it is gated by `deviceIds.length > 0` and always matches at least one row, so it remains safe.

## Why this is safe

- The cloud surface for "linked but no rollups yet" is rendered by a dedicated banner (per the window-contract / linking flow in `SOUL.md`), not by interpreting an error from the freshness query — so silencing the 406 does not hide any user-visible state.
- `.maybeSingle()` keeps the row-shape contract (`data` is `{ synced_at }` or `null`).

## Test plan

- [x] `npm test -- src/lib/dal.test.ts` — all 5 tests pass (including the existing `linked-but-no-rollups` case which exercises the empty path).
- [x] `npm run lint` — no new warnings introduced.
- [x] Added `maybeSingle()` to the in-test fake Supabase client so the test harness stays representative of the real client surface.

Closes #22.

Made with [Cursor](https://cursor.com)