### PR TITLE
fix: buttons should use cursor: pointer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -18,6 +18,10 @@ body {
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }
 
+button:not(:disabled) {
+  cursor: pointer;
+}
+
 /* Recharts tooltip overrides for dark theme */
 .recharts-tooltip-wrapper {
   outline: none;


### PR DESCRIPTION
## Summary
- Adds a global `button:not(:disabled) { cursor: pointer; }` rule in `src/app/globals.css` so every enabled `<button>` shows the pointer cursor on hover.
- Disabled buttons keep the default cursor, preserving the inert affordance.

Closes #30

## Test plan
- [ ] Hover an enabled button (e.g. dashboard period selector) — cursor is a pointer hand.
- [ ] Hover a disabled button — cursor stays as the default arrow.
- [ ] No new `cursor-pointer` utility classes required on future buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)