### PR TITLE
feat(dashboard): per-device cost breakdown (#58)

### DIFF
--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -1,0 +1,120 @@
+import { Suspense } from "react";
+import {
+  getCurrentUser,
+  getCostByDevice,
+  getEarliestActivity,
+} from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { deviceLabel, fmtCost, fmtRelative } from "@/lib/format";
+import { PeriodSelector } from "@/components/period-selector";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+
+export default async function DevicesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const earliestActivity =
+    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+  const range = dateRangeFromDays(params.days, earliestActivity);
+  const devices = await getCostByDevice(user, range);
+
+  const showOwnerColumn = user.role === "manager";
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Devices</h1>
+        <Suspense>
+          <PeriodSelector />
+        </Suspense>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost by Device</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CostBarChart
+            data={devices
+              .filter((d) => d.cost_cents > 0)
+              .map((d) => ({
+                label: showOwnerColumn && d.owner_name
+                  ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
+                  : deviceLabel(d.id, d.label),
+                cost_cents: d.cost_cents,
+              }))}
+            emptyLabel="No device cost data for this period"
+          />
+        </CardContent>
+      </Card>
+
+      {devices.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Devices</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <table className="hidden w-full text-sm sm:table">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-zinc-400">
+                  <th className="pb-2 font-medium">Device</th>
+                  {showOwnerColumn && (
+                    <th className="pb-2 font-medium">Owner</th>
+                  )}
+                  <th className="pb-2 font-medium">Last seen</th>
+                  <th className="pb-2 text-right font-medium">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {devices.map((d) => (
+                  <tr key={d.id} className="border-b border-white/5">
+                    <td className="py-2 text-zinc-200">
+                      {deviceLabel(d.id, d.label)}
+                    </td>
+                    {showOwnerColumn && (
+                      <td className="py-2 text-zinc-300">
+                        {d.owner_name ?? "—"}
+                      </td>
+                    )}
+                    <td className="py-2 text-zinc-400">
+                      {fmtRelative(d.last_seen)}
+                    </td>
+                    <td className="py-2 text-right tabular-nums text-zinc-300">
+                      {fmtCost(d.cost_cents)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <ul className="divide-y divide-white/5 text-sm sm:hidden">
+              {devices.map((d) => (
+                <li key={d.id} className="flex flex-col gap-0.5 py-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-zinc-200">
+                      {deviceLabel(d.id, d.label)}
+                    </span>
+                    <span className="tabular-nums text-zinc-300">
+                      {fmtCost(d.cost_cents)}
+                    </span>
+                  </div>
+                  <div className="text-xs text-zinc-500">
+                    {showOwnerColumn && d.owner_name
+                      ? `${d.owner_name} · ${fmtRelative(d.last_seen)}`
+                      : fmtRelative(d.last_seen)}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   GitBranch,
   LayoutDashboard,
   Cpu,
+  Laptop,
   Menu,
   Settings,
   Timer,
@@ -20,6 +21,7 @@ import {
 const NAV_ITEMS = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
   { href: "/dashboard/team", label: "Team", icon: Users },
+  { href: "/dashboard/devices", label: "Devices", icon: Laptop },
   { href: "/dashboard/models", label: "Models", icon: Cpu },
   { href: "/dashboard/repos", label: "Repos", icon: GitBranch },
   { href: "/dashboard/sessions", label: "Sessions", icon: Timer },

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -350,6 +350,147 @@ describe("Overview ↔ Team reconciliation (#15)", () => {
   });
 });
 
+describe("getCostByDevice", () => {
+  it("manager sees every device, annotates owner, and reconciles with Overview", async () => {
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      {
+        id: "usr_ivan",
+        org_id: "org_team",
+        role: "manager",
+        api_key: "budi_i",
+        display_name: "Ivan",
+        email: "ivan@example.com",
+      },
+      {
+        id: "usr_jane",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_j",
+        display_name: "Jane",
+        email: "jane@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      {
+        id: "dev_ivan_laptop",
+        user_id: "usr_ivan",
+        label: "laptop",
+        last_seen: "2026-04-23T10:00:00Z",
+      },
+      {
+        id: "dev_ivan_desktop",
+        user_id: "usr_ivan",
+        label: null,
+        last_seen: "2026-04-20T09:00:00Z",
+      },
+      {
+        id: "dev_jane_laptop",
+        user_id: "usr_jane",
+        label: "laptop",
+        last_seen: "2026-04-22T12:00:00Z",
+      },
+    ]);
+    fake.seed("daily_rollups", [
+      rollup("dev_ivan_laptop", "2026-04-10", 800_00),
+      rollup("dev_ivan_laptop", "2026-04-11", 400_00),
+      rollup("dev_jane_laptop", "2026-04-10", 1500_00),
+      // dev_ivan_desktop has zero rollups — it should still surface so a
+      // freshly-linked daemon isn't invisible.
+    ]);
+
+    const { getOverviewStats, getCostByDevice } = await loadDal();
+
+    const manager = {
+      id: "usr_ivan",
+      org_id: "org_team",
+      role: "manager",
+      api_key: "budi_i",
+      display_name: "Ivan",
+      email: "ivan@example.com",
+    };
+    const range = { from: "2026-04-01", to: "2026-04-30" };
+
+    const byDevice = await getCostByDevice(manager, range);
+    const overview = await getOverviewStats(manager, range);
+
+    // Every org device is listed, sorted by cost desc, zero-cost rows last.
+    expect(byDevice.map((d) => d.id)).toEqual([
+      "dev_jane_laptop",
+      "dev_ivan_laptop",
+      "dev_ivan_desktop",
+    ]);
+    expect(byDevice.map((d) => d.cost_cents)).toEqual([1500_00, 1200_00, 0]);
+
+    // Owner is annotated for the manager view; same-label laptops under
+    // different owners stay distinguishable.
+    const jane = byDevice.find((d) => d.id === "dev_jane_laptop");
+    expect(jane?.owner_name).toBe("Jane");
+    const ivanLaptop = byDevice.find((d) => d.id === "dev_ivan_laptop");
+    expect(ivanLaptop?.owner_name).toBe("Ivan");
+
+    // Sum of device costs matches Overview total for the same (user, range).
+    expect(byDevice.reduce((s, d) => s + d.cost_cents, 0)).toBe(
+      overview.totalCostCents
+    );
+  });
+
+  it("member only sees their own device and leaves owner_name unset", async () => {
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      {
+        id: "usr_ivan",
+        org_id: "org_team",
+        role: "manager",
+        api_key: "budi_i",
+        display_name: "Ivan",
+        email: "ivan@example.com",
+      },
+      {
+        id: "usr_jane",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_j",
+        display_name: "Jane",
+        email: "jane@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      { id: "dev_ivan", user_id: "usr_ivan", label: "ivan-mbp" },
+      { id: "dev_jane", user_id: "usr_jane", label: "jane-mbp" },
+    ]);
+    fake.seed("daily_rollups", [
+      rollup("dev_ivan", "2026-04-10", 800_00),
+      rollup("dev_jane", "2026-04-10", 1500_00),
+    ]);
+
+    const { getCostByDevice } = await loadDal();
+
+    const jane = {
+      id: "usr_jane",
+      org_id: "org_team",
+      role: "member",
+      api_key: "budi_j",
+      display_name: "Jane",
+      email: "jane@example.com",
+    };
+    const byDevice = await getCostByDevice(jane, {
+      from: "2026-04-01",
+      to: "2026-04-30",
+    });
+
+    expect(byDevice).toEqual([
+      {
+        id: "dev_jane",
+        label: "jane-mbp",
+        owner_name: null,
+        last_seen: null,
+        cost_cents: 1500_00,
+      },
+    ]);
+  });
+});
+
 function rollup(
   deviceId: string,
   bucketDay: string,

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -275,6 +275,107 @@ interface UserLookup {
   org_id: string | null;
 }
 
+export interface DeviceCost {
+  id: string;
+  label: string | null;
+  owner_name: string | null;
+  last_seen: string | null;
+  cost_cents: number;
+}
+
+/**
+ * Get cost breakdown by device.
+ * Manager sees every device in the org; member sees only their own (ADR-0083 §6).
+ *
+ * Reuses `getVisibleDeviceIds` so the device set — and therefore the rollup
+ * sum — matches Overview / Team for the same (user, range). For any visible
+ * user, the Overview total equals the sum of `cost_cents` returned here.
+ *
+ * `owner_name` is populated in the manager view so the table can disambiguate
+ * two laptops labelled `"laptop"` sitting under different owners. For members
+ * it stays `null` — the member already knows every row is theirs and the
+ * extra column would just be noise.
+ */
+export async function getCostByDevice(
+  user: BudiUser,
+  range: DateRange
+): Promise<DeviceCost[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rollups } = await admin
+    .from("daily_rollups")
+    .select("device_id, cost_cents")
+    .in("device_id", deviceIds)
+    .gte("bucket_day", range.from)
+    .lte("bucket_day", range.to)
+    // Match the cap used elsewhere so we never silently truncate the sum.
+    .limit(100_000);
+
+  const { data: devices } = await admin
+    .from("devices")
+    .select("id, label, user_id, last_seen")
+    .in("id", deviceIds);
+
+  const deviceMeta = new Map<
+    string,
+    { label: string | null; user_id: string; last_seen: string | null }
+  >();
+  for (const d of devices ?? []) {
+    deviceMeta.set(d.id as string, {
+      label: (d.label as string | null) ?? null,
+      user_id: d.user_id as string,
+      last_seen: (d.last_seen as string | null) ?? null,
+    });
+  }
+
+  let ownerLookup = new Map<string, string>();
+  if (user.role === "manager") {
+    const ownerIds = Array.from(
+      new Set(Array.from(deviceMeta.values()).map((d) => d.user_id))
+    );
+    if (ownerIds.length > 0) {
+      const { data: owners } = await admin
+        .from("users")
+        .select("id, display_name, email")
+        .in("id", ownerIds);
+      ownerLookup = new Map(
+        (owners ?? []).map((u) => [
+          u.id as string,
+          (u.display_name as string | null) ||
+            (u.email as string | null) ||
+            (u.id as string).slice(0, 8),
+        ])
+      );
+    }
+  }
+
+  const costByDevice = new Map<string, number>();
+  for (const r of rollups ?? []) {
+    const id = r.device_id as string;
+    costByDevice.set(id, (costByDevice.get(id) ?? 0) + Number(r.cost_cents));
+  }
+
+  // Surface every visible device — including zero-cost ones — so a brand-new
+  // daemon shows up the moment it registers, even before it has pushed a
+  // rollup. That matters most during the "linked, waiting for first sync"
+  // gap covered by FirstSyncInProgressBanner on Overview.
+  const result: DeviceCost[] = [];
+  for (const [id, meta] of deviceMeta) {
+    result.push({
+      id,
+      label: meta.label,
+      owner_name:
+        user.role === "manager" ? (ownerLookup.get(meta.user_id) ?? null) : null,
+      last_seen: meta.last_seen,
+      cost_cents: costByDevice.get(id) ?? 0,
+    });
+  }
+
+  return result.sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
 /**
  * Get cost breakdown by model.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -56,3 +56,40 @@ export function fmtFullDate(dateStr: string): string {
     day: "numeric",
   });
 }
+
+/**
+ * A device label for the UI. Falls back to a short suffix of the id so a
+ * still-unlabelled daemon is easy to tell apart in the table while staying
+ * clearly not a user-chosen name.
+ */
+export function deviceLabel(
+  id: string,
+  label: string | null | undefined
+): string {
+  if (label && label.trim()) return label;
+  const suffix = id.replace(/^dev_/, "").slice(0, 8);
+  return `device ${suffix || id}`;
+}
+
+/**
+ * Coarse "X ago" string for server-rendered last-seen timestamps. Deliberately
+ * low-precision (minute granularity, no ticking) — the dashboard layout is
+ * `force-dynamic` so each page load recomputes against a fresh `Date.now()`.
+ */
+export function fmtRelative(iso: string | null, now: number = Date.now()): string {
+  if (!iso) return "never";
+  const diff = Math.max(0, now - Date.parse(iso));
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.floor(d / 7);
+  if (w < 5) return `${w}w ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
+}


### PR DESCRIPTION
## Summary

Closes #58.

- New `/dashboard/devices` page. Bar chart of cost per device + table with label, owner (manager only), last-seen, and cost.
- `getCostByDevice(user, range)` in `src/lib/dal.ts` reuses `getVisibleDeviceIds`, so the Overview total equals the sum of `cost_cents` returned here — same reconciliation invariant the Team page has carried since #15.
- Respects ADR-0083 §6 scoping:
  - Manager: every device in the org; `owner_name` populated so two laptops labelled `"laptop"` under different people stay apart.
  - Member: own devices only; `owner_name` null so the table drops the column.
- Zero-cost devices still surface so a freshly-linked daemon shows up the moment it registers (pairs with `FirstSyncInProgressBanner` on Overview).
- Sidebar entry (Laptop icon) slotted between Team and Models.
- Two small helpers added to `src/lib/format.ts`: `deviceLabel(id, label)` (falls back to a short id suffix) and `fmtRelative(iso)` (server-side "X ago" string for the last-seen column — `force-dynamic` layout recomputes on every render).

## Test plan

- [x] `npm test` — 52 pass (2 new), covering manager visibility, member scoping, and the Overview↔Devices sum invariant
- [x] `npm run build` — `/dashboard/devices` appears in the route manifest
- [x] `npm run lint` — clean
- [ ] After deploy: as manager, visit `/dashboard/devices` with multiple linked devices across org members; confirm chart + table render, owner column populated, zero-cost device visible
- [ ] After deploy: as member, confirm only own device is listed and owner column is hidden

Note: no `.env.local` on this machine so the UI wasn't smoke-tested against live Supabase locally — verified via unit tests, TypeScript, and the production build manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)