### PR TITLE
fix(team): hide /dashboard/team from members; redirect direct hits

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -23,10 +23,10 @@ export default async function DashboardLayout({
 
   return (
     <div className="flex h-screen bg-[#0a0a0a] text-white">
-      <Sidebar />
+      <Sidebar role={user.role} />
       <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-14 items-center gap-2 border-b border-white/10 px-3 sm:gap-3 sm:px-4 md:justify-end md:px-6">
-          <MobileSidebar />
+          <MobileSidebar role={user.role} />
           <div className="flex-1 md:hidden" />
           <SyncFreshness
             deviceCount={freshness.deviceCount}

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { redirect } from "next/navigation";
 import { getCurrentUser, getCostByUser, getEarliestActivity } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
@@ -15,6 +16,10 @@ export default async function TeamPage({
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
+  // Defense-in-depth alongside the sidebar gating in `components/sidebar.tsx`:
+  // the page is scoped to the viewer's own devices (ADR-0083 §6), so for a
+  // member it can only ever show themselves — send them back to Overview (#64).
+  if (user.role !== "manager") redirect("/dashboard");
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -18,9 +18,13 @@ import {
   X,
 } from "lucide-react";
 
+// `managerOnly: true` means the link is rendered only for `role === "manager"`.
+// `/dashboard/team` is scoped to the viewer's own devices (ADR-0083 §6), so for
+// a member it can only ever show themselves — Settings already lists the org
+// roster, so members never need this entry (#64).
 const NAV_ITEMS = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
-  { href: "/dashboard/team", label: "Team", icon: Users },
+  { href: "/dashboard/team", label: "Team", icon: Users, managerOnly: true },
   { href: "/dashboard/devices", label: "Devices", icon: Laptop },
   { href: "/dashboard/models", label: "Models", icon: Cpu },
   { href: "/dashboard/repos", label: "Repos", icon: GitBranch },
@@ -28,15 +32,21 @@ const NAV_ITEMS = [
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
 ] as const;
 
+function visibleNavItems(role: string) {
+  return NAV_ITEMS.filter(
+    (item) => !("managerOnly" in item && item.managerOnly) || role === "manager"
+  );
+}
+
 /**
  * Desktop rail. Hidden below `md` — the mobile drawer (below) takes over
  * there so the 224px rail doesn't eat >50% of a 390px viewport.
  */
-export function Sidebar() {
+export function Sidebar({ role }: { role: string }) {
   return (
     <nav className="hidden w-56 flex-col border-r border-white/10 bg-[#0a0a0a] px-3 py-4 md:flex">
       <BrandLink />
-      <NavList />
+      <NavList items={visibleNavItems(role)} />
     </nav>
   );
 }
@@ -45,7 +55,7 @@ export function Sidebar() {
  * Hamburger button + slide-in drawer for narrow viewports. Rendered inline in
  * the dashboard header so it sits at the top-left where users expect it.
  */
-export function MobileSidebar() {
+export function MobileSidebar({ role }: { role: string }) {
   const [open, setOpen] = useState(false);
   const close = () => setOpen(false);
 
@@ -98,7 +108,7 @@ export function MobileSidebar() {
             </div>
             {/* onNavigate fires before the router commits the new pathname, so
                 the drawer closes as the destination page mounts. */}
-            <NavList onNavigate={close} />
+            <NavList items={visibleNavItems(role)} onNavigate={close} />
           </nav>
         </div>
       )}
@@ -119,11 +129,17 @@ function BrandLink({ onNavigate }: { onNavigate?: MouseEventHandler }) {
   );
 }
 
-function NavList({ onNavigate }: { onNavigate?: MouseEventHandler }) {
+function NavList({
+  items,
+  onNavigate,
+}: {
+  items: ReadonlyArray<(typeof NAV_ITEMS)[number]>;
+  onNavigate?: MouseEventHandler;
+}) {
   const pathname = usePathname();
   return (
     <ul className="space-y-1">
-      {NAV_ITEMS.map((item) => {
+      {items.map((item) => {
         const isActive =
           item.href === "/dashboard"
             ? pathname === "/dashboard"


### PR DESCRIPTION
## Summary

- Hide the **Team** sidebar link for members. Tagging it `managerOnly` in `NAV_ITEMS` and filtering the rendered list by `user.role` keeps the sidebar a single source of truth without spreading role checks through the layout. Both desktop `Sidebar` and `MobileSidebar` now take a `role` prop, plumbed through from `app/dashboard/layout.tsx` (which already loads the user).
- Redirect `/dashboard/team` server-side to `/dashboard` when `user.role !== "manager"` (`app/dashboard/team/page.tsx`) as defense-in-depth — the route is unreachable by URL too.

## Why

Per ADR-0083 §6, the Team page is scoped to the viewer's own devices. For a member it can only ever show themselves, so a freshly-invited member landed on an empty "Team" tab as their first impression. Settings already lists the org roster, so members never need this entry.

## Test plan

- [x] `npm test` — 77 tests pass
- [x] `npm run build` — clean compile
- [ ] As a `member`, the sidebar shows no "Team" entry (desktop and mobile drawer)
- [ ] As a `member`, hitting `/dashboard/team` directly redirects to `/dashboard`
- [ ] As a `manager`, the sidebar still shows "Team" and the page renders unchanged

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)