### PR TITLE
ui(settings): stop API key row from jumping when Reveal/Copy toggles

### DIFF
--- a/src/app/dashboard/settings/api-key-section.tsx
+++ b/src/app/dashboard/settings/api-key-section.tsx
@@ -28,14 +28,18 @@ export function ApiKeySection({ apiKey }: { apiKey: string }) {
         <p className="mb-2 text-sm text-zinc-400">
           Run this on your local machine to point Budi at your cloud account.
         </p>
-        <div className="flex items-start gap-2">
+        <div className="flex items-center gap-2">
           <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
             {displayCommand}
           </code>
+          {/*
+            min-width on both toggles keeps the code column from jumping
+            when labels swap (Reveal→Hide, Copy→Copied).
+          */}
           <button
             onClick={() => setRevealed((v) => !v)}
             aria-label={revealed ? "Hide API key" : "Reveal API key"}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+            className="inline-flex min-w-[6.25rem] items-center justify-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
           >
             {revealed ? (
               <>
@@ -49,7 +53,7 @@ export function ApiKeySection({ apiKey }: { apiKey: string }) {
           </button>
           <button
             onClick={handleCopy}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+            className="inline-flex min-w-[6.25rem] items-center justify-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
           >
             {copied ? (
               <>


### PR DESCRIPTION
## Summary
Two small misses from #50 that the user hit right after merge:

- The flex row used `items-start`, so the Reveal/Copy buttons clung to the top of the taller `<code>` block instead of centering on it. Flip to `items-center`.
- Button labels swap width as state flips (Reveal → Hide, Copy → Copied), which made the neighboring code column visibly reflow. Pin both buttons to `min-w-[6.25rem]` + `justify-center` so the label swap stays inside the button.

No functional changes.

## Test plan
- [x] `npm test --run`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: on `/dashboard/settings`, the command row stays still when Reveal/Hide and Copy/Copied cycle; buttons sit vertically centered against the `<code>` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)