### PR TITLE
fix(setup): move ORG_CASCADE_ORDER out of "use server" file

### DIFF
--- a/src/app/actions/org-cascade.ts
+++ b/src/app/actions/org-cascade.ts
@@ -1,0 +1,20 @@
+/**
+ * Dependency order for wiping an org's data.
+ *
+ * None of the FKs in `001_ingest_schema.sql` declare `ON DELETE CASCADE`, so
+ * we delete leaves first. This list is reused by the tests to document and
+ * pin the expected sequence.
+ *
+ * Lives in its own module because `org.ts` is a `"use server"` file and those
+ * can only export async functions — exporting a plain constant from there
+ * crashes the server action with "A 'use server' file can only export async
+ * functions."
+ */
+export const ORG_CASCADE_ORDER = [
+  "session_summaries",
+  "daily_rollups",
+  "devices",
+  "invite_tokens",
+  "users",
+  "orgs",
+] as const;

--- a/src/app/actions/org.test.ts
+++ b/src/app/actions/org.test.ts
@@ -192,7 +192,8 @@ async function loadActions() {
 describe("deleteOrganization", () => {
   it("cascades through session summaries, rollups, devices, invites, users, then the org itself", async () => {
     seedSoloManagerWithData();
-    const { deleteOrganization, ORG_CASCADE_ORDER } = await loadActions();
+    const { deleteOrganization } = await loadActions();
+    const { ORG_CASCADE_ORDER } = await import("@/app/actions/org-cascade");
 
     // Snapshot the declared order alongside the test so a change to one
     // without the other fails loudly.

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -5,24 +5,6 @@ import { randomBytes } from "crypto";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
-/**
- * Dependency order for wiping an org's data.
- *
- * None of the FKs in `001_ingest_schema.sql` declare `ON DELETE CASCADE`, so
- * we delete leaves first. This list is reused by the tests to document and
- * pin the expected sequence.
- */
-const ORG_CASCADE_ORDER = [
-  "session_summaries",
-  "daily_rollups",
-  "devices",
-  "invite_tokens",
-  "users",
-  "orgs",
-] as const;
-
-export { ORG_CASCADE_ORDER };
-
 export async function createOrg(
   _prevState: { error: string } | undefined,
   formData: FormData
@@ -99,9 +81,10 @@ export async function generateInviteToken() {
  * both the role and the confirmation text on the server so a crafted request
  * can't skip either check.
  *
- * Deletion cascades in dependency order (see `ORG_CASCADE_ORDER`). Supabase
- * auth rows (`auth.users`) are intentionally left intact so former members
- * can still sign in and create/join a different org.
+ * Deletion cascades in dependency order (see `ORG_CASCADE_ORDER` in
+ * `./org-cascade.ts`). Supabase auth rows (`auth.users`) are intentionally
+ * left intact so former members can still sign in and create/join a
+ * different org.
  */
 export async function deleteOrganization(
   _prevState: { error: string } | undefined,


### PR DESCRIPTION
## Summary

- `/setup` (org creation) currently 500s with:
  `Error: A "use server" file can only export async functions.`
- Root cause: `src/app/actions/org.ts` is a `"use server"` module but also re-exports the non-async `ORG_CASCADE_ORDER` constant (added in #39). Next 16 enforces the async-only rule, so every POST to `/setup` crashes before the action body runs.
- Fix: move the constant into a plain module `src/app/actions/org-cascade.ts` and update `org.test.ts` to import it from there. No behavior change in `deleteOrganization` — the cascade remains hardcoded in the same order.

Confirmed via Vercel production logs (six POST /setup → 500 in the last 10 minutes, all with the same error message).

## Test plan

- [x] `npm test` — 8 files / 50 tests pass, including the `deleteOrganization` cascade-order assertion
- [x] `npm run build` — `/setup` route compiles without the "use server" export error
- [x] `npm run lint` — clean
- [ ] After deploy: create a new org via `/setup`, confirm redirect to `/dashboard` (previously 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)