### PR TITLE
feat(onboarding): surface install link in LinkDaemonBanner (#65)

### DIFF
--- a/src/components/link-daemon-banner.tsx
+++ b/src/components/link-daemon-banner.tsx
@@ -2,15 +2,18 @@
 
 import { useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
-import { Terminal, Copy, Check } from "lucide-react";
+import { Terminal, Copy, Check, Download, ExternalLink } from "lucide-react";
+
+const INSTALL_DOCS_URL = "https://getbudi.dev/install";
 
 /**
- * Prominent "link your local Budi" call-to-action.
+ * Prominent "install + link your local Budi" call-to-action.
  *
- * Rendered on the Overview page for freshly signed-up accounts that don't
- * have any devices yet. The goal is that a user who just created a cloud
- * account can tell — without reading docs — which command to run on their
- * laptop to finish the handshake.
+ * Rendered on the Overview page for accounts with no devices yet. Covers two
+ * states the dashboard can't tell apart from the cloud side: the user hasn't
+ * installed budi-core locally yet, and the user has installed it but hasn't
+ * linked this account. Step 1 points to the canonical install docs; step 2
+ * gives the exact `budi cloud init` command to copy.
  */
 export function LinkDaemonBanner({ apiKey }: { apiKey: string }) {
   const [copied, setCopied] = useState(false);
@@ -29,48 +32,65 @@ export function LinkDaemonBanner({ apiKey }: { apiKey: string }) {
           <div className="flex h-10 w-10 flex-none items-center justify-center rounded-lg bg-sky-500/10 text-sky-400">
             <Terminal className="h-5 w-5" />
           </div>
-          <div className="flex-1 space-y-3">
+          <div className="flex-1 space-y-4">
             <div>
               <h2 className="text-base font-semibold text-white">
-                Link your local Budi to finish setup
+                Finish setup to see your activity
               </h2>
               <p className="mt-1 text-sm text-zinc-400">
-                Run this in your terminal on the machine where{" "}
-                <code className="text-zinc-300">budi</code> is installed — the
-                daemon picks up your key on its next cycle.
+                We haven&apos;t heard from a budi daemon on this account yet.
+                Two steps to get you flowing.
               </p>
             </div>
-            <div className="flex items-start gap-2">
-              <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
-                {command}
-              </code>
-              <button
-                onClick={handleCopy}
-                className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
-              >
-                {copied ? (
-                  <>
-                    <Check className="h-4 w-4" /> Copied
-                  </>
-                ) : (
-                  <>
-                    <Copy className="h-4 w-4" /> Copy
-                  </>
-                )}
-              </button>
-            </div>
-            <p className="text-xs text-zinc-500">
-              Don&apos;t have Budi installed?{" "}
+
+            <div className="space-y-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-zinc-500">
+                Step 1 — Install budi
+              </div>
               <a
-                className="text-zinc-300 underline underline-offset-2 hover:text-white"
-                href="https://getbudi.dev"
+                href={INSTALL_DOCS_URL}
                 target="_blank"
                 rel="noreferrer"
+                data-testid="install-budi-link"
+                className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-100 transition-colors hover:bg-white/15"
               >
-                Install it first
+                <Download className="h-4 w-4" />
+                Install budi on your machine
+                <ExternalLink className="h-3.5 w-3.5 text-zinc-400" />
               </a>
-              , then come back here.
-            </p>
+              <p className="text-xs text-zinc-500">
+                Already installed? Skip to step 2.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <div className="text-xs font-medium uppercase tracking-wide text-zinc-500">
+                Step 2 — Link this account
+              </div>
+              <p className="text-sm text-zinc-400">
+                Run this in your terminal — the daemon picks up your key on its
+                next cycle.
+              </p>
+              <div className="flex items-start gap-2">
+                <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+                  {command}
+                </code>
+                <button
+                  onClick={handleCopy}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-4 w-4" /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4" /> Copy
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </CardContent>


### PR DESCRIPTION
Closes #65.

## Summary
- Restructure `LinkDaemonBanner` around two explicit steps so a brand-new member who's never seen budi-core has a path forward, not just a `budi cloud init` snippet they don't yet have a binary to run.
- **Step 1**: prominent button linking to `https://getbudi.dev/install` (canonical install docs, opens in a new tab).
- **Step 2**: the existing copy-`budi cloud init` flow, unchanged.
- Dashboard state machine untouched — the banner still shows only when `freshness.deviceCount === 0`, and disappears once a device links.

## Test plan
- [x] `npm test` — 77/77 pass
- [x] `npm run lint` — clean
- [ ] Manual smoke: sign in as a fresh account with no devices, confirm Step 1 button opens `getbudi.dev/install` in a new tab and Step 2 copy still works
- [ ] Manual smoke: confirm banner disappears once a device links (state unchanged from before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)