### PR TITLE
fix(chart): restore CostBarChart bars + cost labels

### DIFF
--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
+import { Bar, LabelList } from "recharts";
+import { CostBarChart } from "./cost-bar-chart";
+import { fmtCost } from "@/lib/format";
+
+/**
+ * Walk a React element tree (without rendering) and yield every element node.
+ * CostBarChart has no hooks so calling it as a function is safe under vitest's
+ * node environment.
+ */
+function* walk(node: unknown): Generator<ReactElement> {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const n of node) yield* walk(n);
+    return;
+  }
+  const el = node as ReactElement & {
+    props?: { children?: unknown };
+  };
+  if (el.type != null) yield el;
+  const children = el.props?.children;
+  if (children !== undefined) yield* walk(children);
+}
+
+describe("CostBarChart", () => {
+  it("renders the empty placeholder when no rows are supplied", () => {
+    const tree = CostBarChart({ data: [], emptyLabel: "No data for period" });
+    const text = JSON.stringify(tree);
+    expect(text).toContain("No data for period");
+  });
+
+  it("configures Bar + LabelList so mixed-scale rows stay visible and labeled", () => {
+    // Mirrors the repro from #41: one dominant row alongside sub-dollar rows.
+    // Without minPointSize the non-leading bars shrink to <1px; without
+    // isAnimationActive={false} LabelList silently stays empty on first paint.
+    const mixedScale = [
+      { label: "claude_code / claude-opus-4-7", cost_cents: 3000 },
+      { label: "claude-opus-4-6", cost_cents: 81 },
+      { label: "codex / (untagged)", cost_cents: 47 },
+      { label: "tiny-1", cost_cents: 12 },
+      { label: "tiny-2", cost_cents: 9 },
+      { label: "tiny-3", cost_cents: 7 },
+    ];
+    const tree = CostBarChart({
+      data: mixedScale,
+      emptyLabel: "unused",
+    });
+
+    const nodes = Array.from(walk(tree));
+
+    const bar = nodes.find((n) => n.type === Bar);
+    expect(bar, "Bar should be in the rendered tree").toBeDefined();
+    expect(bar!.props.minPointSize).toBeGreaterThanOrEqual(4);
+    expect(bar!.props.isAnimationActive).toBe(false);
+
+    const labelList = nodes.find((n) => n.type === LabelList);
+    expect(
+      labelList,
+      "LabelList should be inside Bar so each row gets a $X.XX suffix"
+    ).toBeDefined();
+    expect(labelList!.props.dataKey).toBe("cost_cents");
+    expect(labelList!.props.position).toBe("right");
+
+    // Formatter must round-trip a cents amount into the fmtCost form so the
+    // regression where `$X.XX` goes missing can't sneak back in.
+    const formatter = labelList!.props.formatter as (
+      v: unknown
+    ) => string | number;
+    expect(formatter).toBeTypeOf("function");
+    expect(formatter(3000)).toBe(fmtCost(3000));
+    expect(formatter(81)).toBe(fmtCost(81));
+  });
+});

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -103,6 +103,17 @@ export function CostBarChart({
           fill="#3b82f6"
           barSize={BAR_SIZE}
           radius={[5, 5, 5, 5]}
+          // Sub-dollar rows otherwise render at <1px next to a double-digit
+          // leader. Floor the rendered width so every >0 row is still a
+          // recognizable sliver; the cost label to the right is the
+          // authoritative magnitude signal (#41).
+          minPointSize={4}
+          // recharts v3 gates LabelList on animation completion; if the Bar
+          // ever fails to emit `onAnimationEnd` (e.g. under strict mode or
+          // when re-rendered mid-animation) `<LabelList>` stays empty and the
+          // `$X.XX` suffix is silently missing. Skip the animation so labels
+          // render on first paint.
+          isAnimationActive={false}
         >
           <LabelList
             dataKey="cost_cents"


### PR DESCRIPTION
## Summary
Two independent regressions in `CostBarChart` on mixed-scale data (Team / Models / Repos):

1. **Labels missing.** recharts v3 renders `<LabelList>` off an internal `showLabels = !isAnimating` gate inside `Bar`. Any hitch in the animation lifecycle (strict mode, re-render mid-animation) leaves labels off forever — matches the repro where `document.querySelectorAll('.recharts-label-list').length === 0`. Set `isAnimationActive={false}` on the Bar so labels render on first paint.
2. **Sub-dollar bars invisible.** A $0.81 row next to a $30 leader was rendering at <1px. Add `minPointSize={4}` so every `>0` row gets a recognizable sliver; the `$X.XX` label to the right stays the authoritative magnitude signal. (Picked the clamp approach over rank normalization to keep the chart truthful.)

Also adds a tree-walking render test using the issue's mixed-scale fixture that asserts `minPointSize`, `isAnimationActive`, and a LabelList with the `fmtCost` formatter. The test runs under the existing node env (no RTL/jsdom deps added).

`recharts` is pinned at `^3.8.1` — the `LabelList` import itself resolves fine from the top-level `recharts` entry, so no import-path change was needed.

Closes #41.

## Test plan
- [x] `npm test --run` — new `cost-bar-chart.test.tsx` passes (44 tests total)
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Visually verify `/dashboard/models`, `/dashboard/team`, `/dashboard/repos`:
  - [ ] every row has a visible bar (≥4px) and a `$X.XX` label to the right
  - [ ] top row still shows proportional magnitude against the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)