### PR TITLE
feat(ingest): persist device label on auto-register + update (#60)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -428,3 +428,143 @@ describe("POST /v1/ingest + dashboard read path (#14)", () => {
     expect(sessions[0].message_count).toBe(2);
   });
 });
+
+describe("POST /v1/ingest — device label persistence (#60)", () => {
+  function seedUser() {
+    fake.seed("orgs", [{ id: "org_test", name: "test" }]);
+    fake.seed("users", [
+      {
+        id: "usr_test",
+        org_id: "org_test",
+        role: "manager",
+        api_key: "budi_testkey",
+        display_name: "Test",
+        email: "t@example.com",
+      },
+    ]);
+  }
+
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const baseEnvelope = {
+    schema_version: 1,
+    device_id: "dev_test",
+    org_id: "org_test",
+    synced_at: "2026-04-15T12:00:00Z",
+    payload: { daily_rollups: [], session_summaries: [] },
+  };
+
+  it("persists label on auto-register when the envelope carries one", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    await POST(
+      mkReq({ ...baseEnvelope, label: "ivan-mbp" }) as unknown as Parameters<
+        typeof POST
+      >[0]
+    );
+
+    const [device] = fake.rows("devices");
+    expect(device.label).toBe("ivan-mbp");
+  });
+
+  it("auto-registers with label=null when the envelope omits the field (old daemon)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    await POST(mkReq(baseEnvelope) as unknown as Parameters<typeof POST>[0]);
+
+    const [device] = fake.rows("devices");
+    expect(device.label).toBeNull();
+  });
+
+  it("updates the label when a subsequent ingest carries a new one", async () => {
+    seedUser();
+    fake.seed("devices", [
+      {
+        id: "dev_test",
+        user_id: "usr_test",
+        label: "old-name",
+        last_seen: "2026-04-14T00:00:00Z",
+      },
+    ]);
+    const { POST } = await import("./route");
+
+    await POST(
+      mkReq({ ...baseEnvelope, label: "  new-name  " }) as unknown as Parameters<
+        typeof POST
+      >[0]
+    );
+
+    const [device] = fake.rows("devices");
+    // Trimmed, case preserved, length within cap.
+    expect(device.label).toBe("new-name");
+  });
+
+  it("leaves an existing label untouched when the envelope omits the field", async () => {
+    seedUser();
+    fake.seed("devices", [
+      {
+        id: "dev_test",
+        user_id: "usr_test",
+        label: "already-set",
+        last_seen: "2026-04-14T00:00:00Z",
+      },
+    ]);
+    const { POST } = await import("./route");
+
+    // No `label` key → old daemon. Must not clobber what a newer daemon set.
+    await POST(mkReq(baseEnvelope) as unknown as Parameters<typeof POST>[0]);
+
+    const [device] = fake.rows("devices");
+    expect(device.label).toBe("already-set");
+  });
+
+  it("clears a stale label when the envelope explicitly sends empty string", async () => {
+    seedUser();
+    fake.seed("devices", [
+      {
+        id: "dev_test",
+        user_id: "usr_test",
+        label: "going-away",
+        last_seen: "2026-04-14T00:00:00Z",
+      },
+    ]);
+    const { POST } = await import("./route");
+
+    // Explicit opt-out: user set `label = ""` in cloud.toml. Cloud must honour
+    // that and wipe the stored label, not treat it as "no update".
+    await POST(
+      mkReq({ ...baseEnvelope, label: "" }) as unknown as Parameters<
+        typeof POST
+      >[0]
+    );
+
+    const [device] = fake.rows("devices");
+    expect(device.label).toBeNull();
+  });
+
+  it("caps over-long labels at 128 chars so a bad envelope can't flood the column", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const longLabel = "a".repeat(500);
+    await POST(
+      mkReq({ ...baseEnvelope, label: longLabel }) as unknown as Parameters<
+        typeof POST
+      >[0]
+    );
+
+    const [device] = fake.rows("devices");
+    expect((device.label as string).length).toBe(128);
+  });
+});

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -12,15 +12,43 @@ const MAX_BODY_BYTES = 1024 * 1024;
 
 const CURRENT_SCHEMA_VERSION = 1;
 
