### PR TITLE
fix(invite): preserve next= through auth round-trip (closes #62)

### DIFF
--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Regression coverage for issue #62 — invite-link round-trip.
+ *
+ * The bug: the Supabase auth callback redirected every brand-new (or
+ * orgless) user to `/setup`, ignoring the `?next=/invite/<token>` query
+ * param. That auto-provisioned a personal org for the invitee before the
+ * invite page ever ran, and the invite page then short-circuited with
+ * "Already in an Organization".
+ *
+ * These tests pin the post-auth redirect target for every combination of
+ * (user state) × (next param) so the regression cannot return silently.
+ */
+
+type Row = Record<string, unknown>;
+
+class FakeAdmin {
+  rows: Row[] = [];
+
+  seed(rows: Row[]) {
+    this.rows = [...rows];
+  }
+
+  from(_table: string) {
+    void _table;
+    return new FakeQuery(this.rows);
+  }
+}
+
+class FakeQuery {
+  private filters: Array<(r: Row) => boolean> = [];
+  private _pendingPatch: Row | null = null;
+
+  constructor(private readonly rows: Row[]) {}
+
+  select(_cols?: string) {
+    void _cols;
+    return this;
+  }
+
+  eq(col: string, value: unknown) {
+    this.filters.push((r) => r[col] === value);
+    return this;
+  }
+
+  async single() {
+    const matched = this.rows.filter((r) => this.filters.every((f) => f(r)));
+    if (matched.length !== 1) {
+      return { data: null, error: { message: "not found" } };
+    }
+    return { data: matched[0], error: null };
+  }
+
+  async insert(row: Row) {
+    this.rows.push({ ...row });
+    return { data: null, error: null };
+  }
+
+  update(patch: Row) {
+    this._pendingPatch = patch;
+    return this;
+  }
+
+  // The callback awaits the chained `.update().eq()` directly.
+  then<T>(onFulfilled: (r: { data: null; error: null }) => T) {
+    if (this._pendingPatch) {
+      const matches = this.rows.filter((r) => this.filters.every((f) => f(r)));
+      for (const r of matches) Object.assign(r, this._pendingPatch);
+      this._pendingPatch = null;
+    }
+    return Promise.resolve(onFulfilled({ data: null, error: null }));
+  }
+}
+
+const admin = new FakeAdmin();
+
+let mockUser: { id: string; email: string; user_metadata: Row } | null = {
+  id: "user_abc",
+  email: "bon@example.com",
+  user_metadata: {},
+};
+let exchangeError: { message: string } | null = null;
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => admin,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: {
+      exchangeCodeForSession: async (_code: string) => {
+        void _code;
+        return { error: exchangeError };
+      },
+      getUser: async () => ({ data: { user: mockUser }, error: null }),
+    },
+  }),
+}));
+
+vi.mock("server-only", () => ({}));
+
+beforeEach(() => {
+  admin.seed([]);
+  mockUser = {
+    id: "user_abc",
+    email: "bon@example.com",
+    user_metadata: {},
+  };
+  exchangeError = null;
+});
+
+const ORIGIN = "http://localhost:3000";
+
+async function runCallback(query: string): Promise<string> {
+  const { GET } = await import("./route");
+  const url = `${ORIGIN}/auth/callback${query}`;
+  const res = await GET(new Request(url));
+  return res.headers.get("location") ?? "";
+}
+
+describe("/auth/callback — invite-link round-trip (#62)", () => {
+  it("forwards a new user with ?next=/invite/<token> straight to the invite page", async () => {
+    // No row in `users` yet — first sign-in. Without the fix, this would
+    // redirect to /setup and the invitee would create their own org before
+    // the invite page ever ran.
+    const location = await runCallback("?code=abc&next=%2Finvite%2Ftok_xyz");
+
+    expect(location).toBe(`${ORIGIN}/invite/tok_xyz`);
+    // The user row must still be created — the invite page expects to find
+    // it and just patch on the org_id.
+    expect(admin.rows).toHaveLength(1);
+    expect(admin.rows[0].org_id).toBeNull();
+  });
+
+  it("forwards an existing orgless user with ?next=/invite/<token> to the invite page", async () => {
+    admin.seed([
+      {
+        id: "user_abc",
+        org_id: null,
+        display_name: "Bon",
+      },
+    ]);
+
+    const location = await runCallback("?code=abc&next=%2Finvite%2Ftok_xyz");
+
+    expect(location).toBe(`${ORIGIN}/invite/tok_xyz`);
+  });
+
+  it("still sends a brand-new user with no next to /setup", async () => {
+    const location = await runCallback("?code=abc");
+    expect(location).toBe(`${ORIGIN}/setup`);
+  });
+
+  it("still sends an existing orgless user with no next to /setup", async () => {
+    admin.seed([{ id: "user_abc", org_id: null, display_name: "Bon" }]);
+
+    const location = await runCallback("?code=abc");
+    expect(location).toBe(`${ORIGIN}/setup`);
+  });
+
+  it("sends an existing user with an org to ?next when it's safe", async () => {
+    admin.seed([{ id: "user_abc", org_id: "org_1", display_name: "Bon" }]);
+
+    const location = await runCallback("?code=abc&next=%2Fdashboard%2Fteam");
+    expect(location).toBe(`${ORIGIN}/dashboard/team`);
+  });
+
+  it("ignores an open-redirect attempt in next and falls through to /dashboard", async () => {
+    admin.seed([{ id: "user_abc", org_id: "org_1", display_name: "Bon" }]);
+
+    // `next=https://evil.example` is rejected by the safety whitelist —
+    // the callback falls back to /dashboard.
+    const location = await runCallback(
+      "?code=abc&next=https%3A%2F%2Fevil.example"
+    );
+    expect(location).toBe(`${ORIGIN}/dashboard`);
+  });
+
+  it("redirects to /login on missing code", async () => {
+    const location = await runCallback("");
+    expect(location).toBe(`${ORIGIN}/login?error=missing_code`);
+  });
+
+  it("redirects to /login on auth_failed", async () => {
+    exchangeError = { message: "bad code" };
+    const location = await runCallback("?code=abc");
+    expect(location).toBe(`${ORIGIN}/login?error=auth_failed`);
+  });
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,16 +1,26 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isInvitePath, isSafeNextPath } from "@/lib/auth-redirect";
 import { randomBytes } from "crypto";
 
 /**
  * OAuth callback handler for Supabase Auth.
  * Exchanges the code for a session, then ensures a budi `users` row exists.
+ *
+ * The `?next=<path>` query param is preserved across the auth round-trip
+ * by `buildAuthCallbackUrl` on the login page. When `next` points at an
+ * invite link, this handler must NOT short-circuit to `/setup`: the invite
+ * page is responsible for joining the user to the inviter's org. Sending
+ * a brand-new user to `/setup` first would auto-provision a personal org
+ * and silently break the invite (issue #62).
  */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/dashboard";
+  const rawNext = searchParams.get("next");
+  const next = isSafeNextPath(rawNext) ? rawNext : "/dashboard";
+  const cameFromInvite = isInvitePath(rawNext);
 
   if (!code) {
     return NextResponse.redirect(`${origin}/login?error=missing_code`);
@@ -65,6 +75,11 @@ export async function GET(request: Request) {
       );
     }
 
+    // Came in via an invite link — let the invite page assign the org.
+    if (cameFromInvite) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+
     // New user with no org — redirect to setup
     return NextResponse.redirect(`${origin}/setup`);
   }
