### PR TITLE
chore: drop remaining dead exports and write-only test fields

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -27,7 +27,7 @@ class FakeSupabase {
 
   from(name: string) {
     if (!this.tables.has(name)) this.tables.set(name, []);
-    return new FakeQuery(this.tables.get(name)!, name);
+    return new FakeQuery(this.tables.get(name)!);
   }
 
   seed(name: string, rows: Row[]) {
@@ -44,17 +44,12 @@ class FakeQuery {
   private _orderKey: string | null = null;
   private _orderAsc = true;
   private _limit: number | null = null;
-  private _selectCols: string | null = null;
   private _head = false;
   private _countMode: "exact" | null = null;
 
-  constructor(
-    private readonly rows: Row[],
-    private readonly name: string
-  ) {}
+  constructor(private readonly rows: Row[]) {}
 
-  select(cols?: string, opts?: { count?: "exact"; head?: boolean }) {
-    this._selectCols = cols ?? null;
+  select(_cols?: string, opts?: { count?: "exact"; head?: boolean }) {
     this._countMode = opts?.count ?? null;
     this._head = opts?.head ?? false;
     return this;

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -7,7 +7,7 @@ export interface DateRange {
   to: string; // YYYY-MM-DD
 }
 
-export interface BudiUser {
+interface BudiUser {
   id: string;
   org_id: string | null;
   role: string;
@@ -166,7 +166,7 @@ export async function getEarliestActivity(
 }
 
 /** Synthetic user id used to group rollups whose owner we can't surface. */
-export const UNASSIGNED_USER_ID = "__unassigned__";
+const UNASSIGNED_USER_ID = "__unassigned__";
 
 /**
  * Get cost breakdown by user/device.


### PR DESCRIPTION
## Summary

Follow-up dead-code pass after #33.

- `src/lib/dal.ts`: `BudiUser` and `UNASSIGNED_USER_ID` are only referenced inside the DAL itself. Dropping the `export` keyword on both so the module's public surface matches what's actually consumed.
- `src/app/api/v1/ingest/route.test.ts`: the `FakeQuery` test fake had `_selectCols` (written in `select()`, never read) and a `name` constructor parameter that was stored but never used. Removed both.

Nothing else turned up — no unused files, no unused dependencies, lint is clean.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 30/30 tests pass
- [x] Verified `BudiUser` / `UNASSIGNED_USER_ID` have no external importers via grep
- [x] Verified `_selectCols` and `name` are never read in the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)