### PR TITLE
polish(dashboard): make stalled SyncFreshness badge actionable

### DIFF
--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { clsx } from "clsx";
+import { ChevronDown } from "lucide-react";
 
 /**
  * Freshness threshold beyond which a linked daemon is considered "stalled".
@@ -72,6 +73,13 @@ function LinkedSyncFreshness({
       ? "stalled"
       : "ok";
 
+  // Stalled mirrors the `not_linked` CTA pattern: make it actionable so the
+  // user can self-serve. The popover names the two CLI commands and the
+  // config file that are almost always the answer (#53).
+  if (state === "stalled") {
+    return <StalledBadge effective={effective} now={now} />;
+  }
+
   return (
     <div
       className={clsx(
@@ -79,9 +87,7 @@ function LinkedSyncFreshness({
         state === "ok" &&
           "border-emerald-400/20 bg-emerald-400/5 text-emerald-300",
         state === "linked_no_data" &&
-          "border-sky-400/20 bg-sky-400/5 text-sky-300",
-        state === "stalled" &&
-          "border-amber-400/30 bg-amber-400/10 text-amber-300"
+          "border-sky-400/20 bg-sky-400/5 text-sky-300"
       )}
       data-testid="sync-freshness"
       data-sync-state={state}
@@ -95,11 +101,120 @@ function LinkedSyncFreshness({
         className={clsx(
           "h-1.5 w-1.5 rounded-full",
           state === "ok" && "bg-emerald-300",
-          state === "linked_no_data" && "animate-pulse bg-sky-300",
-          state === "stalled" && "bg-amber-300"
+          state === "linked_no_data" && "animate-pulse bg-sky-300"
         )}
       />
       <SyncFreshnessLabel state={state} effective={effective} now={now} />
+    </div>
+  );
+}
+
+function StalledBadge({
+  effective,
+  now,
+}: {
+  effective: string | null;
+  now: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const relative = effective
+    ? formatRelative(Date.parse(effective), now)
+    : "unknown";
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        data-testid="sync-freshness"
+        data-sync-state="stalled"
+        title={
+          effective
+            ? `Last contact: ${new Date(effective).toLocaleString()}`
+            : undefined
+        }
+        className="inline-flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-400/10 px-2.5 py-1 text-xs font-medium text-amber-300 transition-colors hover:border-amber-400/60 hover:bg-amber-400/20"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-300" />
+        <span className="hidden sm:inline">Stalled — last synced </span>
+        <span>{relative}</span>
+        <ChevronDown
+          className={clsx(
+            "h-3 w-3 transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Cloud sync is stalled"
+          className="absolute right-0 top-full z-20 mt-1 w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-white/10 bg-zinc-950 p-3 text-xs text-zinc-300 shadow-xl"
+          data-testid="sync-freshness-popover"
+        >
+          <p className="mb-1 text-zinc-100">
+            No data has reached the cloud in over 24 hours.
+          </p>
+          <p className="mb-2 text-zinc-400">From your local machine:</p>
+          <ol className="mb-3 list-decimal space-y-1 pl-4">
+            <li>
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                budi cloud status
+              </code>{" "}
+              — diagnose what&rsquo;s off
+            </li>
+            <li>
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                budi cloud sync
+              </code>{" "}
+              — push queued data now
+            </li>
+            <li>
+              Check{" "}
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                ~/.config/budi/cloud.toml
+              </code>{" "}
+              has{" "}
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                enabled = true
+              </code>{" "}
+              and a real{" "}
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                api_key
+              </code>
+              .
+            </li>
+          </ol>
+          <a
+            className="text-zinc-400 underline decoration-dotted underline-offset-2 hover:text-zinc-200"
+            href="https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md"
+            target="_blank"
+            rel="noreferrer"
+          >
+            ADR-0083 — cloud sync contract
+          </a>
+        </div>
+      )}
     </div>
   );
 }
@@ -109,7 +224,7 @@ function SyncFreshnessLabel({
   effective,
   now,
 }: {
-  state: "linked_no_data" | "stalled" | "ok";
+  state: "linked_no_data" | "ok";
   effective: string | null;
   now: number;
 }) {
@@ -128,13 +243,11 @@ function SyncFreshnessLabel({
   return (
     <>
       {/*
-        Prefix ("Synced" / "Stalled — last synced") is redundant with the
-        colored dot at mobile widths. Drop it below `sm` so the whole badge
-        fits next to the hamburger + logout icon on a 390px viewport.
+        Prefix ("Synced") is redundant with the colored dot at mobile widths.
+        Drop it below `sm` so the whole badge fits next to the hamburger +
+        logout icon on a 390px viewport.
       */}
-      <span className="hidden sm:inline">
-        {state === "stalled" ? "Stalled — last synced " : "Synced "}
-      </span>
+      <span className="hidden sm:inline">Synced </span>
       <span>{formatRelative(Date.parse(effective), now)}</span>
     </>
   );


### PR DESCRIPTION
## Summary
When `SyncFreshness` flips to `stalled`, the user sees `Stalled — last synced Xd ago` on a non-interactive div and has to guess what to do. This is the exact moment where the not_linked badge already hands users a CTA; stalled should do the same.

- Stalled badge is now a `<button>` + popover. Click opens a small amber-bordered panel with the three recovery steps:
  1. `budi cloud status` — diagnose what's off
  2. `budi cloud sync` — push queued data now
  3. Check `~/.config/budi/cloud.toml` has `enabled = true` and a real `api_key`
- Links to ADR-0083 (cloud sync contract).
- Closes on ESC or outside click.
- `data-testid="sync-freshness"` and `data-sync-state="stalled"` stay on the trigger so selectors don't break.
- Extracted the stalled branch into `StalledBadge` so the popover state is self-contained — `SyncFreshnessLabel` only handles `ok` / `linked_no_data` now.

No new deps. Reuses the existing amber palette the `not_linked` CTA uses and a `ChevronDown` from lucide-react (already in the tree).

Closes #53.

## Test plan
- [x] `npm test --run` (44 tests)
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: stall the daemon (set `enabled = false` in `~/.config/budi/cloud.toml` and wait / fake the timestamp) and verify:
  - [ ] Badge renders as a button, opens the popover on click
  - [ ] ESC closes; outside click closes
  - [ ] Popover fits on 390px viewport without clipping (`w-[min(20rem,calc(100vw-2rem))]`)
  - [ ] ADR link opens in a new tab
  - [ ] Existing selectors (`[data-sync-state="stalled"]`) still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)