@@ -84,8 +99,12 @@ export async function GET(request: Request) {
       .eq("id", user.id);
   }
 
-  // If user has no org, redirect to setup
+  // If user has no org, send them to the invite page when they came via
+  // one — otherwise to setup so they can create their own org.
   if (!existingUser.org_id) {
+    if (cameFromInvite) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
     return NextResponse.redirect(`${origin}/setup`);
   }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { buildAuthCallbackUrl } from "@/lib/auth-redirect";
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -9,12 +10,20 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  // Forward the `?next=<path>` query param through the auth round-trip so
+  // that an invite link (`/login?next=/invite/<token>`) lands the user back
+  // on the invite page after OAuth / magic-link, instead of `/dashboard`.
+  function callbackUrl() {
+    const next = new URLSearchParams(window.location.search).get("next");
+    return buildAuthCallbackUrl(window.location.origin, next);
+  }
+
   async function signInWithProvider(provider: "github" | "google") {
     const supabase = createClient();
     const { error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
+        redirectTo: callbackUrl(),
       },
     });
     if (error) setError(error.message);
@@ -29,7 +38,7 @@ export default function LoginPage() {
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: `${window.location.origin}/auth/callback`,
+        emailRedirectTo: callbackUrl(),
       },
     });
 

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -1,17 +1,28 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isInvitePath } from "@/lib/auth-redirect";
 import { OrgSetupForm } from "./form";
 
 export const dynamic = "force-dynamic";
 
