### PR TITLE
fix(dashboard): scope sync-freshness badge to viewer's own devices (#74)

### DIFF
--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -190,7 +190,7 @@ describe("getSyncFreshness (linking / freshness snapshot)", () => {
     expect(snap.lastRollupAt).toBeNull();
   });
 
-  it("reports the most recent rollup synced_at across visible devices", async () => {
+  it("reports the most recent rollup synced_at across the viewer's own devices", async () => {
     fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);
     fake.seed("users", [{ ...baseUser }]);
     fake.seed("devices", [
@@ -219,6 +219,86 @@ describe("getSyncFreshness (linking / freshness snapshot)", () => {
     expect(snap.deviceCount).toBe(2);
     expect(snap.lastSeenAt).toBe("2026-04-18T11:00:00Z");
     expect(snap.lastRollupAt).toBe("2026-04-18T10:30:00Z");
+  });
+
+  it("(#74) badge ignores teammates' devices for a manager — own daemon stale, teammate daemon fresh", async () => {
+    // Regression for the bug surfaced 2026-04-27: a manager's header badge
+    // showed "Synced 3m ago" because a teammate's daemon had just pushed,
+    // masking the fact that the manager's own daemon hadn't synced in 2h.
+    // The freshness signal is read as self-trust ("is *my* daemon healthy");
+    // teammate state belongs on /dashboard/devices, not in the header.
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      { ...baseUser, org_id: "org_team" },
+      {
+        id: "usr_teammate",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_t",
+        display_name: "Teammate",
+        email: "teammate@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      {
+        id: "dev_my_mac",
+        user_id: "usr_ivan",
+        last_seen: "2026-04-18T10:00:00Z", // 2h ago
+      },
+      {
+        id: "dev_teammate_mac",
+        user_id: "usr_teammate",
+        last_seen: "2026-04-18T11:57:00Z", // 3m ago — would win an org-wide MAX
+      },
+    ]);
+    fake.seed("daily_rollups", [
+      rollup("dev_my_mac", "2026-04-18", 100, {
+        synced_at: "2026-04-18T10:00:00Z",
+      }),
+      rollup("dev_teammate_mac", "2026-04-18", 50, {
+        synced_at: "2026-04-18T11:57:00Z",
+      }),
+    ]);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness({ ...baseUser, org_id: "org_team" });
+
+    expect(snap.deviceCount).toBe(1); // own devices only — teammate's doesn't count
+    expect(snap.lastSeenAt).toBe("2026-04-18T10:00:00Z"); // mine, not teammate's
+    expect(snap.lastRollupAt).toBe("2026-04-18T10:00:00Z");
+  });
+
+  it("(#74) reports not-linked for a manager whose org has teammate devices but no own daemon", async () => {
+    // The LinkDaemonBanner gating keys off deviceCount===0; previously a
+    // manager who hadn't run `budi cloud init` themselves wouldn't see the
+    // prompt because teammates had linked, masking their own missing setup.
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      { ...baseUser, org_id: "org_team" },
+      {
+        id: "usr_teammate",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_t",
+        display_name: "Teammate",
+        email: "teammate@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      {
+        id: "dev_teammate_mac",
+        user_id: "usr_teammate",
+        last_seen: "2026-04-18T11:57:00Z",
+      },
+    ]);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness({ ...baseUser, org_id: "org_team" });
+    expect(snap).toEqual({
+      deviceCount: 0,
+      lastSeenAt: null,
+      lastRollupAt: null,
+    });
   });
 });
 

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -540,18 +540,25 @@ export async function getSessions(user: BudiUser, range: DateRange) {
  *
  * Used by the dashboard header to render a "Last synced X ago" indicator and
  * to distinguish *not linked yet* from *linked, waiting for first sync* from
- * *stalled*.
+ * *stalled*. Always scoped to the **viewer's own devices**, regardless of
+ * role — the badge answers "is *my* daemon healthy" and a manager whose own
+ * daemon has been silent for hours should see a stale badge even if a
+ * teammate's daemon synced 3 minutes ago (#74). The org-wide "who's stale?"
+ * view lives on `/dashboard/devices`, which is the right surface for a
+ * manager chasing down a teammate's broken daemon.
  *
- * - `deviceCount` is the number of daemons the viewer can see. Zero means the
- *   account exists on cloud but no local daemon has ever called `/v1/ingest`
- *   with this API key yet — the "not linked yet" state.
- * - `lastSeenAt` is the most recent `devices.last_seen` across the visible
- *   devices. It advances on every successful ingest, even when the payload
- *   contains zero rollups, so it's the authoritative "is the daemon talking
- *   to us" signal.
+ * - `deviceCount` is the number of daemons the viewer themselves has linked.
+ *   Zero means the viewer's account exists on cloud but they haven't run
+ *   `budi cloud init` yet — the "not linked yet" state. (The same field
+ *   drives the `LinkDaemonBanner` on the overview, so a manager who hasn't
+ *   linked their own daemon still gets the prompt even if teammates have.)
+ * - `lastSeenAt` is the most recent `devices.last_seen` across the viewer's
+ *   own devices. It advances on every successful ingest, even when the
+ *   payload contains zero rollups, so it's the authoritative "is *my*
+ *   daemon talking to us" signal.
  * - `lastRollupAt` is the most recent `daily_rollups.synced_at` across the
- *   visible devices. If `deviceCount > 0` but `lastRollupAt` is null, the
- *   daemon is linked but hasn't pushed any usage rows yet — that's the
+ *   viewer's own devices. If `deviceCount > 0` but `lastRollupAt` is null,
+ *   the viewer is linked but hasn't pushed any usage rows yet — that's the
  *   "initial sync in progress / no data yet" state.
  */
 export async function getSyncFreshness(user: BudiUser): Promise<{
@@ -560,7 +567,11 @@ export async function getSyncFreshness(user: BudiUser): Promise<{
   lastRollupAt: string | null;
 }> {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const { data: ownDevices } = await admin
+    .from("devices")
+    .select("id")
+    .eq("user_id", user.id);
+  const deviceIds = (ownDevices ?? []).map((d) => d.id as string);
   if (deviceIds.length === 0) {
     return { deviceCount: 0, lastSeenAt: null, lastRollupAt: null };
   }


### PR DESCRIPTION
## Summary

Closes #74.

The header "Synced Xm ago" badge ran an org-wide \`MAX(synced_at)\` for managers (via \`getVisibleDeviceIds\`), so a teammate's recent push masked the fact that the manager's own daemon was stale. Surfaced 2026-04-27 during a manual cloud-vs-CLI reconciliation — the badge said "Synced 3m ago" while the manager's own daemon hadn't pushed in 2h 22m, hiding ~\$30 of unsynced cost.

Same scoping also gated \`LinkDaemonBanner\` via \`deviceCount\`, so a manager who hadn't run \`budi cloud init\` themselves wouldn't see the prompt if a teammate had already linked.

## Change

\`getSyncFreshness\` in \`src/lib/dal.ts\` now always queries the caller's own devices (\`devices.user_id = user.id\`), regardless of role. Org-wide visibility into teammate freshness already lives on \`/dashboard/devices\`, which is the right surface for a manager chasing down a teammate's broken daemon — the header is for self-trust.

## Test plan

- [x] \`npm test\` (102 passing — 2 new regression tests)
- [x] \`npm run lint\`
- [x] \`npm run build\`
- [ ] Manual: as a manager in a 2-daemon org, force a teammate's daemon to push while my own is silent — header should reflect *my* staleness, not the teammate's freshness.
- [ ] Manual: as a manager who hasn't run \`budi cloud init\` but whose teammates have, \`/dashboard\` should still show \`LinkDaemonBanner\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)