### PR TITLE
fix(chart): stop Tokens y-axis label overlapping 400K tick

### DIFF
--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -72,7 +72,7 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
     <ResponsiveContainer width="100%" height={300}>
       <BarChart
         data={bucketed}
-        margin={{ left: 12, right: 8, top: 8, bottom: 8 }}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
       >
         <CartesianGrid
           strokeDasharray="3 3"
@@ -91,11 +91,13 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
           tick={{ fill: "#71717a", fontSize: 12 }}
           tickLine={false}
           axisLine={false}
+          width={72}
           label={{
             value: "Tokens",
             angle: -90,
             position: "insideLeft",
-            offset: 8,
+            offset: 0,
+            dx: -8,
             style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
           }}
         />


### PR DESCRIPTION
## Summary
- Reserve a 72px gutter on the activity chart's Y-axis (`width={72}`) and nudge the rotated label 8px left with `dx` so it sits outside the tick column.
- Bump `margin.left` from 12 → 16 for a touch more breathing room without wasting plot width.

Closes #42.

## Test plan
- [x] `npm test --run`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Visually verify `/dashboard` at 1d / 7d / 30d / All — `Tokens` label no longer overlaps any tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)