-export default async function SetupPage() {
+export default async function SetupPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) redirect("/login");
+
+  // If the user landed here while in the middle of accepting an invite,
+  // forward to the invite page so they join the inviter's org instead of
+  // creating their own (issue #62).
+  const { next } = await searchParams;
+  if (isInvitePath(next)) redirect(next);
 
   // Check if user already has an org
   const admin = createAdminClient();

--- a/src/lib/auth-redirect.test.ts
+++ b/src/lib/auth-redirect.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAuthCallbackUrl,
+  isInvitePath,
+  isSafeNextPath,
+} from "./auth-redirect";
+
+describe("isSafeNextPath", () => {
+  it("accepts an invite path", () => {
+    expect(isSafeNextPath("/invite/abc123")).toBe(true);
+  });
+
+  it("accepts a dashboard path", () => {
+    expect(isSafeNextPath("/dashboard")).toBe(true);
+    expect(isSafeNextPath("/dashboard/team")).toBe(true);
+  });
+
+  it("rejects null/empty/undefined", () => {
+    expect(isSafeNextPath(null)).toBe(false);
+    expect(isSafeNextPath("")).toBe(false);
+    expect(isSafeNextPath(undefined)).toBe(false);
+  });
+
+  it("rejects absolute URLs (open-redirect guard)", () => {
+    expect(isSafeNextPath("https://evil.example/invite/x")).toBe(false);
+    expect(isSafeNextPath("http://evil.example")).toBe(false);
+  });
+
+  it("rejects protocol-relative URLs (open-redirect guard)", () => {
+    expect(isSafeNextPath("//evil.example/invite/x")).toBe(false);
+  });
+
+  it("rejects paths outside the whitelist", () => {
+    expect(isSafeNextPath("/login")).toBe(false);
+    expect(isSafeNextPath("/setup")).toBe(false);
+    expect(isSafeNextPath("/")).toBe(false);
+  });
+});
+
+describe("isInvitePath", () => {
+  it("returns true for /invite/<token>", () => {
+    expect(isInvitePath("/invite/abc123")).toBe(true);
+  });
+
+  it("returns false for everything else", () => {
+    expect(isInvitePath("/dashboard")).toBe(false);
+    expect(isInvitePath(null)).toBe(false);
+    expect(isInvitePath(undefined)).toBe(false);
+    expect(isInvitePath("/invitex")).toBe(false);
+  });
+});
+
+describe("buildAuthCallbackUrl", () => {
+  const origin = "https://app.example";
+
+  it("returns the bare callback when there is no next", () => {
+    expect(buildAuthCallbackUrl(origin, null)).toBe(
+      "https://app.example/auth/callback"
+    );
+    expect(buildAuthCallbackUrl(origin, undefined)).toBe(
+      "https://app.example/auth/callback"
+    );
+  });
+
+  it("forwards a safe invite path through ?next=", () => {
+    expect(buildAuthCallbackUrl(origin, "/invite/tok_abc")).toBe(
+      "https://app.example/auth/callback?next=%2Finvite%2Ftok_abc"
+    );
+  });
+
+  it("drops unsafe next values rather than forwarding them", () => {
+    // Open-redirect attempts must not be reflected back as ?next=.
+    expect(buildAuthCallbackUrl(origin, "https://evil.example")).toBe(
+      "https://app.example/auth/callback"
+    );
+    expect(buildAuthCallbackUrl(origin, "//evil.example")).toBe(
+      "https://app.example/auth/callback"
+    );
+  });
+});

