### PR TITLE
fix(periods): align cloud 1d/7d/30d windows with local Budi rolling semantics (#75)

### DIFF
--- a/src/lib/date-range.test.ts
+++ b/src/lib/date-range.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { dateRangeFromDays } from "@/lib/date-range";
 
+/**
+ * Pins the rolling-window contract introduced in #75. Each `days=N` query
+ * spans `N + 1` day buckets (today minus N, through today inclusive) — the
+ * same semantic the local Budi CLI uses for `-p Nd`. Older callers that
+ * compared cloud and CLI numbers for the same window saw an off-by-one gap;
+ * these tests pin the alignment so the regression can't return silently.
+ */
 describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -12,27 +19,27 @@ describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
   });
 
   it("defaults to 7 days when no param is provided", () => {
-    // 7d inclusive of today: from = today - 6.
+    // 7d rolling: from = today - 7 (8 day buckets, including today).
     const r = dateRangeFromDays(undefined);
-    expect(r.from).toBe("2026-04-12");
+    expect(r.from).toBe("2026-04-11");
     expect(r.to).toBe("2026-04-18");
   });
 
-  it("1d is a single-day window (today so far)", () => {
+  it("1d covers yesterday + today (matches local `budi stats -p 1d`)", () => {
     const r = dateRangeFromDays("1");
-    expect(r.from).toBe("2026-04-18");
+    expect(r.from).toBe("2026-04-17");
     expect(r.to).toBe("2026-04-18");
   });
 
-  it("7d includes today and the previous 6 days", () => {
+  it("7d covers today and the previous 7 days", () => {
     const r = dateRangeFromDays("7");
-    expect(r.from).toBe("2026-04-12");
+    expect(r.from).toBe("2026-04-11");
     expect(r.to).toBe("2026-04-18");
   });
 
-  it("30d includes today and the previous 29 days", () => {
+  it("30d covers today and the previous 30 days", () => {
     const r = dateRangeFromDays("30");
-    expect(r.from).toBe("2026-03-20");
+    expect(r.from).toBe("2026-03-19");
     expect(r.to).toBe("2026-04-18");
   });
 
@@ -41,7 +48,7 @@ describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
     (bad) => {
       const r = dateRangeFromDays(bad);
       expect(r.to).toBe("2026-04-18");
-      expect(r.from).toBe("2026-04-12");
+      expect(r.from).toBe("2026-04-11");
     }
   );
 
@@ -49,7 +56,7 @@ describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
     // Developers occasionally need a bespoke window; preserving this was one
     // of the compatibility notes on the 90d→30d default change.
     const r = dateRangeFromDays("14");
-    expect(r.from).toBe("2026-04-05");
+    expect(r.from).toBe("2026-04-04");
     expect(r.to).toBe("2026-04-18");
   });
 
@@ -64,7 +71,7 @@ describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
     // org with no rollups yet should still render like the default 7d view
     // rather than crashing.
     const r = dateRangeFromDays("all");
-    expect(r.from).toBe("2026-04-12");
+    expect(r.from).toBe("2026-04-11");
     expect(r.to).toBe("2026-04-18");
   });
 });

--- a/src/lib/date-range.ts
+++ b/src/lib/date-range.ts
@@ -5,16 +5,28 @@ import { ALL_PERIOD_VALUE, DEFAULT_PERIOD_DAYS } from "@/lib/periods";
 /**
  * Build a `DateRange` from the `?days=` search param.
  *
- * Local Budi's developer-facing windows are `1d` / `7d` / `30d` (ADR-0088 §7).
- * To match the local semantics:
- *   - `days=1` means "today so far" — `from` and `to` are both today.
- *   - `days=7` means "the last 7 days including today" — from = today - 6.
- *   - `days=30` means "the last 30 days including today" — from = today - 29.
+ * Local Budi's developer-facing windows are `1d` / `7d` / `30d` (ADR-0088 §7)
+ * and the CLI implements them as a *rolling* window starting N days back at
+ * start-of-day-local and ending now. We mirror that here so cloud-vs-CLI
+ * reconciliation for the same user, same period, lines up to the cent
+ * (modulo the daemon's local sync queue):
+ *   - `days=1` → from = yesterday, to = today (yesterday + today).
+ *   - `days=7` → from = today - 7, to = today (8 day buckets).
+ *   - `days=30` → from = today - 30, to = today (31 day buckets).
  *   - `days=all` is the cloud-only lifetime preset; `from` is materialized
  *     from the per-org earliest-activity lookup supplied by the caller.
  *
+ * The captions ("Showing last N days") are copied verbatim from the local
+ * CLI's labels — they describe the rolling-window concept, not the calendar
+ * day count, which matches what users already read elsewhere in the budi
+ * ecosystem (statusline, `budi stats -p Nd`, Claude Code integration).
+ *
  * Default (no param) is `7d` to mirror the default developer window in the
  * CLI and statusline. Invalid or non-positive values fall back to the default.
+ *
+ * History: prior to #75 the cloud treated `days=1` as "today so far" (single
+ * calendar day) and `days=N` as `N` days inclusive. That diverged from local
+ * Budi and produced confusing apples-to-apples reconciliation gaps.
  */
 export function dateRangeFromDays(
   days: string | undefined,
@@ -30,7 +42,7 @@ export function dateRangeFromDays(
       return { from: earliestActivityDate, to: toStr };
     }
     return {
-      from: format(subDays(to, DEFAULT_PERIOD_DAYS - 1), "yyyy-MM-dd"),
+      from: format(subDays(to, DEFAULT_PERIOD_DAYS), "yyyy-MM-dd"),
       to: toStr,
     };
   }
@@ -41,7 +53,7 @@ export function dateRangeFromDays(
       ? Math.floor(parsed)
       : DEFAULT_PERIOD_DAYS;
   return {
-    from: format(subDays(to, n - 1), "yyyy-MM-dd"),
+    from: format(subDays(to, n), "yyyy-MM-dd"),
     to: toStr,
   };
 }


### PR DESCRIPTION
## Summary

Closes #75.

Cloud \`?days=N\` used to treat the period as N calendar days **inclusive** (\`from = today - (N-1)\`), so \`days=1\` collapsed to "today so far" and \`days=7\` covered 7 buckets. Local Budi's CLI uses a **rolling** window — \`-p 1d\` covers yesterday + today (window_start = yesterday 00:00 local), \`-p 7d\` covers 8 day buckets, etc.

That mismatch produced confusing reconciliation gaps between cloud and local for the same user, same window. Aligning cloud to local closes the gap and honors the developer-facing window contract from ADR-0088 §7.

## Change

\`src/lib/date-range.ts\` — \`from = today - N\` (was \`today - (N-1)\`). Same shift applies to the no-earliest-activity fallback for \`days=all\`.

Captions in \`src/lib/periods.ts\` ("Showing last N days") read correctly under the rolling interpretation, so no copy change is needed — same wording the local CLI ships.

## Test plan

- [x] \`npm test\` (100 passing — \`dateRangeFromDays\` test rewritten to pin the rolling contract)
- [x] \`npm run lint\`
- [x] \`npm run build\`
- [ ] Manual: cloud \`/team?days=1\` for a single user should reconcile to \`budi stats -p 1d -f json\` (modulo the local sync queue, tracked separately in #74)

🤖 Generated with [Claude Code](https://claude.com/claude-code)