### PR TITLE
fix(repos): collapse Unassigned / (untagged) into one bucket

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -31,6 +31,20 @@ export default async function ReposPage({
     getCostByTicket(user, range),
   ]);
 
+  // Multiple raw `repo_id` sentinels can collapse to the same display label
+  // (e.g. `"Unassigned"` and `"(untagged)"` both render as `"(no repo)"`),
+  // which would otherwise show up as duplicate bars. Merge by label so the
+  // chart has one row per bucket the user actually sees.
+  const repoBuckets = new Map<string, number>();
+  for (const r of repos) {
+    const label = repoName(r.repo_id);
+    repoBuckets.set(label, (repoBuckets.get(label) ?? 0) + r.cost_cents);
+  }
+  const repoChartData = Array.from(repoBuckets, ([label, cost_cents]) => ({
+    label,
+    cost_cents,
+  })).sort((a, b) => b.cost_cents - a.cost_cents);
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -47,15 +61,11 @@ export default async function ReposPage({
           </CardHeader>
           <CardContent>
             <CostBarChart
-              data={repos.map((r) => ({
-                label: repoName(r.repo_id),
-                cost_cents: r.cost_cents,
-              }))}
+              data={repoChartData}
               emptyLabel="No project data for this period"
             />
             <p className="mt-3 text-xs text-zinc-500">
-              <span className="text-zinc-400">Unassigned</span> and{" "}
-              <span className="text-zinc-400">(untagged)</span> aggregate spend
+              <span className="text-zinc-400">(no repo)</span> aggregates spend
               from sessions whose directory didn&rsquo;t map to a known git
               remote. Your local Budi&rsquo;s privacy layer strips the repo
               identifier in that case; see{" "}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -19,9 +19,17 @@ export function fmtNum(n: number): string {
   return n.toLocaleString("en-US");
 }
 
-/** Extract a short repo name from a hashed repo_id. */
+/**
+ * Extract a short repo name from a hashed repo_id.
+ *
+ * The daemon emits two historical sentinels when a session's directory has
+ * no resolvable git remote — `"Unassigned"` (legacy) and `"(untagged)"`
+ * (current). Both mean the same thing to the viewer, so collapse them to a
+ * single display bucket. Don't rewrite DB values; just unify at render time.
+ */
 export function repoName(repoId: string | null): string {
   if (!repoId) return "(unknown)";
+  if (repoId === "Unassigned" || repoId === "(untagged)") return "(no repo)";
   if (repoId.startsWith("sha256:")) return repoId.slice(7, 15) + "...";
   if (repoId.length > 16) return repoId.slice(0, 12) + "...";
   return repoId;


### PR DESCRIPTION
## Summary
- `Unassigned` and `(untagged)` are both daemon-written `repo_id` sentinels for "no git remote detected" — one legacy, one current. Surfacing them as two separate rows in `Cost by Project` makes a fresh user guess at the distinction.
- Normalize both to `"(no repo)"` in `repoName()` (affects Repos chart + Sessions table).
- Merge by display label in the Repos page before rendering so sentinels that collide under the same label produce one bar, not two.
- Simplify the #38 footnote to describe the unified bucket.
- DB values are untouched.

Closes #46.

## Test plan
- [x] `npm test --run`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Visually verify `/dashboard/repos` — `Cost by Project` shows a single `(no repo)` row for what used to be `Unassigned` + `(untagged)`; footnote reads cleanly.
- [ ] `/dashboard/sessions` rows for those sentinels render as `(no repo)` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)