### PR TITLE
chore: remove dead code and unused exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "next": "16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "recharts": "^3.8.1",
-        "tailwind-merge": "^3.5.0"
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -7202,16 +7201,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tailwind-merge": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "recharts": "^3.8.1",
-    "tailwind-merge": "^3.5.0"
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -10,19 +10,15 @@ const ERROR_MESSAGES: Record<string, string> = {
 const DEFAULT_MESSAGE =
   "Something went wrong during authentication. Please try signing in again.";
 
-export default function AuthErrorPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ reason?: string }>;
-}) {
+export default function AuthErrorPage() {
   async function handleSignOut() {
     const supabase = createClient();
     await supabase.auth.signOut();
     window.location.href = "/login";
   }
 
-  // Use React.use() would be needed for async searchParams in Next 16,
-  // but for a simple client component we read from the URL directly
+  // Client component: read directly from the URL rather than routing through
+  // the server `searchParams` prop (which would require React.use() in N16).
   const reason =
     typeof window !== "undefined"
       ? new URLSearchParams(window.location.search).get("reason")

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -14,17 +14,15 @@ import { clsx } from "clsx";
  */
 const STALLED_AFTER_MS = 24 * 60 * 60 * 1000;
 
-export interface SyncFreshnessProps {
-  deviceCount: number;
-  lastSeenAt: string | null;
-  lastRollupAt: string | null;
-}
-
 export function SyncFreshness({
   deviceCount,
   lastSeenAt,
   lastRollupAt,
-}: SyncFreshnessProps) {
+}: {
+  deviceCount: number;
+  lastSeenAt: string | null;
+  lastRollupAt: string | null;
+}) {
   // Not-linked is rendered as a call-to-action so it's obvious what to do
   // next instead of looking like a silent empty dashboard.
   if (deviceCount === 0) {

--- a/src/lib/periods.ts
+++ b/src/lib/periods.ts
@@ -17,15 +17,8 @@ export const PERIODS = [
   { label: "All", value: "all" },
 ] as const;
 
-export type PeriodValue = (typeof PERIODS)[number]["value"];
-
 /** Sentinel `?days=` value for the lifetime window. */
 export const ALL_PERIOD_VALUE = "all";
 
 /** Default landing window when no `?days=` is provided. */
 export const DEFAULT_PERIOD_DAYS = 7;
-
-/** Accepted numeric values for the core windows. */
-export const ALLOWED_PERIOD_DAYS: ReadonlyArray<number> = PERIODS.filter(
-  (p) => p.value !== ALL_PERIOD_VALUE
-).map((p) => Number(p.value));


### PR DESCRIPTION
## Summary

Housekeeping pass — no runtime or UX change. Removes dead code surfaced by `knip` and one dead prop surfaced by ESLint.

- **`tailwind-merge`** — dropped from `package.json` / `package-lock.json`. Nothing imported it; `clsx` is already used for conditional classes throughout the codebase.
- **`src/lib/periods.ts`** — deleted the unused `PeriodValue` type alias and the unused `ALLOWED_PERIOD_DAYS` export.
- **`src/components/sync-freshness.tsx`** — de-exported `SyncFreshnessProps`; it was only referenced as the function's own parameter type, so it's now inlined at the callsite.
- **`src/app/auth/error/page.tsx`** — removed the `searchParams` prop from `AuthErrorPage`. The component reads the URL directly via `window.location.search`, so the prop was declared but never consumed (also silenced a standing `@typescript-eslint/no-unused-vars` warning).

## Notes

`knip` still flags `postcss` and `server-only` as "unlisted dependencies" — those are false positives. `postcss` is transitively provided by `@tailwindcss/postcss`, and `server-only` is bundled with Next.js. Neither is dead code. No source files were orphaned.

## Test plan

- [x] `npm run lint` — clean (previously emitted one `no-unused-vars` warning on `searchParams`)
- [x] `npm test` — 30/30 pass
- [x] `npm run build` — succeeds
- [x] `npx knip` — no more unused exports / unused dependencies reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)