### PR TITLE
ui(settings): render member role as a pill badge

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx";
 import { getCurrentUser, getOrgMembers } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -67,11 +68,12 @@ export default async function SettingsPage() {
                     <td className="py-2 text-zinc-400">{m.email || "-"}</td>
                     <td className="py-2">
                       <span
-                        className={
+                        className={clsx(
+                          "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
                           m.role === "manager"
-                            ? "text-blue-400"
-                            : "text-zinc-400"
-                        }
+                            ? "border-blue-500/30 bg-blue-500/10 text-blue-300"
+                            : "border-zinc-500/30 bg-zinc-500/10 text-zinc-400"
+                        )}
                       >
                         {m.role}
                       </span>


### PR DESCRIPTION
## Summary
- Replace the bare `text-blue-400` span in the Team Members table with a non-interactive pill.
- Manager = blue border/bg/text; member = zinc. Same pattern as the Danger zone card so it reads as a status chip, not a link.

Closes #44.

## Test plan
- [x] `npm test --run`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Visually verify `/dashboard/settings` — manager and member rows render as pills, no hover/pointer affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)