### PR TITLE
feat(api): add GET /v1/whoami for CLI auto-seed

### DIFF
--- a/src/app/api/v1/whoami/route.test.ts
+++ b/src/app/api/v1/whoami/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #541: `/v1/whoami` — identifies the bearer of an API key so the CLI
+ * can auto-seed `org_id` in `~/.config/budi/cloud.toml`.
+ *
+ * Tests hit the real route handler against a minimal Supabase fake
+ * that implements only the `from(tbl).select(cols).eq(col, v).single()`
+ * chain the auth check uses.
+ */
+
+type Row = Record<string, unknown>;
+
+class FakeSupabase {
+  private rows: Row[] = [];
+
+  seed(rows: Row[]) {
+    this.rows = [...rows];
+  }
+
+  from(_table: string) {
+    void _table;
+    return new FakeQuery(this.rows);
+  }
+}
+
+class FakeQuery {
+  private filters: Array<(r: Row) => boolean> = [];
+
+  constructor(private readonly rows: Row[]) {}
+
+  select(_cols?: string) {
+    void _cols;
+    return this;
+  }
+
+  eq(col: string, value: unknown) {
+    this.filters.push((r) => r[col] === value);
+    return this;
+  }
+
+  async single() {
+    const matched = this.rows.filter((r) => this.filters.every((f) => f(r)));
+    if (matched.length !== 1) {
+      return { data: null, error: { message: "not found" } };
+    }
+    return { data: matched[0], error: null };
+  }
+}
+
+const fake = new FakeSupabase();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => fake,
+}));
+
+beforeEach(() => {
+  fake.seed([]);
+});
+
+describe("GET /v1/whoami (#541)", () => {
+  it("returns the org_id for a valid budi_* key", async () => {
+    fake.seed([
+      {
+        id: "usr_test",
+        org_id: "org_xEvtA",
+        api_key: "budi_testkey",
+      },
+    ]);
+
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      method: "GET",
+      headers: { authorization: "Bearer budi_testkey" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    const body = (await res.json()) as { org_id: string };
+
+    expect(res.status).toBe(200);
+    expect(body.org_id).toBe("org_xEvtA");
+  });
+
+  it("401s when the Authorization header is missing", async () => {
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami");
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
+  });
+
+  it("401s when the Authorization header is not a Bearer", async () => {
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Basic dXNlcjpwYXNz" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("401s for a key that doesn't start with budi_", async () => {
+    // Defensive — avoids lookup-by-random-string from probing the DB.
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Bearer sk-openai-abc123" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("401s when the api_key has no matching user row", async () => {
+    fake.seed([
+      {
+        id: "usr_other",
+        org_id: "org_other",
+        api_key: "budi_other",
+      },
+    ]);
+
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Bearer budi_nonexistent" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
+  });
+
+  it("never echoes the api_key in the response", async () => {
+    // Defense-in-depth: even an authenticated response should only
+    // surface `org_id`; the key itself must never come back on the wire.
+    fake.seed([
+      {
+        id: "usr_test",
+        org_id: "org_xEvtA",
+        api_key: "budi_testkey",
+      },
+    ]);
+
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Bearer budi_testkey" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    const text = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(text).not.toContain("budi_testkey");
+    expect(text).not.toContain("api_key");
+  });
+});

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Authenticate the request via Bearer token.
+ * Returns the user row or null if auth fails. Mirrors the shape used by
+ * `/v1/ingest/route.ts::authenticateApiKey`; intentionally duplicated so
+ * each endpoint stays grep-able on its own.
+ */
+async function authenticateApiKey(
+  supabase: ReturnType<typeof createAdminClient>,
+  authHeader: string | null
+) {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const apiKey = authHeader.slice(7);
+  if (!apiKey.startsWith("budi_")) return null;
+
+  const { data, error } = await supabase
+    .from("users")
+    .select("id, org_id")
+    .eq("api_key", apiKey)
+    .single();
+
+  if (error || !data) return null;
+  return data;
+}
+
+/**
+ * GET /v1/whoami
+ *
+ * Identifies the bearer of an API key so the CLI can auto-seed
+ * `~/.config/budi/cloud.toml` with `org_id` without sending the user
+ * to the dashboard to hand-copy it. Paired with siropkin/budi#541 on
+ * the CLI side.
+ *
+ * Auth: Authorization: Bearer budi_<key>
+ * Response (200): { "org_id": string }
+ * Response (401): { "error": "Unauthorized" }
+ *
+ * No request body; all identity data derives from the key.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = createAdminClient();
+  const user = await authenticateApiKey(
+    supabase,
+    request.headers.get("authorization")
+  );
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return Response.json({ org_id: user.org_id });
+}


### PR DESCRIPTION
## Summary

New endpoint that identifies the bearer of an API key so the CLI can auto-seed `org_id` in `~/.config/budi/cloud.toml` after the user pastes a fresh key via `budi cloud init --api-key KEY`. Without this, the CLI has to nudge the user back to the dashboard to hand-copy their org id.

**Contract:**
\`\`\`
GET /v1/whoami
Authorization: Bearer budi_<key>
→ 200 { \"org_id\": \"org_xxx\" }
→ 401 { \"error\": \"Unauthorized\" }
\`\`\`

Auth mirrors `/v1/ingest::authenticateApiKey`: require `Authorization: Bearer budi_<key>`, look up the `users` row with that `api_key`, 401 on any mismatch. No request body. Response surfaces only `org_id` — the key never echoes back, even on success.

Paired with siropkin/budi#541 (CLI-side consumer) and siropkin/budi#540 (daemon cloud-uploader startup log, already merged).

## Risks

- **No rate limiting.** Matches `/v1/ingest` for now. If whoami becomes an abuse vector for API-key probing, rate-limit the prefix-match branch (returning 401 before DB lookup for non-`budi_`-prefixed keys already short-circuits most of that).
- **Leaks the association between a valid key and its `org_id`.** Intentional — that's the whole feature. A caller holding a valid key is already authenticated to read their org's rollups via `/v1/ingest`.
- **No CORS headers.** Intended for CLI consumption, not browsers. If a dashboard feature needs this later, add CORS via the middleware.

## Validation

- `npx vitest run src/app/api/v1/whoami/` — 6 tests pass (happy path, missing Authorization, wrong scheme, non-budi-prefix key, non-existent key, response-body-doesn't-leak-key).
- `npm run lint` — clean.
- `npm run build` — Next.js picks up `/api/v1/whoami` in the dynamic route table.
- `npx vitest run` — full suite (50 tests) still green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)