### PR TITLE
fix: replace non-existent `budi cloud join` with working TOML flow (#25)

### DIFF
--- a/src/app/dashboard/settings/api-key-section.tsx
+++ b/src/app/dashboard/settings/api-key-section.tsx
@@ -6,7 +6,13 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export function ApiKeySection({ apiKey }: { apiKey: string }) {
   const [copied, setCopied] = useState(false);
 
-  const command = `budi cloud join --api-key ${apiKey}`;
+  // Budi 8.2.x has no `budi cloud` link verb — users configure cloud sync
+  // by writing ~/.config/budi/cloud.toml directly. A one-shot
+  // `budi cloud init --api-key` is tracked for 8.3 in siropkin/budi#446.
+  const command = `mkdir -p ~/.config/budi && cat >~/.config/budi/cloud.toml <<'TOML'
+enabled = true
+api_key = "${apiKey}"
+TOML`;
 
   function handleCopy() {
     navigator.clipboard.writeText(command);
@@ -21,12 +27,13 @@ export function ApiKeySection({ apiKey }: { apiKey: string }) {
       </CardHeader>
       <CardContent>
         <p className="mb-2 text-sm text-zinc-400">
-          Use this key with{" "}
-          <code className="text-zinc-300">budi cloud join</code> on your local
-          machine to start syncing data.
+          Paste this on your local machine to point Budi at your cloud
+          account. A one-command{" "}
+          <code className="text-zinc-300">budi cloud init</code> flow is
+          coming in Budi 8.3.
         </p>
-        <div className="flex items-center gap-2">
-          <code className="block flex-1 rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+        <div className="flex items-start gap-2">
+          <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
             {command}
           </code>
           <button

--- a/src/components/link-daemon-banner.tsx
+++ b/src/components/link-daemon-banner.tsx
@@ -14,7 +14,13 @@ import { Terminal, Copy, Check } from "lucide-react";
  */
 export function LinkDaemonBanner({ apiKey }: { apiKey: string }) {
   const [copied, setCopied] = useState(false);
-  const command = `budi cloud join --api-key ${apiKey}`;
+  // Budi 8.2.x has no `budi cloud` link verb — users configure cloud sync
+  // by writing ~/.config/budi/cloud.toml directly. A one-shot
+  // `budi cloud init --api-key` is tracked for 8.3 in siropkin/budi#446.
+  const command = `mkdir -p ~/.config/budi && cat >~/.config/budi/cloud.toml <<'TOML'
+enabled = true
+api_key = "${apiKey}"
+TOML`;
 
   function handleCopy() {
     navigator.clipboard.writeText(command);
@@ -35,13 +41,16 @@ export function LinkDaemonBanner({ apiKey }: { apiKey: string }) {
                 Link your local Budi to finish setup
               </h2>
               <p className="mt-1 text-sm text-zinc-400">
-                Run this in your terminal on the machine where{" "}
-                <code className="text-zinc-300">budi</code> is installed. Your
-                first sync will start automatically once it runs.
+                Paste this in your terminal on the machine where{" "}
+                <code className="text-zinc-300">budi</code> is installed — it
+                writes <code className="text-zinc-300">cloud.toml</code> so
+                the daemon picks up your key on its next cycle. A one-command{" "}
+                <code className="text-zinc-300">budi cloud init</code> flow is
+                coming in Budi 8.3.
               </p>
             </div>
-            <div className="flex items-center gap-2">
-              <code className="block flex-1 rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+            <div className="flex items-start gap-2">
+              <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
                 {command}
               </code>
               <button


### PR DESCRIPTION
## Summary

Fixes #25 — the Settings page and the new-user "Link your local Budi" banner both displayed `budi cloud join --api-key <key>`, a subcommand that does not exist on the current Budi 8.2.x release (the CLI only ships `status` and `sync`). New users copying the command got `error: unrecognized subcommand 'join'`.

This PR replaces the bad command in both places with the actual supported linking flow on 8.2.x — a heredoc that writes `~/.config/budi/cloud.toml` — and nudges users that a one-shot `budi cloud init --api-key` will land in Budi 8.3 (tracked upstream in siropkin/budi#446). Once that ships, the UI can collapse back to a single-line command and we can gate by CLI version.

Picks Option B from the issue to preserve the copy-to-clipboard UX: the command the button copies now runs on a stock 8.2.x install.

## Changes

- `src/app/dashboard/settings/api-key-section.tsx` — swap command + copy text; use `whitespace-pre-wrap` so the heredoc renders readably.
- `src/components/link-daemon-banner.tsx` — same swap in the Overview onboarding banner.

## Test plan

- [x] `npm run lint` — no new warnings.
- [x] `npm run build` — Next build succeeds.
- [x] `npm test` — 28/28 vitest pass.
- [ ] Manual: load `/dashboard/settings` and the Overview banner, click **Copy**, paste into a shell — the heredoc runs cleanly and produces a valid `cloud.toml`.
- [ ] Manual: confirm `budi cloud status` then picks up the key on next sync cycle.

## Follow-up

- Once siropkin/budi#446 ships in 8.3.0, replace the heredoc with `budi cloud init --api-key <key>` and gate the copy by installed CLI version (or just add a "requires Budi 8.3+" note next to the button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)