### PR TITLE
feat(dashboard): chart readability pass for #37

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -53,6 +53,22 @@ export default async function ReposPage({
               }))}
               emptyLabel="No project data for this period"
             />
+            <p className="mt-3 text-xs text-zinc-500">
+              <span className="text-zinc-400">Unassigned</span> and{" "}
+              <span className="text-zinc-400">(untagged)</span> aggregate spend
+              from sessions whose directory didn&rsquo;t map to a known git
+              remote. Your local Budi&rsquo;s privacy layer strips the repo
+              identifier in that case; see{" "}
+              <a
+                className="underline decoration-dotted underline-offset-2 hover:text-zinc-300"
+                href="https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md"
+                target="_blank"
+                rel="noreferrer"
+              >
+                ADR-0083
+              </a>
+              .
+            </p>
           </CardContent>
         </Card>
 

--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -10,7 +10,7 @@ import {
   YAxis,
 } from "recharts";
 import { differenceInDays, format, startOfMonth, startOfWeek } from "date-fns";
-import { fmtDate, fmtNum } from "@/lib/format";
+import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
 
 interface ActivityData {
   bucket_day: string;
@@ -91,6 +91,13 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
           tick={{ fill: "#71717a", fontSize: 12 }}
           tickLine={false}
           axisLine={false}
+          label={{
+            value: "Tokens",
+            angle: -90,
+            position: "insideLeft",
+            offset: 8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
         />
         <Tooltip
           contentStyle={{
@@ -99,7 +106,7 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
             borderRadius: "8px",
             fontSize: "13px",
           }}
-          labelFormatter={(label) => fmtDate(String(label))}
+          labelFormatter={(label) => fmtFullDate(String(label))}
           formatter={(value, name) => [
             fmtNum(Number(value)),
             String(name) === "input_tokens" ? "Input" : "Output",

--- a/src/components/period-selector.tsx
+++ b/src/components/period-selector.tsx
@@ -2,7 +2,11 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { clsx } from "clsx";
-import { DEFAULT_PERIOD_DAYS, PERIODS } from "@/lib/periods";
+import {
+  DEFAULT_PERIOD_DAYS,
+  PERIODS,
+  formatPeriodCaption,
+} from "@/lib/periods";
 
 export function PeriodSelector() {
   const router = useRouter();
@@ -16,21 +20,29 @@ export function PeriodSelector() {
   }
 
   return (
-    <div className="flex gap-1 rounded-lg border border-white/10 bg-white/[0.02] p-1">
-      {PERIODS.map((p) => (
-        <button
-          key={p.value}
-          onClick={() => selectPeriod(p.value)}
-          className={clsx(
-            "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-            current === p.value
-              ? "bg-white/10 text-white"
-              : "text-zinc-400 hover:text-zinc-200"
-          )}
-        >
-          {p.label}
-        </button>
-      ))}
+    <div className="flex items-center gap-3">
+      <span
+        className="hidden text-xs text-zinc-400 sm:inline"
+        data-testid="period-caption"
+      >
+        {formatPeriodCaption(current)}
+      </span>
+      <div className="flex gap-1 rounded-lg border border-white/10 bg-white/[0.02] p-1">
+        {PERIODS.map((p) => (
+          <button
+            key={p.value}
+            onClick={() => selectPeriod(p.value)}
+            className={clsx(
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              current === p.value
+                ? "bg-white/10 text-white"
+                : "text-zinc-400 hover:text-zinc-200"
+            )}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -38,3 +38,13 @@ export function fmtDate(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
+
+/** Long-form date for chart tooltips — includes year so the window is unambiguous. */
+export function fmtFullDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00");
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/src/lib/periods.test.ts
+++ b/src/lib/periods.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { formatPeriodCaption } from "@/lib/periods";
+
+describe("formatPeriodCaption", () => {
+  it("falls back to the default window when the param is missing", () => {
+    expect(formatPeriodCaption(undefined)).toBe("Showing last 7 days");
+  });
+
+  it("uses singular copy for a one-day window", () => {
+    expect(formatPeriodCaption("1")).toBe("Showing last 1 day");
+  });
+
+  it("matches the numeric value for preset windows", () => {
+    expect(formatPeriodCaption("7")).toBe("Showing last 7 days");
+    expect(formatPeriodCaption("30")).toBe("Showing last 30 days");
+  });
+
+  it("labels the lifetime preset explicitly", () => {
+    expect(formatPeriodCaption("all")).toBe("Showing all time");
+  });
+
+  it("falls back to the default when the param is unparseable", () => {
+    expect(formatPeriodCaption("garbage")).toBe("Showing last 7 days");
+    expect(formatPeriodCaption("-5")).toBe("Showing last 7 days");
+    expect(formatPeriodCaption("0")).toBe("Showing last 7 days");
+  });
+});

--- a/src/lib/periods.ts
+++ b/src/lib/periods.ts
@@ -22,3 +22,17 @@ export const ALL_PERIOD_VALUE = "all";
 
 /** Default landing window when no `?days=` is provided. */
 export const DEFAULT_PERIOD_DAYS = 7;
+
+/**
+ * Human-readable caption for the active period — shown beside the selector so
+ * a fresh user can tell at a glance which window the dashboard is summarizing.
+ * Falls back to the default window when `days` is missing or unparseable so
+ * the caption always matches what the data access layer actually queried.
+ */
+export function formatPeriodCaption(days: string | undefined): string {
+  if (days === ALL_PERIOD_VALUE) return "Showing all time";
+  const n = Number(days);
+  const window = Number.isFinite(n) && n > 0 ? n : DEFAULT_PERIOD_DAYS;
+  if (window === 1) return "Showing last 1 day";
+  return `Showing last ${window} days`;
+}


### PR DESCRIPTION
## Summary

Scoped fix for the **section C** findings in #37 — the fresh-eyes UX audit — since the meta-issue explicitly invites splitting into smaller tickets. A, B, and the remaining C items (hover-on-Unassigned in the bar chart itself) stay as separate follow-ups.

- **C1** — Period selector now captions the active window inline (\`Showing last 7 days\` / \`Showing last 1 day\` / \`Showing last 30 days\` / \`Showing all time\`). Drives from the same source as \`dateRangeFromDays\`, so it can't drift from the data the dashboard actually queried.
- **C2** — \`Daily Activity (Tokens)\` chart gains a rotated \`Tokens\` y-axis label and swaps the tooltip date to long form (\`Apr 17, 2026\`) so the unit and window are unambiguous.
- **C3** — Repos → \`Cost by Project\` card now carries a one-line footer explaining the \`Unassigned\` / \`(untagged)\` buckets and links to ADR-0083 so a fresh user isn't alarmed by a large Unassigned bar dominating the breakdown.

New \`formatPeriodCaption\` helper lives next to \`PERIODS\` in \`src/lib/periods.ts\` (keeping the window contract in one place) and is unit-tested.

Closes part of #37.

## Test plan

- [x] \`npm test\` — 35/35 pass (5 new tests on \`formatPeriodCaption\`)
- [x] \`npm run lint\`
- [x] \`npm run build\` — production build succeeds
- [ ] Manual smoke on \`/dashboard\`: period caption updates as the buttons change, Tokens y-axis reads upright
- [ ] Manual smoke on \`/dashboard/repos\`: Unassigned footnote renders, ADR-0083 link opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)