### PR TITLE
feat(invite): make invite links multi-use (#68)

### DIFF
--- a/src/app/invite/[token]/page.test.tsx
+++ b/src/app/invite/[token]/page.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Coverage for issue #68 — invite tokens are multi-use.
+ *
+ * The handler used to single-use the token by writing back `used_by` /
+ * `used_at` and short-circuiting every subsequent visitor with "Already
+ * Used." The new contract: the token stays redeemable until `expires_at`,
+ * each successful join inserts a row into `invite_redemptions`, and a
+ * re-click by an already-joined user is an idempotent redirect to the
+ * dashboard rather than an error.
+ *
+ * These tests pin the redemption flow at the handler level so the
+ * regression cannot return silently if someone re-introduces a "used_by"
+ * style guard.
+ */
+
+type Row = Record<string, unknown>;
+
+class FakeSupabase {
+  tables = new Map<string, Row[]>();
+
+  from(name: string) {
+    if (!this.tables.has(name)) this.tables.set(name, []);
+    return new FakeQuery(this.tables, name);
+  }
+
+  seed(name: string, rows: Row[]) {
+    this.tables.set(name, [...rows]);
+  }
+
+  rows(name: string): Row[] {
+    return this.tables.get(name) ?? [];
+  }
+}
+
+class FakeQuery {
+  private filters: Array<(r: Row) => boolean> = [];
+  private _op: "select" | "delete" | "update" | "insert" | "upsert" = "select";
+  private _patch: Row | null = null;
+  private _upsertOpts: { ignoreDuplicates?: boolean; onConflict?: string } = {};
+
+  constructor(
+    private readonly tables: Map<string, Row[]>,
+    private readonly table: string
+  ) {}
+
+  private get rows(): Row[] {
+    return this.tables.get(this.table) ?? [];
+  }
+
+  select(_cols?: string) {
+    void _cols;
+    this._op = "select";
+    return this;
+  }
+
+  insert(row: Row | Row[]) {
+    this._op = "insert";
+    const next = [...this.rows, ...(Array.isArray(row) ? row : [row])];
+    this.tables.set(this.table, next);
+    return Promise.resolve({ data: null, error: null });
+  }
+
+  upsert(
+    row: Row,
+    opts: { ignoreDuplicates?: boolean; onConflict?: string } = {}
+  ) {
+    this._op = "upsert";
+    this._patch = row;
+    this._upsertOpts = opts;
+    // Apply immediately — the handler awaits the upsert directly without an `.eq()`.
+    this.applyUpsert();
+    return Promise.resolve({ data: null, error: null });
+  }
+
+  update(patch: Row) {
+    this._op = "update";
+    this._patch = patch;
+    return this;
+  }
+
+  eq(col: string, value: unknown) {
+    this.filters.push((r) => r[col] === value);
+    if (this._op === "update") this.applyUpdate();
+    return this;
+  }
+
+  async single() {
+    const matched = this.rows.filter((r) => this.filters.every((f) => f(r)));
+    if (matched.length === 1) return { data: matched[0], error: null };
+    return {
+      data: null,
+      error: { message: `expected 1 row, got ${matched.length}` },
+    };
+  }
+
+  private applyUpdate() {
+    if (!this._patch) return;
+    const patch = this._patch;
+    const next = this.rows.map((r) =>
+      this.filters.every((f) => f(r)) ? { ...r, ...patch } : r
+    );
+    this.tables.set(this.table, next);
+  }
+
+  private applyUpsert() {
+    if (!this._patch) return;
+    const patch = this._patch;
+    const onConflict = (this._upsertOpts.onConflict ?? "")
+      .split(",")
+      .map((c) => c.trim())
+      .filter(Boolean);
+    if (onConflict.length === 0) {
+      this.tables.set(this.table, [...this.rows, patch]);
+      return;
+    }
+    const conflict = this.rows.find((r) =>
+      onConflict.every((c) => r[c] === patch[c])
+    );
+    if (conflict) {
+      if (!this._upsertOpts.ignoreDuplicates) Object.assign(conflict, patch);
+      return;
+    }
+    this.tables.set(this.table, [...this.rows, patch]);
+  }
+}
+
+const fake = new FakeSupabase();
+let authUser: { id: string; email?: string; user_metadata?: Row } | null = null;
+const redirectMock = vi.fn((to: string) => {
+  throw new Error(`__REDIRECT__:${to}`);
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => fake,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    auth: {
+      getUser: async () => ({ data: { user: authUser } }),
+    },
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => redirectMock(to),
+}));
+
+vi.mock("server-only", () => ({}));
+
+beforeEach(() => {
+  for (const t of ["orgs", "users", "invite_tokens", "invite_redemptions"]) {
+    fake.seed(t, []);
+  }
+  authUser = null;
+  redirectMock.mockClear();
+});
+
+const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+const PAST = new Date(Date.now() - 60 * 1000).toISOString();
+
+function seedInvite(overrides: Row = {}) {
+  fake.seed("orgs", [{ id: "org_acme", name: "Acme" }]);
+  fake.seed("invite_tokens", [
+    {
+      id: "tok_xyz",
+      org_id: "org_acme",
+      role: "member",
+      created_by: "usr_manager",
+      created_at: PAST,
+      expires_at: FUTURE,
+      ...overrides,
+    },
+  ]);
+}
+
+async function loadPage() {
+  const mod = await import("./page");
+  return mod.default;
+}
+
+async function visit(token = "tok_xyz") {
+  const InvitePage = await loadPage();
+  return InvitePage({ params: Promise.resolve({ token }) });
+}
+
+describe("invite/[token] page — multi-use redemption (#68)", () => {
+  it("lets two distinct authenticated users redeem the same token", async () => {
+    seedInvite();
+    fake.seed("users", [
+      { id: "usr_manager", org_id: "org_acme", role: "manager" },
+    ]);
+
+    // First teammate joins.
+    authUser = {
+      id: "usr_alice",
+      email: "alice@example.com",
+      user_metadata: {},
+    };
+    await expect(visit()).rejects.toThrow("__REDIRECT__:/dashboard");
+
+    // Second teammate joins via the SAME token — must succeed (no "Already Used").
+    authUser = { id: "usr_bob", email: "bob@example.com", user_metadata: {} };
+    await expect(visit()).rejects.toThrow("__REDIRECT__:/dashboard");
+
+    const users = fake.rows("users");
+    expect(users.find((u) => u.id === "usr_alice")?.org_id).toBe("org_acme");
+    expect(users.find((u) => u.id === "usr_bob")?.org_id).toBe("org_acme");
+
+    const redemptions = fake.rows("invite_redemptions");
+    expect(redemptions.map((r) => r.user_id).sort()).toEqual([
+      "usr_alice",
+      "usr_bob",
+    ]);
+    // The token row stays intact and reusable — no `used_by` is written back.
+    const token = fake.rows("invite_tokens")[0];
+    expect(token.id).toBe("tok_xyz");
+    expect(token).not.toHaveProperty("used_by");
+  });
+
+  it("treats a re-click by an already-joined user as an idempotent dashboard redirect", async () => {
+    seedInvite();
+    fake.seed("users", [
+      { id: "usr_manager", org_id: "org_acme", role: "manager" },
+      { id: "usr_alice", org_id: "org_acme", role: "member" },
+    ]);
+    // Pretend Alice already redeemed once.
+    fake.seed("invite_redemptions", [
+      { token_id: "tok_xyz", user_id: "usr_alice" },
+    ]);
+
+    authUser = {
+      id: "usr_alice",
+      email: "alice@example.com",
+      user_metadata: {},
+    };
+    await expect(visit()).rejects.toThrow("__REDIRECT__:/dashboard");
+
+    // No duplicate row appears.
+    expect(fake.rows("invite_redemptions")).toHaveLength(1);
+  });
+
+  it("blocks a user already in a different org with the cross-org guard", async () => {
+    seedInvite();
+    fake.seed("users", [
+      { id: "usr_alice", org_id: "org_other", role: "member" },
+    ]);
+
+    authUser = {
+      id: "usr_alice",
+      email: "alice@example.com",
+      user_metadata: {},
+    };
+    const node = await visit();
+
+    // Renders the "Already in an Organization" message — does NOT redirect.
+    expect(redirectMock).not.toHaveBeenCalled();
+    const html = JSON.stringify(node);
+    expect(html).toContain("Already in an Organization");
+    // No redemption row is written for a cross-org bounce.
+    expect(fake.rows("invite_redemptions")).toHaveLength(0);
+  });
+
+  it("redirects an unauthenticated visitor to /login with a next= round-trip", async () => {
+    seedInvite();
+    authUser = null;
+
+    await expect(visit()).rejects.toThrow(
+      "__REDIRECT__:/login?next=/invite/tok_xyz"
+    );
+    expect(fake.rows("invite_redemptions")).toHaveLength(0);
+  });
+
+  it("renders Expired (and writes nothing) when the token is past expires_at", async () => {
+    seedInvite({ expires_at: PAST });
+    authUser = {
+      id: "usr_alice",
+      email: "alice@example.com",
+      user_metadata: {},
+    };
+
+    const node = await visit();
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(JSON.stringify(node)).toContain("Expired");
+    expect(fake.rows("invite_redemptions")).toHaveLength(0);
+  });
+
+  it("renders Invalid Invite for a token that does not exist", async () => {
+    authUser = {
+      id: "usr_alice",
+      email: "alice@example.com",
+      user_metadata: {},
+    };
+
+    const node = await visit("does_not_exist");
+    expect(JSON.stringify(node)).toContain("Invalid Invite");
+    expect(fake.rows("invite_redemptions")).toHaveLength(0);
+  });
+});

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -16,7 +16,7 @@ export default async function InvitePage({
   // Validate the invite token
   const { data: invite } = await admin
     .from("invite_tokens")
-    .select("id, org_id, role, expires_at, used_by")
+    .select("id, org_id, role, expires_at")
     .eq("id", token)
     .single();
 
@@ -25,22 +25,7 @@ export default async function InvitePage({
       <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
         <div className="text-center">
           <h1 className="text-xl font-bold text-white">Invalid Invite</h1>
-          <p className="mt-2 text-zinc-400">
-            This invite link is invalid or has already been used.
-          </p>
-        </div>
-      </main>
-    );
-  }
-
-  if (invite.used_by) {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
-        <div className="text-center">
-          <h1 className="text-xl font-bold text-white">Already Used</h1>
-          <p className="mt-2 text-zinc-400">
-            This invite link has already been used.
-          </p>
+          <p className="mt-2 text-zinc-400">This invite link is invalid.</p>
         </div>
       </main>
     );
@@ -80,6 +65,13 @@ export default async function InvitePage({
   if (existingUser?.org_id) {
     // User already in an org
     if (existingUser.org_id === invite.org_id) {
+      // Re-click by an already-joined member is idempotent.
+      await admin
+        .from("invite_redemptions")
+        .upsert(
+          { token_id: token, user_id: authUser.id },
+          { onConflict: "token_id,user_id", ignoreDuplicates: true }
+        );
       redirect("/dashboard");
     }
     return (
@@ -123,11 +115,16 @@ export default async function InvitePage({
     });
   }
 
-  // Mark token as used
+  // Record the redemption. `invite_redemptions` is now the source of truth
+  // for "who joined via this token" — the token itself stays valid for other
+  // teammates until it expires. Idempotent on (token, user) so a re-click by
+  // the same user is a no-op.
   await admin
-    .from("invite_tokens")
-    .update({ used_by: authUser.id, used_at: new Date().toISOString() })
-    .eq("id", token);
+    .from("invite_redemptions")
+    .upsert(
+      { token_id: token, user_id: authUser.id },
+      { onConflict: "token_id,user_id", ignoreDuplicates: true }
+    );
 
   redirect("/dashboard");
 }

--- a/supabase/migrations/003_multi_use_invites.sql
+++ b/supabase/migrations/003_multi_use_invites.sql
@@ -1,0 +1,52 @@
+-- Multi-use invite links (issue #68)
+--
+-- Switches `invite_tokens` from single-use (one `used_by`/`used_at` slot per
+-- token) to multi-use: any signed-in user who clicks before `expires_at` can
+-- join the inviter's org. The audit trail of "who joined via which token"
+-- moves into a child `invite_redemptions` table so the token itself stops
+-- carrying redemption state.
+
+-- ============================================================
+-- 1. New child table: one row per (token, user) redemption
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS invite_redemptions (
+    token_id     TEXT NOT NULL REFERENCES invite_tokens(id) ON DELETE CASCADE,
+    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    redeemed_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (token_id, user_id)
+);
+
+ALTER TABLE invite_redemptions ENABLE ROW LEVEL SECURITY;
+
+-- Mirrors the `invite_tokens` SELECT policy: managers can read redemptions
+-- only for tokens that belong to their own org.
+CREATE POLICY "Managers can read org invite redemptions"
+    ON invite_redemptions FOR SELECT
+    USING (
+        token_id IN (
+            SELECT id FROM invite_tokens
+            WHERE org_id IN (
+                SELECT org_id FROM users
+                WHERE id = auth.uid()::text
+                  AND role = 'manager'
+            )
+        )
+    );
+
+-- ============================================================
+-- 2. Backfill audit history from the legacy single-use columns
+-- ============================================================
+
+INSERT INTO invite_redemptions (token_id, user_id, redeemed_at)
+SELECT id, used_by, COALESCE(used_at, created_at)
+FROM invite_tokens
+WHERE used_by IS NOT NULL
+ON CONFLICT (token_id, user_id) DO NOTHING;
+
+-- ============================================================
+-- 3. Drop the now-dead single-use columns
+-- ============================================================
+
+ALTER TABLE invite_tokens DROP COLUMN IF EXISTS used_by;
+ALTER TABLE invite_tokens DROP COLUMN IF EXISTS used_at;


### PR DESCRIPTION
Closes #68.

## Summary

- Switches invite tokens from single-use to multi-use so the settings copy ("share with your team") matches reality.
- New `invite_redemptions(token_id, user_id, redeemed_at)` child table replaces `invite_tokens.used_by`/`used_at`. Tokens stay redeemable until `expires_at`.
- Migration backfills existing redemptions from `used_by`/`used_at` before dropping the columns so audit history isn't lost.
- Handler now upserts a redemption row with `ON CONFLICT DO NOTHING`. A re-click by an already-joined member is an idempotent `/dashboard` redirect instead of "Already Used."
- Cross-org guard, expiry check, and unauthenticated `next=` round-trip are unchanged.

## Test plan

- [x] New `src/app/invite/[token]/page.test.tsx` covers:
  - Two distinct authenticated users redeeming the same token both succeed, both rows land in `invite_redemptions`, and the token row is untouched.
  - A re-click by an already-joined user is an idempotent redirect to `/dashboard` with no duplicate redemption row.
  - Cross-org guard still trips for a user already in a different org (no redemption written).
  - Unauthenticated visit redirects to `/login?next=/invite/<token>` with no side effects.
  - Expired and missing tokens render their respective messages and write nothing.
- [x] Full vitest suite: 83/83 passing.
- [x] `npm run lint` clean.
- [ ] Manual: regenerate an invite link in the settings UI, share with two teammates, both should be able to join the org via the same link.
- [ ] Verify `003_multi_use_invites.sql` runs cleanly against an environment that has partially-redeemed `invite_tokens` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)