--- a/src/lib/auth-redirect.ts
+++ b/src/lib/auth-redirect.ts
@@ -1,0 +1,50 @@
+/**
+ * Helpers for preserving a post-login destination across the Supabase
+ * auth round-trip (login form → OAuth/magic-link → /auth/callback → app).
+ *
+ * The risk we are guarding against is the invite flow (`/invite/<token>`):
+ * if `?next=` is dropped during the round-trip, a brand-new user gets
+ * silently provisioned into a fresh personal org and the invite no-ops.
+ * See issue #62 for the original report.
+ */
+
+const ALLOWED_NEXT_PREFIXES = ["/invite/", "/dashboard"] as const;
+
+/**
+ * Whitelist of paths that are safe to use as a post-auth destination.
+ * Refuses absolute URLs and protocol-relative URLs to avoid open redirects.
+ */
+export function isSafeNextPath(
+  next: string | null | undefined
+): next is string {
+  if (!next) return false;
+  if (!next.startsWith("/")) return false;
+  if (next.startsWith("//")) return false;
+  return ALLOWED_NEXT_PREFIXES.some(
+    (prefix) => next === prefix || next.startsWith(prefix)
+  );
+}
+
+/**
+ * Returns true when `next` points at the invite-acceptance page. The
+ * auth callback uses this to skip the `/setup` redirect for users who
+ * came in via an invite link — the invite page provisions them into
+ * the inviter's org instead.
+ */
+export function isInvitePath(next: string | null | undefined): next is string {
+  return typeof next === "string" && next.startsWith("/invite/");
+}
+
+/**
+ * Build the OAuth/magic-link `redirectTo` URL, forwarding a sanitized
+ * `next` query param so the callback knows where to send the user once
+ * the session is established.
+ */
+export function buildAuthCallbackUrl(
+  origin: string,
+  next: string | null | undefined
+): string {
+  const base = `${origin}/auth/callback`;
+  if (!isSafeNextPath(next)) return base;
+  return `${base}?next=${encodeURIComponent(next)}`;
+}


### PR DESCRIPTION
## Summary

Closes #62.

The invite flow was effectively a no-op for new users: clicking `/invite/<token>` sent them to `/login?next=/invite/<token>`, but the OAuth/magic-link round-trip dropped `next`. The callback then sent brand-new users to `/setup`, which auto-provisioned a personal org. When the user later navigated back to the invite, `existingUser.org_id` was already set and `/invite/[token]` rejected them with "Already in an Organization".

Fix is in three places:

- **`src/app/login/page.tsx`** — forwards `?next=<path>` into the OAuth/magic-link `redirectTo` URL via a new `buildAuthCallbackUrl` helper. Reads `next` from `window.location.search` to avoid needing a Suspense boundary.
- **`src/lib/auth-redirect.ts`** — small whitelist of safe `next` prefixes (`/invite/`, `/dashboard`) plus `isInvitePath` predicate. Rejects absolute / protocol-relative URLs so this can't be turned into an open redirect.
- **`src/app/auth/callback/route.ts`** — when `next` is an invite path, redirect there even if the user has no org yet. The invite page is responsible for joining them; sending them through `/setup` first was the bug.
- **`src/app/setup/page.tsx`** — defensive forwarding: if a user somehow lands on `/setup?next=/invite/...`, send them to the invite page instead of the org-creation form.

The bonus from the issue (surfacing "Invite your teammate" as a primary onboarding CTA) is intentionally out of scope for this PR — it's a UX change, not a bug fix.

## Test plan

- [x] `npm test` — adds regression coverage in `src/app/auth/callback/route.test.ts` (8 tests covering every user-state × next-param combination, plus open-redirect protection) and `src/lib/auth-redirect.test.ts` (helper unit tests).
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual repro of the original flow:
  - [ ] Stacy generates invite link from `/dashboard/settings`.
  - [ ] Bon (signed out, no `users` row) opens `/invite/<token>` → bounced to `/login?next=/invite/<token>` → signs in via GitHub.
  - [ ] After OAuth, lands back on `/invite/<token>`, **not** `/setup`. No "type in org name" form.
  - [ ] Bon ends up in Stacy's org; `/dashboard/team` shows him for Stacy.
- [ ] Manual sanity:
  - [ ] Login with no `next` still works (lands on `/dashboard` or `/setup` as before).
  - [ ] `?next=https://evil.example` is dropped — no open redirect.
  - [ ] Existing-token / used-token / expired-token branches in `/invite/[token]` still render the same messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)