+// Cap the stored label so a malformed envelope can't flood the devices table.
+// 128 chars is comfortably above any sane hostname or user-chosen nickname.
+const MAX_LABEL_LENGTH = 128;
+
 interface SyncEnvelope {
   schema_version: number;
   device_id: string;
   org_id: string;
   synced_at: string;
+  // User-controlled display name for this device. Daemon default is the OS
+  // hostname, but the user can override (or blank) via `cloud.toml` — so this
+  // is treated as an opaque string, not PII the cloud mandates. See the
+  // privacy note in ADR-0083 §1 and the paired daemon ticket on siropkin/budi.
+  label?: string | null;
   payload: {
     daily_rollups: IngestDailyRollup[];
     session_summaries: IngestSessionSummary[];
   };
+}
+
+/**
+ * Interpret the envelope's `label` field:
+ *   - key absent (undefined): don't touch the stored value — old daemon compat.
+ *   - present but non-string / null: explicit clear → store `null`.
+ *   - empty / whitespace-only: explicit clear → store `null`.
+ *   - non-empty string: trim + cap at MAX_LABEL_LENGTH, store that.
+ *
+ * Returning `undefined` signals "no update"; `null` or a string signals a
+ * write (so an empty or explicit-null envelope entry clears a stale label).
+ */
+function normalizeLabel(raw: unknown): string | null | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null) return null;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(0, MAX_LABEL_LENGTH);
 }
 
 /**
@@ -136,13 +164,19 @@ export async function POST(request: NextRequest) {
     .eq("id", body.device_id)
     .single();
 
+  const labelUpdate = normalizeLabel(body.label);
+  const now = new Date().toISOString();
+
   if (deviceError || !device) {
-    // Auto-register the device if it doesn't exist yet
+    // Auto-register the device if it doesn't exist yet. `label` is persisted
+    // here (when sent) so the Devices dashboard shows a recognisable name
+    // from the very first sync rather than the truncated id fallback (#60).
     const { error: insertError } = await supabase.from("devices").insert({
       id: body.device_id,
       user_id: user.id,
-      first_seen: new Date().toISOString(),
-      last_seen: new Date().toISOString(),
+      first_seen: now,
+      last_seen: now,
+      label: labelUpdate ?? null,
     });
     if (insertError) {
       console.error("Failed to register device:", insertError);
@@ -166,11 +200,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Update last_seen
-    await supabase
-      .from("devices")
-      .update({ last_seen: new Date().toISOString() })
-      .eq("id", body.device_id);
+    // Update last_seen. Only overwrite `label` when the envelope explicitly
+    // carried one — an old daemon (key absent) must not clobber a label that
+    // a newer daemon previously set on the same device.
+    const patch: { last_seen: string; label?: string | null } = {
+      last_seen: now,
+    };
+    if (labelUpdate !== undefined) patch.label = labelUpdate;
+    await supabase.from("devices").update(patch).eq("id", body.device_id);
   }
 
   // --- UPSERT daily rollups (ADR-0083 §5) ---


### PR DESCRIPTION
## Summary

Closes #60. Paired with siropkin/budi#552 (daemon side, milestone 8.3.7).

The Devices page (#58) falls back to \`device a1b2c3d4\` for everything, because the ingest envelope never carries a label. This PR extends the envelope with an optional \`label\` and persists it on both the auto-register and update paths so a daemon that sends one shows up immediately on the dashboard.

## Behaviour

| Envelope \`label\` | Stored value |
|---|---|
| key absent (old daemon) | **unchanged** — no clobber |
| \`"ivan-mbp"\` | \`"ivan-mbp"\` (trimmed, capped at 128) |
| \`"   "\` / \`""\` | \`null\` — explicit opt-out |
| \`null\` / wrong type | \`null\` |

The daemon owns the string (default = OS hostname, overridable in \`~/.config/budi/cloud.toml\`), so cloud just writes what it receives. No migration — \`devices.label\` already exists and is nullable.

## Privacy note

ADR-0083 §1 bans uploading prompts, code, paths, emails, and raw payloads. \`label\` is a user-controlled string with an explicit opt-out path (set \`label = ""\` in cloud.toml), so it doesn't change what the cloud is allowed to see — it just lets the user pick a friendlier identifier than \`dev_<id>\`.

## Test plan

- [x] \`npm test\` — 58 pass (6 new)
  - auto-register persists label when sent
  - auto-register stores null when absent (old daemon)
  - subsequent ingest updates label, trims whitespace
  - old-daemon envelope (no \`label\` key) leaves existing label intact
  - \`label: ""\` clears a stale label
  - 500-char label is capped at 128
- [x] \`npm run build\` — clean
- [x] \`npm run lint\` — clean
- [ ] After deploy: run a daemon build that sends \`label\` (post siropkin/budi#552), confirm Devices page renders the friendly name without UI changes on this side

Note: no \`.env.local\` on this machine so this wasn't smoke-tested against live Supabase — unit tests + TS + prod build manifest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)