### PR TITLE
ui(settings): mask API key + copy Org ID

### DIFF
--- a/src/app/dashboard/settings/api-key-section.tsx
+++ b/src/app/dashboard/settings/api-key-section.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 import { useState } from "react";
+import { Copy, Check, Eye, EyeOff } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export function ApiKeySection({ apiKey }: { apiKey: string }) {
   const [copied, setCopied] = useState(false);
+  const [revealed, setRevealed] = useState(false);
 
   const command = `budi cloud init --api-key ${apiKey}`;
+  const displayCommand = revealed
+    ? command
+    : `budi cloud init --api-key ${maskApiKey(apiKey)}`;
 
   function handleCopy() {
     navigator.clipboard.writeText(command);
@@ -25,16 +30,48 @@ export function ApiKeySection({ apiKey }: { apiKey: string }) {
         </p>
         <div className="flex items-start gap-2">
           <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
-            {command}
+            {displayCommand}
           </code>
           <button
-            onClick={handleCopy}
-            className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+            onClick={() => setRevealed((v) => !v)}
+            aria-label={revealed ? "Hide API key" : "Reveal API key"}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
           >
-            {copied ? "Copied!" : "Copy"}
+            {revealed ? (
+              <>
+                <EyeOff className="h-4 w-4" /> Hide
+              </>
+            ) : (
+              <>
+                <Eye className="h-4 w-4" /> Reveal
+              </>
+            )}
+          </button>
+          <button
+            onClick={handleCopy}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+          >
+            {copied ? (
+              <>
+                <Check className="h-4 w-4" /> Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4" /> Copy
+              </>
+            )}
           </button>
         </div>
       </CardContent>
     </Card>
   );
+}
+
+function maskApiKey(key: string): string {
+  const idx = key.indexOf("_");
+  if (idx >= 0) {
+    const bodyLen = Math.max(key.length - idx - 1, 8);
+    return key.slice(0, idx + 1) + "•".repeat(bodyLen);
+  }
+  return "•".repeat(Math.max(key.length, 12));
 }

--- a/src/app/dashboard/settings/copy-button.tsx
+++ b/src/app/dashboard/settings/copy-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+export function CopyButton({
+  value,
+  label,
+}: {
+  value: string;
+  label: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? `${label} — copied` : label}
+      className="inline-flex items-center rounded-md p-1 text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-200"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -3,6 +3,7 @@ import { getCurrentUser, getOrgMembers } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { ApiKeySection } from "./api-key-section";
+import { CopyButton } from "./copy-button";
 import { InviteSection } from "./invite-section";
 import { DangerZone } from "./danger-zone";
 
@@ -33,9 +34,12 @@ export default async function SettingsPage() {
               <dt className="text-zinc-400">Name</dt>
               <dd className="text-zinc-200">{org?.name ?? "-"}</dd>
             </div>
-            <div className="flex justify-between">
+            <div className="flex items-center justify-between">
               <dt className="text-zinc-400">Org ID</dt>
-              <dd className="font-mono text-xs text-zinc-400">{user.org_id}</dd>
+              <dd className="flex items-center gap-1 font-mono text-xs text-zinc-400">
+                <span>{user.org_id}</span>
+                <CopyButton value={user.org_id} label="Copy Org ID" />
+              </dd>
             </div>
           </dl>
         </CardContent>


### PR DESCRIPTION
## Summary
- Mask the API key in the `Your API Key` card by default — the displayed command shows `budi_••••…` so the real key isn't visible over the user's shoulder. Reveal/Hide toggle flips it. Copy still writes the real command.
- Add a small copy-icon button next to `Org ID` so it's grabbable for support tickets without manual text selection.
- Reuses `lucide-react` (Eye/EyeOff, Copy/Check) already in the tree.

Closes #45.

## Test plan
- [x] `npm test --run`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Visually verify `/dashboard/settings`:
  - [ ] API key card starts masked; Reveal shows the full key; Hide masks again
  - [ ] Copy writes the real `budi cloud init --api-key budi_…` command regardless of mask state
  - [ ] Org ID has a copy icon; clicking it swaps to a check for ~2s and pastes the Org ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)