### PR TITLE
feat(invite): allow cross-org switch from invite page (#72)

### DIFF
--- a/src/app/actions/org.test.ts
+++ b/src/app/actions/org.test.ts
@@ -69,6 +69,30 @@ class FakeQuery {
     return this.maybeFlushMutating();
   }
 
+  upsert(
+    row: Row,
+    opts: { ignoreDuplicates?: boolean; onConflict?: string } = {}
+  ) {
+    this._op = "select"; // settle so subsequent ops on the same builder are clean
+    const onConflict = (opts.onConflict ?? "")
+      .split(",")
+      .map((c) => c.trim())
+      .filter(Boolean);
+    if (onConflict.length === 0) {
+      this.tables.set(this.table, [...this.rows, row]);
+      return Promise.resolve({ data: null, error: null });
+    }
+    const conflict = this.rows.find((r) =>
+      onConflict.every((c) => r[c] === row[c])
+    );
+    if (conflict) {
+      if (!opts.ignoreDuplicates) Object.assign(conflict, row);
+      return Promise.resolve({ data: null, error: null });
+    }
+    this.tables.set(this.table, [...this.rows, row]);
+    return Promise.resolve({ data: null, error: null });
+  }
+
   async single() {
     const matched = this.rows.filter((r) => this.filters.every((f) => f(r)));
     if (matched.length === 1) return { data: matched[0], error: null };
@@ -151,6 +175,7 @@ beforeEach(() => {
     "daily_rollups",
     "session_summaries",
     "invite_tokens",
+    "invite_redemptions",
   ]) {
     fake.seed(t, []);
   }
@@ -479,5 +504,177 @@ describe("updateMemberRole", () => {
 
     expect(result).toEqual({ ok: true });
     expect(revalidatePathMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("switchOrganization", () => {
+  const FUTURE = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const PAST = new Date(Date.now() - 60 * 1000).toISOString();
+
+  function seedSwitchableMember() {
+    fake.seed("orgs", [
+      { id: "org_acme", name: "Acme Co" },
+      { id: "org_other", name: "Other Inc" },
+    ]);
+    fake.seed("users", [
+      { id: "usr_ivan", org_id: "org_other", role: "manager", api_key: "k1" },
+      { id: "usr_alice", org_id: "org_other", role: "member", api_key: "k2" },
+      { id: "usr_acme_mgr", org_id: "org_acme", role: "manager", api_key: "k3" },
+    ]);
+    fake.seed("devices", [{ id: "dev_alice", user_id: "usr_alice" }]);
+    fake.seed("daily_rollups", [
+      { device_id: "dev_alice", bucket_day: "2026-04-20", cost_cents: 100 },
+    ]);
+    fake.seed("session_summaries", [
+      { device_id: "dev_alice", session_id: "s1" },
+    ]);
+    fake.seed("invite_tokens", [
+      {
+        id: "tok_acme",
+        org_id: "org_acme",
+        role: "member",
+        created_by: "usr_acme_mgr",
+        expires_at: FUTURE,
+      },
+    ]);
+  }
+
+  function fd(values: Record<string, string>): FormData {
+    const f = new FormData();
+    for (const [k, v] of Object.entries(values)) f.set(k, v);
+    return f;
+  }
+
+  it("flips the caller's org_id, leaves devices/data intact, and writes an audit row", async () => {
+    seedSwitchableMember();
+    authUserId = "usr_alice";
+
+    const { switchOrganization } = await loadActions();
+    await expect(
+      switchOrganization(
+        undefined,
+        fd({ token: "tok_acme", targetOrgId: "org_acme", confirm: "Acme Co" })
+      )
+    ).rejects.toThrow("__REDIRECT__");
+
+    const alice = fake.rows("users").find((u) => u.id === "usr_alice");
+    expect(alice?.org_id).toBe("org_acme");
+    expect(alice?.role).toBe("member");
+
+    // Devices + synced data follow the user (FKs are user_id, not org_id).
+    expect(fake.rows("devices")).toHaveLength(1);
+    expect(fake.rows("daily_rollups")).toHaveLength(1);
+    expect(fake.rows("session_summaries")).toHaveLength(1);
+
+    // Audit trail in invite_redemptions, same shape as a fresh join.
+    const redemptions = fake.rows("invite_redemptions");
+    expect(redemptions).toEqual([
+      { token_id: "tok_acme", user_id: "usr_alice" },
+    ]);
+
+    // The token itself is untouched and still redeemable for other teammates.
+    expect(fake.rows("invite_tokens")).toHaveLength(1);
+
+    expect(redirectMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("refuses a manager (would orphan the current org)", async () => {
+    seedSwitchableMember();
+    authUserId = "usr_ivan"; // manager of org_other
+
+    const { switchOrganization } = await loadActions();
+    const result = await switchOrganization(
+      undefined,
+      fd({ token: "tok_acme", targetOrgId: "org_acme", confirm: "Acme Co" })
+    );
+
+    expect(result?.error).toMatch(/Managers can't switch/i);
+    const ivan = fake.rows("users").find((u) => u.id === "usr_ivan");
+    expect(ivan?.org_id).toBe("org_other");
+    expect(fake.rows("invite_redemptions")).toHaveLength(0);
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    seedSwitchableMember();
+    authUserId = null;
+
+    const { switchOrganization } = await loadActions();
+    const result = await switchOrganization(
+      undefined,
+      fd({ token: "tok_acme", targetOrgId: "org_acme", confirm: "Acme Co" })
+    );
+
+    expect(result).toEqual({ error: "Not authenticated" });
+  });
+
+  it("refuses an expired invite even if the form looks valid", async () => {
+    seedSwitchableMember();
+    fake.seed("invite_tokens", [
+      {
+        id: "tok_acme",
+        org_id: "org_acme",
+        role: "member",
+        created_by: "usr_acme_mgr",
+        expires_at: PAST,
+      },
+    ]);
+    authUserId = "usr_alice";
+
+    const { switchOrganization } = await loadActions();
+    const result = await switchOrganization(
+      undefined,
+      fd({ token: "tok_acme", targetOrgId: "org_acme", confirm: "Acme Co" })
+    );
+
+    expect(result).toEqual({ error: "Invite link has expired" });
+    const alice = fake.rows("users").find((u) => u.id === "usr_alice");
+    expect(alice?.org_id).toBe("org_other");
+  });
+
+  it("refuses a missing/forged token", async () => {
+    seedSwitchableMember();
+    authUserId = "usr_alice";
+
+    const { switchOrganization } = await loadActions();
+    const result = await switchOrganization(
+      undefined,
+      fd({ token: "tok_nope", targetOrgId: "org_acme", confirm: "Acme Co" })
+    );
+
+    expect(result).toEqual({ error: "Invite link is invalid" });
+  });
+
+  it("refuses a tampered targetOrgId that doesn't match the token", async () => {
+    seedSwitchableMember();
+    authUserId = "usr_alice";
+
+    const { switchOrganization } = await loadActions();
+    const result = await switchOrganization(
+      undefined,
+      fd({ token: "tok_acme", targetOrgId: "org_other", confirm: "Acme Co" })
+    );
+
+    expect(result).toEqual({
+      error: "Invite link does not match the target organization",
+    });
+    const alice = fake.rows("users").find((u) => u.id === "usr_alice");
+    expect(alice?.org_id).toBe("org_other");
+  });
+
+  it("requires the typed confirmation to match the target org name", async () => {
+    seedSwitchableMember();
+    authUserId = "usr_alice";
+
+    const { switchOrganization } = await loadActions();
+    const result = await switchOrganization(
+      undefined,
+      fd({ token: "tok_acme", targetOrgId: "org_acme", confirm: "acme co" })
+    );
+
+    expect(result).toEqual({
+      error: "Type the organization name exactly to confirm",
+    });
+    const alice = fake.rows("users").find((u) => u.id === "usr_alice");
+    expect(alice?.org_id).toBe("org_other");
   });
 });

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -210,6 +210,101 @@ export async function leaveOrganization(): Promise<{ error: string } | void> {
 }
 
 /**
+ * Member-only: switch the caller from their current org to the org an invite
+ * token belongs to. The opt-in alternative to the dead-end "Already in an
+ * Organization" screen on `/invite/[token]` (#72).
+ *
+ * Devices, daily rollups, and session summaries are keyed off `user_id`
+ * (transitively through `devices`), so flipping `users.org_id` is enough to
+ * carry every piece of synced data with the user — there's no DELETE in this
+ * action by design. The original org loses visibility on the caller's data
+ * the moment the update commits.
+ *
+ * Managers are refused for the same reason `leaveOrganization` refuses them:
+ * a sole manager switching out would orphan the org with no one able to
+ * invite, promote, or delete. They have to delete the org first (or, once
+ * we ship one, hand off ownership).
+ *
+ * The token is re-validated server-side. The form-supplied `targetOrgId` is
+ * cross-checked against the token's `org_id` so a tampered request can't
+ * land the user in an org the token wasn't issued for.
+ */
+export async function switchOrganization(
+  _prevState: { error: string } | undefined,
+  formData: FormData
+): Promise<{ error: string } | void> {
+  const tokenId = String(formData.get("token") ?? "");
+  const targetOrgId = String(formData.get("targetOrgId") ?? "");
+  const confirm = String(formData.get("confirm") ?? "");
+
+  const supabase = await createClient();
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+  if (!authUser) return { error: "Not authenticated" };
+
+  const admin = createAdminClient();
+  const { data: me } = await admin
+    .from("users")
+    .select("id, org_id, role")
+    .eq("id", authUser.id)
+    .single();
+
+  if (!me?.org_id) return { error: "Not a member of any organization" };
+  if (me.role === "manager") {
+    return {
+      error:
+        "Managers can't switch organizations. Delete this org or hand off ownership first.",
+    };
+  }
+
+  const { data: invite } = await admin
+    .from("invite_tokens")
+    .select("id, org_id, role, expires_at")
+    .eq("id", tokenId)
+    .single();
+
+  if (!invite) return { error: "Invite link is invalid" };
+  if (new Date(invite.expires_at as string) < new Date()) {
+    return { error: "Invite link has expired" };
+  }
+  if (invite.org_id !== targetOrgId) {
+    return { error: "Invite link does not match the target organization" };
+  }
+  if (invite.org_id === me.org_id) {
+    return { error: "You are already a member of that organization" };
+  }
+
+  const { data: targetOrg } = await admin
+    .from("orgs")
+    .select("id, name")
+    .eq("id", invite.org_id as string)
+    .single();
+  if (!targetOrg) return { error: "Target organization not found" };
+
+  if (confirm.trim() !== (targetOrg.name as string)) {
+    return { error: "Type the organization name exactly to confirm" };
+  }
+
+  const { error: updateError } = await admin
+    .from("users")
+    .update({ org_id: invite.org_id, role: invite.role })
+    .eq("id", me.id as string);
+  if (updateError) return { error: "Failed to switch organization" };
+
+  // Audit row, same shape as a fresh join. Idempotent on (token, user) so a
+  // re-click after the switch is a no-op rather than a duplicate-key error.
+  await admin
+    .from("invite_redemptions")
+    .upsert(
+      { token_id: tokenId, user_id: me.id as string },
+      { onConflict: "token_id,user_id", ignoreDuplicates: true }
+    );
+
+  redirect("/dashboard");
+}
+
+/**
  * Manager-only: change another org member's role between `member` and
  * `manager`. Self-edits go through the same path so the server's safety
  * guards (in particular the last-manager check) apply uniformly.

--- a/src/app/invite/[token]/cross-org-switch.tsx
+++ b/src/app/invite/[token]/cross-org-switch.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { clsx } from "clsx";
+import { switchOrganization } from "@/app/actions/org";
+
+/**
+ * Cross-org switch panel for `/invite/[token]` (#72).
+ *
+ * Shown when an authenticated user clicks an invite for an org other than
+ * the one they currently belong to. Replaces the old dead-end "Multi-org is
+ * not supported yet" copy with an explicit, opt-in switch path.
+ *
+ * The action is destructive from the *leaving* org's perspective (the user's
+ * devices and history move with them and stop being visible to that org's
+ * manager), so we mirror the typed-confirmation pattern from
+ * `deleteOrganization` — the user has to type the target org's name. The
+ * server re-validates this; the client gate just keeps the button inert
+ * until the user has completed the deliberate act.
+ *
+ * Managers are blocked at the page level (not rendered here) because the
+ * action would otherwise orphan their current org. If a manager somehow
+ * reaches this UI, the server action refuses and we surface the error.
+ */
+export function CrossOrgSwitch({
+  token,
+  currentOrgName,
+  targetOrgId,
+  targetOrgName,
+}: {
+  token: string;
+  currentOrgName: string;
+  targetOrgId: string;
+  targetOrgName: string;
+}) {
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const canSubmit = confirm.trim() === targetOrgName && !pending;
+
+  function submit(formData: FormData) {
+    setError(null);
+    startTransition(async () => {
+      const result = await switchOrganization(undefined, formData);
+      if (result?.error) setError(result.error);
+    });
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
+      <div className="w-full max-w-md rounded-xl border border-white/10 bg-zinc-950 p-6 shadow-xl">
+        <h1 className="text-xl font-bold text-white">
+          Switch organizations?
+        </h1>
+        <div className="mt-4 space-y-3 text-sm text-zinc-300">
+          <p>
+            You&rsquo;re currently a member of{" "}
+            <strong className="text-zinc-100">{currentOrgName}</strong>.
+          </p>
+          <p>
+            This invite is for{" "}
+            <strong className="text-zinc-100">{targetOrgName}</strong>.
+          </p>
+          <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-amber-200">
+            If you switch, all of your devices, sessions, and cost history
+            will move with you to{" "}
+            <strong>{targetOrgName}</strong>.{" "}
+            <strong>{currentOrgName}</strong>&rsquo;s manager will no longer
+            see your usage.
+          </p>
+        </div>
+
+        {error && (
+          <p className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
+            {error}
+          </p>
+        )}
+
+        <form action={submit} className="mt-5 space-y-3">
+          <input type="hidden" name="token" value={token} />
+          <input type="hidden" name="targetOrgId" value={targetOrgId} />
+          <label className="block text-xs text-zinc-400">
+            Type{" "}
+            <span className="font-mono text-zinc-200">{targetOrgName}</span>{" "}
+            to confirm:
+          </label>
+          <input
+            type="text"
+            name="confirm"
+            autoFocus
+            autoComplete="off"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            disabled={pending}
+            className="w-full rounded-lg border border-white/10 bg-black/40 px-3 py-2 font-mono text-sm text-zinc-200 focus:border-blue-500/60 focus:outline-none"
+          />
+          <div className="flex justify-end gap-2 pt-2">
+            <a
+              href="/dashboard"
+              className={clsx(
+                "rounded-lg px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-white/5",
+                pending && "pointer-events-none opacity-50"
+              )}
+            >
+              Stay in {currentOrgName}
+            </a>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className={clsx(
+                "rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+                canSubmit
+                  ? "bg-blue-600 text-white hover:bg-blue-700"
+                  : "cursor-not-allowed bg-blue-600/40 text-blue-200/60"
+              )}
+            >
+              {pending ? "Switching…" : `Switch to ${targetOrgName}`}
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/invite/[token]/page.test.tsx
+++ b/src/app/invite/[token]/page.test.tsx
@@ -242,8 +242,12 @@ describe("invite/[token] page — multi-use redemption (#68)", () => {
     expect(fake.rows("invite_redemptions")).toHaveLength(1);
   });
 
-  it("blocks a user already in a different org with the cross-org guard", async () => {
+  it("renders the cross-org switch panel for a member already in another org (#72)", async () => {
     seedInvite();
+    fake.seed("orgs", [
+      { id: "org_acme", name: "Acme" },
+      { id: "org_other", name: "Other Inc" },
+    ]);
     fake.seed("users", [
       { id: "usr_alice", org_id: "org_other", role: "member" },
     ]);
@@ -253,13 +257,52 @@ describe("invite/[token] page — multi-use redemption (#68)", () => {
       email: "alice@example.com",
       user_metadata: {},
     };
+    const node = (await visit()) as { props: Record<string, unknown> };
+
+    // Surfaces the explicit switch path — does NOT redirect, does NOT show the
+    // old "Multi-org is not supported yet" dead-end copy. The page hands a
+    // CrossOrgSwitch client component the four props it needs to render the
+    // confirmation flow; pin them all so the page<->component contract can't
+    // drift silently.
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(node.props).toEqual({
+      token: "tok_xyz",
+      currentOrgName: "Other Inc",
+      targetOrgId: "org_acme",
+      targetOrgName: "Acme",
+    });
+    expect(JSON.stringify(node)).not.toContain("Multi-org is not supported");
+    // The flip-to-Acme write only lands when the user submits the form, so a
+    // pure render must not have moved them.
+    const alice = fake.rows("users").find((u) => u.id === "usr_alice");
+    expect(alice?.org_id).toBe("org_other");
+    expect(fake.rows("invite_redemptions")).toHaveLength(0);
+  });
+
+  it("refuses a manager from a different org without rendering the switch UI", async () => {
+    seedInvite();
+    fake.seed("orgs", [
+      { id: "org_acme", name: "Acme" },
+      { id: "org_other", name: "Other Inc" },
+    ]);
+    fake.seed("users", [
+      { id: "usr_alice", org_id: "org_other", role: "manager" },
+    ]);
+
+    authUser = {
+      id: "usr_alice",
+      email: "alice@example.com",
+      user_metadata: {},
+    };
     const node = await visit();
 
-    // Renders the "Already in an Organization" message — does NOT redirect.
     expect(redirectMock).not.toHaveBeenCalled();
     const html = JSON.stringify(node);
     expect(html).toContain("Already in an Organization");
-    // No redemption row is written for a cross-org bounce.
+    // The switch CTA must not be rendered for a manager — they'd orphan their
+    // current org. Copy nudges them toward delete/hand-off instead.
+    expect(html).not.toContain("Switch organizations?");
+    expect(html).toContain("Delete");
     expect(fake.rows("invite_redemptions")).toHaveLength(0);
   });
 

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { randomBytes } from "crypto";
+import { CrossOrgSwitch } from "./cross-org-switch";
 
 export const dynamic = "force-dynamic";
 
@@ -58,7 +59,7 @@ export default async function InvitePage({
   // Check if user already exists
   const { data: existingUser } = await admin
     .from("users")
-    .select("id, org_id")
+    .select("id, org_id, role")
     .eq("id", authUser.id)
     .single();
 
@@ -74,18 +75,49 @@ export default async function InvitePage({
         );
       redirect("/dashboard");
     }
+
+    // Cross-org click: surface an explicit switch path (#72). A manager
+    // switching out would orphan their current org, so they get a refusal
+    // instead of a switch button.
+    const [{ data: currentOrg }, { data: targetOrg }] = await Promise.all([
+      admin.from("orgs").select("id, name").eq("id", existingUser.org_id).single(),
+      admin.from("orgs").select("id, name").eq("id", invite.org_id).single(),
+    ]);
+
+    const currentOrgName = currentOrg?.name ?? existingUser.org_id;
+    const targetOrgName = targetOrg?.name ?? invite.org_id;
+
+    if (existingUser.role === "manager") {
+      return (
+        <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
+          <div className="w-full max-w-md rounded-xl border border-white/10 bg-zinc-950 p-6 text-center shadow-xl">
+            <h1 className="text-xl font-bold text-white">
+              Already in an Organization
+            </h1>
+            <p className="mt-3 text-sm text-zinc-300">
+              You manage <strong>{currentOrgName}</strong>, so you can&rsquo;t
+              switch into <strong>{targetOrgName}</strong> directly. Delete{" "}
+              <strong>{currentOrgName}</strong> first (or hand off ownership),
+              then re-click this invite.
+            </p>
+            <a
+              href="/dashboard"
+              className="mt-5 inline-block rounded-lg border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-zinc-200 hover:bg-white/10"
+            >
+              Back to dashboard
+            </a>
+          </div>
+        </main>
+      );
+    }
+
     return (
-      <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
-        <div className="text-center">
-          <h1 className="text-xl font-bold text-white">
-            Already in an Organization
-          </h1>
-          <p className="mt-2 text-zinc-400">
-            You are already a member of another organization. Multi-org is not
-            supported yet.
-          </p>
-        </div>
-      </main>
+      <CrossOrgSwitch
+        token={token}
+        currentOrgName={currentOrgName}
+        targetOrgId={invite.org_id}
+        targetOrgName={targetOrgName}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #72.

Replaces the dead-end "Already in an Organization" screen on `/invite/[token]` with an opt-in switch flow. A member who clicks an invite for an org other than their current one now sees both org names, a clear "data moves with you" warning, and a typed-confirmation gate before anything writes — same UX shape as `deleteOrganization`.

- **New server action `switchOrganization`** in `src/app/actions/org.ts`: re-validates the token (existence, expiry, `org_id` matches the form-supplied target), refuses managers (would orphan the source org), updates `users.org_id` + `role`, and inserts an audit row into `invite_redemptions`. No deletes — devices, daily rollups, and session summaries follow the user via the existing `user_id` FK chain, which is the "data moves with you" behavior the UI promises.
- **New `CrossOrgSwitch` client component** at `src/app/invite/[token]/cross-org-switch.tsx`: typed-confirmation gate, "Stay in {currentOrg}" escape hatch, and inline error surface for server-side refusals.
- **Manager refusal at the page level**: a manager hitting a cross-org invite gets the old refusal copy (now naming both orgs) plus a nudge to delete or hand off ownership first — the switch CTA isn't rendered for them at all.

## Test plan

- [x] `npm test` (100 passing, +9 new tests)
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx tsc --noEmit` — no new errors in touched files
- [ ] Manual: cross-org member → switch → land in target org with devices/rollups intact
- [ ] Manual: manager hits cross-org invite → sees refusal, no switch button
- [ ] Manual: typed confirmation gate (wrong/empty input keeps button disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)