### PR TITLE
feat(team): managers can edit member roles from settings

### DIFF
--- a/src/app/actions/org.test.ts
+++ b/src/app/actions/org.test.ts
@@ -135,6 +135,14 @@ vi.mock("next/navigation", () => ({
   redirect: (to: string) => redirectMock(to),
 }));
 
+const revalidatePathMock = vi.fn((path: string) => {
+  void path;
+});
+
+vi.mock("next/cache", () => ({
+  revalidatePath: (path: string) => revalidatePathMock(path),
+}));
+
 beforeEach(() => {
   for (const t of [
     "orgs",
@@ -149,6 +157,7 @@ beforeEach(() => {
   authUserId = null;
   signOut.mockClear();
   redirectMock.mockClear();
+  revalidatePathMock.mockClear();
 });
 
 function seedSoloManagerWithData() {
@@ -232,7 +241,9 @@ describe("deleteOrganization", () => {
     fd.set("confirm", "Acme Co");
 
     const result = await deleteOrganization(undefined, fd);
-    expect(result).toEqual({ error: "Only managers can delete the organization" });
+    expect(result).toEqual({
+      error: "Only managers can delete the organization",
+    });
     expect(fake.rows("orgs")).toHaveLength(1);
     expect(fake.rows("users")).toHaveLength(2);
     expect(signOut).not.toHaveBeenCalled();
@@ -320,5 +331,153 @@ describe("leaveOrganization", () => {
     const { leaveOrganization } = await loadActions();
     const result = await leaveOrganization();
     expect(result).toEqual({ error: "Not a member of any organization" });
+  });
+});
+
+describe("updateMemberRole", () => {
+  function seedTwoOrgs() {
+    fake.seed("orgs", [
+      { id: "org_acme", name: "Acme Co" },
+      { id: "org_other", name: "Other Inc" },
+    ]);
+    fake.seed("users", [
+      { id: "usr_ivan", org_id: "org_acme", role: "manager", api_key: "k1" },
+      { id: "usr_pat", org_id: "org_acme", role: "member", api_key: "k2" },
+      { id: "usr_jess", org_id: "org_acme", role: "manager", api_key: "k3" },
+      // Cross-org user — must never be reachable from an Acme manager.
+      {
+        id: "usr_outsider",
+        org_id: "org_other",
+        role: "member",
+        api_key: "k4",
+      },
+    ]);
+  }
+
+  it("promotes a member to manager and revalidates the settings page", async () => {
+    seedTwoOrgs();
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_pat", "manager");
+
+    expect(result).toEqual({ ok: true });
+    const pat = fake.rows("users").find((u) => u.id === "usr_pat");
+    expect(pat?.role).toBe("manager");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/dashboard/settings");
+  });
+
+  it("demotes another manager when ≥2 managers exist", async () => {
+    seedTwoOrgs();
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_jess", "member");
+
+    expect(result).toEqual({ ok: true });
+    const jess = fake.rows("users").find((u) => u.id === "usr_jess");
+    expect(jess?.role).toBe("member");
+  });
+
+  it("refuses to demote the last remaining manager (other-demote)", async () => {
+    fake.seed("orgs", [{ id: "org_acme", name: "Acme Co" }]);
+    fake.seed("users", [
+      { id: "usr_ivan", org_id: "org_acme", role: "manager", api_key: "k1" },
+      { id: "usr_pat", org_id: "org_acme", role: "member", api_key: "k2" },
+      { id: "usr_jess", org_id: "org_acme", role: "manager", api_key: "k3" },
+    ]);
+    // Ivan demotes Jess first — now Ivan is the only manager.
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    await updateMemberRole("usr_jess", "member");
+    const result = await updateMemberRole("usr_jess", "member");
+    // The first call removed Jess as manager, second is a no-op short-circuit.
+    expect(result).toEqual({ ok: true });
+
+    // Now an attempt to demote the only remaining manager (Ivan) must fail.
+    const lastManagerResult = await updateMemberRole("usr_ivan", "member");
+    expect(lastManagerResult).toEqual({
+      error: "Can't demote the last manager — promote someone else first.",
+    });
+    const ivan = fake.rows("users").find((u) => u.id === "usr_ivan");
+    expect(ivan?.role).toBe("manager");
+  });
+
+  it("refuses self-demote when caller is the last manager", async () => {
+    fake.seed("orgs", [{ id: "org_acme", name: "Acme Co" }]);
+    fake.seed("users", [
+      { id: "usr_ivan", org_id: "org_acme", role: "manager", api_key: "k1" },
+      { id: "usr_pat", org_id: "org_acme", role: "member", api_key: "k2" },
+    ]);
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_ivan", "member");
+
+    expect(result).toEqual({
+      error: "Can't demote the last manager — promote someone else first.",
+    });
+    const ivan = fake.rows("users").find((u) => u.id === "usr_ivan");
+    expect(ivan?.role).toBe("manager");
+  });
+
+  it("refuses a non-manager caller", async () => {
+    seedTwoOrgs();
+    authUserId = "usr_pat"; // member
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_pat", "manager");
+
+    expect(result).toEqual({ error: "Only managers can change member roles" });
+    const pat = fake.rows("users").find((u) => u.id === "usr_pat");
+    expect(pat?.role).toBe("member");
+  });
+
+  it("refuses to touch a user from another org", async () => {
+    seedTwoOrgs();
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_outsider", "manager");
+
+    expect(result).toEqual({
+      error: "User is not a member of your organization",
+    });
+    const outsider = fake.rows("users").find((u) => u.id === "usr_outsider");
+    expect(outsider?.role).toBe("member");
+  });
+
+  it("rejects unknown role values", async () => {
+    seedTwoOrgs();
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_pat", "owner");
+
+    expect(result).toEqual({ error: "Invalid role" });
+    const pat = fake.rows("users").find((u) => u.id === "usr_pat");
+    expect(pat?.role).toBe("member");
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    seedTwoOrgs();
+    authUserId = null;
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_pat", "manager");
+
+    expect(result).toEqual({ error: "Not authenticated" });
+  });
+
+  it("short-circuits a no-op without writing or revalidating", async () => {
+    seedTwoOrgs();
+    authUserId = "usr_ivan";
+
+    const { updateMemberRole } = await loadActions();
+    const result = await updateMemberRole("usr_pat", "member");
+
+    expect(result).toEqual({ ok: true });
+    expect(revalidatePathMock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { randomBytes } from "crypto";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -206,4 +207,78 @@ export async function leaveOrganization(): Promise<{ error: string } | void> {
 
   await supabase.auth.signOut();
   redirect("/login");
+}
+
+/**
+ * Manager-only: change another org member's role between `member` and
+ * `manager`. Self-edits go through the same path so the server's safety
+ * guards (in particular the last-manager check) apply uniformly.
+ *
+ * The admin client bypasses RLS, so this action has to scope every read
+ * and write to the caller's `org_id` itself — a manager from org A must
+ * never be able to flip a user in org B.
+ *
+ * The "last manager" guard mirrors the invariant enforced by
+ * `leaveOrganization`: an org must always have ≥1 manager. Without this
+ * check a sole manager could demote themselves and orphan the org with
+ * no one able to invite, promote, or delete it.
+ */
+export async function updateMemberRole(
+  targetUserId: string,
+  newRole: string
+): Promise<{ ok?: true; error?: string }> {
+  if (newRole !== "member" && newRole !== "manager") {
+    return { error: "Invalid role" };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+  if (!authUser) return { error: "Not authenticated" };
+
+  const admin = createAdminClient();
+  const { data: me } = await admin
+    .from("users")
+    .select("id, org_id, role")
+    .eq("id", authUser.id)
+    .single();
+
+  if (!me?.org_id || me.role !== "manager") {
+    return { error: "Only managers can change member roles" };
+  }
+
+  const { data: target } = await admin
+    .from("users")
+    .select("id, org_id, role")
+    .eq("id", targetUserId)
+    .single();
+
+  if (!target || target.org_id !== me.org_id) {
+    return { error: "User is not a member of your organization" };
+  }
+
+  if (target.role === newRole) return { ok: true };
+
+  if (target.role === "manager" && newRole === "member") {
+    const { data: managers } = await admin
+      .from("users")
+      .select("id")
+      .eq("org_id", me.org_id)
+      .eq("role", "manager");
+    if ((managers?.length ?? 0) <= 1) {
+      return {
+        error: "Can't demote the last manager — promote someone else first.",
+      };
+    }
+  }
+
+  const { error: updateError } = await admin
+    .from("users")
+    .update({ role: newRole })
+    .eq("id", targetUserId);
+  if (updateError) return { error: "Failed to update role" };
+
+  revalidatePath("/dashboard/settings");
+  return { ok: true };
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { getCurrentUser, getOrgMembers } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -6,6 +5,7 @@ import { ApiKeySection } from "./api-key-section";
 import { CopyButton } from "./copy-button";
 import { InviteSection } from "./invite-section";
 import { DangerZone } from "./danger-zone";
+import { RoleCell } from "./role-cell";
 
 export default async function SettingsPage() {
   const user = await getCurrentUser();
@@ -19,6 +19,7 @@ export default async function SettingsPage() {
     .single();
 
   const members = await getOrgMembers(user.org_id);
+  const canEditRoles = user.role === "manager";
 
   return (
     <div className="space-y-6">
@@ -76,7 +77,11 @@ export default async function SettingsPage() {
                       </td>
                       <td className="py-2 text-zinc-400">{m.email || "-"}</td>
                       <td className="py-2">
-                        <RoleBadge role={m.role} />
+                        <RoleCell
+                          userId={m.id}
+                          initialRole={m.role}
+                          canEdit={canEditRoles}
+                        />
                       </td>
                     </tr>
                   ))}
@@ -89,7 +94,11 @@ export default async function SettingsPage() {
                       <span className="truncate text-zinc-200">
                         {m.display_name || "-"}
                       </span>
-                      <RoleBadge role={m.role} />
+                      <RoleCell
+                        userId={m.id}
+                        initialRole={m.role}
+                        canEdit={canEditRoles}
+                      />
                     </div>
                     {m.email && (
                       <p className="truncate text-xs text-zinc-500">
@@ -108,20 +117,5 @@ export default async function SettingsPage() {
 
       <DangerZone userRole={user.role} orgName={org?.name ?? ""} />
     </div>
-  );
-}
-
-function RoleBadge({ role }: { role: string }) {
-  return (
-    <span
-      className={clsx(
-        "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
-        role === "manager"
-          ? "border-blue-500/30 bg-blue-500/10 text-blue-300"
-          : "border-zinc-500/30 bg-zinc-500/10 text-zinc-400"
-      )}
-    >
-      {role}
-    </span>
   );
 }

--- a/src/app/dashboard/settings/role-cell.tsx
+++ b/src/app/dashboard/settings/role-cell.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { clsx } from "clsx";
+import { updateMemberRole } from "@/app/actions/org";
+
+/**
+ * Role display + (for managers) inline editor for a single team-members row.
+ *
+ * Members see the same read-only badge as before. Managers see a styled
+ * native `<select>` that promotes/demotes on change. The update is applied
+ * optimistically and rolled back if the server action returns an error
+ * (e.g. last-manager guard) — the inline error appears under the select.
+ *
+ * Self-edits go through the same server path; we never short-circuit a
+ * demote-self locally because the "last manager" check is server-side only.
+ */
+export function RoleCell({
+  userId,
+  initialRole,
+  canEdit,
+}: {
+  userId: string;
+  initialRole: string;
+  canEdit: boolean;
+}) {
+  const [role, setRole] = useState(initialRole);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  if (!canEdit) return <RoleBadge role={role} />;
+
+  function onChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const next = e.target.value;
+    const previous = role;
+    if (next === previous) return;
+
+    setRole(next);
+    setError(null);
+    startTransition(async () => {
+      const result = await updateMemberRole(userId, next);
+      if (result.error) {
+        setRole(previous);
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <select
+        value={role}
+        onChange={onChange}
+        disabled={pending}
+        aria-label="Role"
+        className={clsx(
+          "rounded-md border px-2 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-1 disabled:opacity-50",
+          role === "manager"
+            ? "border-blue-500/30 bg-blue-500/10 text-blue-300 focus:ring-blue-500/40"
+            : "border-zinc-500/30 bg-zinc-500/10 text-zinc-300 focus:ring-zinc-500/40"
+        )}
+      >
+        <option value="member">member</option>
+        <option value="manager">manager</option>
+      </select>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}
+
+function RoleBadge({ role }: { role: string }) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium",
+        role === "manager"
+          ? "border-blue-500/30 bg-blue-500/10 text-blue-300"
+          : "border-zinc-500/30 bg-zinc-500/10 text-zinc-400"
+      )}
+    >
+      {role}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a manager-only `updateMemberRole` server action that re-validates auth, scopes the target to the caller's `org_id`, validates the role value, short-circuits no-ops, and enforces a last-manager guard so an org can never end up with zero managers.
- Replaces the read-only `RoleBadge` in `/dashboard/settings` with a new `RoleCell` client component — managers see a styled native `<select>` with optimistic update + rollback + inline error; non-managers see the same badge as before.
- Calls `revalidatePath('/dashboard/settings')` after a successful write so other tabs/clients pick up the change on next render.

Closes #69.

## Test plan

- [x] `npm test` — 92 tests pass, including 9 new cases in `org.test.ts` (promote, demote-with-≥2-managers, last-manager guard for both other-demote and self-demote, non-manager rejection, cross-org rejection, unknown role values, unauthenticated caller, no-op short-circuit)
- [x] `npm run lint` clean
- [ ] Manual smoke (recommended before merge):
  - Manager promotes a member → badge updates inline, reload confirms persistence
  - Manager demotes another manager when ≥2 managers exist → succeeds
  - Manager attempts to demote the only remaining manager (incl. self) → inline error, select reverts to `manager`
  - Member viewing the page → no select rendered, only badges
  - Mobile viewport (`<sm`) → stacked list still renders the select consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)