### PR TITLE
fix(periods): scope ?days=N to viewer's local TZ, not server-UTC (#78)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -335,7 +335,14 @@ describe("POST /v1/ingest + dashboard read path (#14)", () => {
       display_name: "Test User",
       email: "test@example.com",
     };
-    const range = { from: "2026-04-01", to: "2026-04-16" };
+    const range = {
+      from: "2026-04-01",
+      to: "2026-04-16",
+      bucketFrom: "2026-04-01",
+      bucketTo: "2026-04-16",
+      startedAtFrom: "2026-04-01T00:00:00.000Z",
+      startedAtTo: "2026-04-16T23:59:59.999Z",
+    };
 
     const overview = await getOverviewStats(user, range);
     expect(overview.totalCostCents).toBe(1234);
@@ -500,9 +507,10 @@ describe("POST /v1/ingest — device label persistence (#60)", () => {
     const { POST } = await import("./route");
 
     await POST(
-      mkReq({ ...baseEnvelope, label: "  new-name  " }) as unknown as Parameters<
-        typeof POST
-      >[0]
+      mkReq({
+        ...baseEnvelope,
+        label: "  new-name  ",
+      }) as unknown as Parameters<typeof POST>[0]
     );
 
     const [device] = fake.rows("devices");

--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -5,6 +5,7 @@ import {
   getEarliestActivity,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { deviceLabel, fmtCost, fmtRelative } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
@@ -22,7 +23,8 @@ export default async function DevicesPage({
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
-  const range = dateRangeFromDays(params.days, earliestActivity);
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
   const devices = await getCostByDevice(user, range);
 
   const showOwnerColumn = user.role === "manager";
@@ -45,9 +47,10 @@ export default async function DevicesPage({
             data={devices
               .filter((d) => d.cost_cents > 0)
               .map((d) => ({
-                label: showOwnerColumn && d.owner_name
-                  ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
-                  : deviceLabel(d.id, d.label),
+                label:
+                  showOwnerColumn && d.owner_name
+                    ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
+                    : deviceLabel(d.id, d.label),
                 cost_cents: d.cost_cents,
               }))}
             emptyLabel="No device cost data for this period"

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,7 +2,9 @@ import { redirect } from "next/navigation";
 import { MobileSidebar, Sidebar } from "@/components/sidebar";
 import { UserMenu } from "@/components/user-menu";
 import { SyncFreshness } from "@/components/sync-freshness";
+import { TimeZoneSync } from "@/components/timezone-sync";
 import { getCurrentUser, getSyncFreshness } from "@/lib/dal";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 
 export const dynamic = "force-dynamic";
 
@@ -20,9 +22,11 @@ export default async function DashboardLayout({
   // dashboard (especially via the local statusline link) therefore always
   // reflects the *current* ingest watermark rather than stale SSR.
   const freshness = await getSyncFreshness(user);
+  const cookieTz = await getViewerTimeZone();
 
   return (
     <div className="flex h-screen bg-[#0a0a0a] text-white">
+      <TimeZoneSync currentCookieTz={cookieTz} />
       <Sidebar role={user.role} />
       <div className="flex flex-1 flex-col overflow-hidden">
         <header className="flex h-14 items-center gap-2 border-b border-white/10 px-3 sm:gap-3 sm:px-4 md:justify-end md:px-6">

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { getCurrentUser, getCostByModel, getEarliestActivity } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { formatModelName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
@@ -18,7 +19,8 @@ export default async function ModelsPage({
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
-  const range = dateRangeFromDays(params.days, earliestActivity);
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
   const models = await getCostByModel(user, range);
 
   return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import {
   getSyncFreshness,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { fmtCost, fmtNum } from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
@@ -29,7 +30,8 @@ export default async function OverviewPage({
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
-  const range = dateRangeFromDays(params.days, earliestActivity);
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
   const [stats, activity, freshness] = await Promise.all([
     getOverviewStats(user, range),
     getDailyActivity(user, range),

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -7,6 +7,7 @@ import {
   getEarliestActivity,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
@@ -24,7 +25,8 @@ export default async function ReposPage({
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
-  const range = dateRangeFromDays(params.days, earliestActivity);
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
   const [repos, branches, tickets] = await Promise.all([
     getCostByRepo(user, range),
     getCostByBranch(user, range),

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { getCurrentUser, getEarliestActivity, getSessions } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
@@ -36,7 +37,8 @@ export default async function SessionsPage({
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
-  const range = dateRangeFromDays(params.days, earliestActivity);
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
   const sessions = await getSessions(user, range);
 
   return (

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { getCurrentUser, getCostByUser, getEarliestActivity } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { fmtCost } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
@@ -23,7 +24,8 @@ export default async function TeamPage({
 
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
-  const range = dateRangeFromDays(params.days, earliestActivity);
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
   const userCosts = await getCostByUser(user, range);
 
   return (
@@ -77,10 +79,7 @@ export default async function TeamPage({
             </table>
             <ul className="divide-y divide-white/5 text-sm sm:hidden">
               {userCosts.map((u, i) => (
-                <li
-                  key={i}
-                  className="flex items-center justify-between py-2"
-                >
+                <li key={i} className="flex items-center justify-between py-2">
                   <span className="text-zinc-200">{u.name}</span>
                   <span className="tabular-nums text-zinc-300">
                     {fmtCost(u.cost_cents)}

--- a/src/components/timezone-sync.tsx
+++ b/src/components/timezone-sync.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const COOKIE_NAME = "budi_tz";
+// One year — matches typical browser-detected-locale persistence. The cookie
+// only carries the IANA TZ string; rotating it costs nothing if the user
+// flies somewhere else, since the next render after the move overwrites it.
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Persists the viewer's IANA timezone (`Intl.DateTimeFormat...timeZone`)
+ * into a cookie so server components can scope `?days=N` ranges to the
+ * viewer's local "today" rather than server-UTC. See siropkin/budi-cloud#78
+ * for the original gap (a US/Pacific user lost yesterday-evening activity
+ * because the daemon's `bucket_day` is UTC and the cloud filtered against
+ * server-UTC `now()`).
+ *
+ * Mounted once in the dashboard layout. The first paint of a fresh session
+ * still uses the UTC fallback, but a subsequent navigation/refresh picks up
+ * the cookie. We `router.refresh()` after writing so the freshly-loaded page
+ * re-fetches its server data with the correct TZ instead of waiting for the
+ * user's next click.
+ */
+export function TimeZoneSync({
+  currentCookieTz,
+}: {
+  currentCookieTz: string | null;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (!detected || detected === currentCookieTz) return;
+
+    document.cookie = [
+      `${COOKIE_NAME}=${encodeURIComponent(detected)}`,
+      "Path=/",
+      `Max-Age=${COOKIE_MAX_AGE_SECONDS}`,
+      "SameSite=Lax",
+    ].join("; ");
+
+    // Re-render server components with the now-known TZ so the user doesn't
+    // have to click a period button to see their data correctly scoped.
+    router.refresh();
+  }, [currentCookieTz, router]);
+
+  return null;
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -11,6 +11,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 type Row = Record<string, unknown>;
 
+/**
+ * Tests in this file pre-date the TZ-aware `DateRange` (#78). They construct
+ * ranges in UTC for clarity, so we synthesize the SQL-side fields from the
+ * local-TZ `from`/`to` rather than threading a real `Intl` timezone through
+ * each fixture.
+ */
+function utcRange(from: string, to: string) {
+  return {
+    from,
+    to,
+    bucketFrom: from,
+    bucketTo: to,
+    startedAtFrom: `${from}T00:00:00.000Z`,
+    startedAtTo: `${to}T23:59:59.999Z`,
+  };
+}
+
 class FakeSupabase {
   tables = new Map<string, Row[]>();
 
@@ -344,7 +361,7 @@ describe("Overview ↔ Team reconciliation (#15)", () => {
       display_name: "Ivan",
       email: "ivan@example.com",
     };
-    const range = { from: "2026-04-01", to: "2026-04-30" };
+    const range = utcRange("2026-04-01", "2026-04-30");
 
     const overview = await getOverviewStats(user, range);
     const byUser = await getCostByUser(user, range);
@@ -398,7 +415,7 @@ describe("Overview ↔ Team reconciliation (#15)", () => {
       display_name: "Ivan",
       email: "ivan@example.com",
     };
-    const range = { from: "2026-04-01", to: "2026-04-30" };
+    const range = utcRange("2026-04-01", "2026-04-30");
 
     const overview = await getOverviewStats(manager, range);
     const byUser = await getCostByUser(manager, range);
@@ -489,7 +506,7 @@ describe("getCostByDevice", () => {
       display_name: "Ivan",
       email: "ivan@example.com",
     };
-    const range = { from: "2026-04-01", to: "2026-04-30" };
+    const range = utcRange("2026-04-01", "2026-04-30");
 
     const byDevice = await getCostByDevice(manager, range);
     const overview = await getOverviewStats(manager, range);
@@ -554,10 +571,10 @@ describe("getCostByDevice", () => {
       display_name: "Jane",
       email: "jane@example.com",
     };
-    const byDevice = await getCostByDevice(jane, {
-      from: "2026-04-01",
-      to: "2026-04-30",
-    });
+    const byDevice = await getCostByDevice(
+      jane,
+      utcRange("2026-04-01", "2026-04-30")
+    );
 
     expect(byDevice).toEqual([
       {

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -3,8 +3,30 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 export interface DateRange {
-  from: string; // YYYY-MM-DD
-  to: string; // YYYY-MM-DD
+  /** Inclusive lower bound in the **viewer's local TZ** (`YYYY-MM-DD`). */
+  from: string;
+  /** Inclusive upper bound in the **viewer's local TZ** (`YYYY-MM-DD`). */
+  to: string;
+  /**
+   * UTC `bucket_day` lower bound for the daemon's UTC-bucketed
+   * `daily_rollups` table. Derived from `from 00:00:00` in the viewer's TZ
+   * so the SQL filter captures every UTC bucket overlapping the local-TZ
+   * window — including the previous UTC day for users west of UTC, where
+   * yesterday-evening-local activity lands in "today's" UTC bucket. See
+   * siropkin/budi-cloud#78.
+   */
+  bucketFrom: string;
+  /** UTC `bucket_day` upper bound; mirror of `bucketFrom`. */
+  bucketTo: string;
+  /**
+   * Inclusive lower bound for `session_summaries.started_at`, an ISO-8601
+   * UTC instant (e.g. `2026-04-26T07:00:00.000Z`). Sessions are precise
+   * timestamps so we filter on the actual instant rather than a calendar
+   * day, avoiding the same TZ-vs-UTC drift that motivates `bucketFrom`.
+   */
+  startedAtFrom: string;
+  /** Inclusive upper bound for `session_summaries.started_at`. */
+  startedAtTo: string;
 }
 
 interface BudiUser {
@@ -62,8 +84,8 @@ export async function getOverviewStats(user: BudiUser, range: DateRange) {
       "cost_cents, input_tokens, output_tokens, message_count, cache_creation_tokens, cache_read_tokens"
     )
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to)
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo)
     // Defeat the default PostgREST max-rows cap so Overview and Team sum the
     // same complete row set (#15).
     .limit(100_000);
@@ -72,8 +94,8 @@ export async function getOverviewStats(user: BudiUser, range: DateRange) {
     .from("session_summaries")
     .select("*", { count: "exact", head: true })
     .in("device_id", deviceIds)
-    .gte("started_at", range.from)
-    .lte("started_at", range.to + "T23:59:59Z");
+    .gte("started_at", range.startedAtFrom)
+    .lte("started_at", range.startedAtTo);
 
   const totals = (rollups ?? []).reduce(
     (acc, r) => ({
@@ -108,8 +130,8 @@ export async function getDailyActivity(user: BudiUser, range: DateRange) {
       "bucket_day, input_tokens, output_tokens, cost_cents, message_count"
     )
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to)
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo)
     .order("bucket_day");
 
   // Aggregate by day
@@ -195,8 +217,8 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
     .from("daily_rollups")
     .select("device_id, cost_cents")
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to)
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo)
     // Defeat the default PostgREST max-rows cap so we sum every row instead
     // of a silently-truncated subset.
     .limit(100_000);
@@ -308,8 +330,8 @@ export async function getCostByDevice(
     .from("daily_rollups")
     .select("device_id, cost_cents")
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to)
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo)
     // Match the cap used elsewhere so we never silently truncate the sum.
     .limit(100_000);
 
@@ -367,7 +389,9 @@ export async function getCostByDevice(
       id,
       label: meta.label,
       owner_name:
-        user.role === "manager" ? (ownerLookup.get(meta.user_id) ?? null) : null,
+        user.role === "manager"
+          ? (ownerLookup.get(meta.user_id) ?? null)
+          : null,
       last_seen: meta.last_seen,
       cost_cents: costByDevice.get(id) ?? 0,
     });
@@ -389,8 +413,8 @@ export async function getCostByModel(user: BudiUser, range: DateRange) {
     .from("daily_rollups")
     .select("provider, model, cost_cents")
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to);
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo);
 
   const byModel = new Map<
     string,
@@ -428,8 +452,8 @@ export async function getCostByRepo(user: BudiUser, range: DateRange) {
     .from("daily_rollups")
     .select("repo_id, cost_cents")
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to);
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo);
 
   const byRepo = new Map<string, number>();
   for (const r of rollups ?? []) {
@@ -455,8 +479,8 @@ export async function getCostByBranch(user: BudiUser, range: DateRange) {
     .from("daily_rollups")
     .select("repo_id, git_branch, cost_cents")
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to);
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo);
 
   const byBranch = new Map<
     string,
@@ -494,8 +518,8 @@ export async function getCostByTicket(user: BudiUser, range: DateRange) {
     .from("daily_rollups")
     .select("ticket, cost_cents")
     .in("device_id", deviceIds)
-    .gte("bucket_day", range.from)
-    .lte("bucket_day", range.to)
+    .gte("bucket_day", range.bucketFrom)
+    .lte("bucket_day", range.bucketTo)
     .not("ticket", "is", null);
 
   const byTicket = new Map<string, number>();
@@ -527,8 +551,8 @@ export async function getSessions(user: BudiUser, range: DateRange) {
     .from("session_summaries")
     .select("*")
     .in("device_id", deviceIds)
-    .gte("started_at", range.from)
-    .lte("started_at", range.to + "T23:59:59Z")
+    .gte("started_at", range.startedAtFrom)
+    .lte("started_at", range.startedAtTo)
     .order("started_at", { ascending: false })
     .limit(100);
 

--- a/src/lib/date-range.test.ts
+++ b/src/lib/date-range.test.ts
@@ -7,6 +7,11 @@ import { dateRangeFromDays } from "@/lib/date-range";
  * same semantic the local Budi CLI uses for `-p Nd`. Older callers that
  * compared cloud and CLI numbers for the same window saw an off-by-one gap;
  * these tests pin the alignment so the regression can't return silently.
+ *
+ * The `from`/`to` fields here are scoped to the **viewer's local TZ** as of
+ * #78. The default-UTC tests below mirror the pre-#78 behavior so the
+ * server-UTC fallback (no cookie set yet on first paint) doesn't regress.
+ * The PDT/AEST tests below are #78's actual contract.
  */
 describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
   beforeEach(() => {
@@ -73,5 +78,90 @@ describe("dateRangeFromDays (1d/7d/30d window contract)", () => {
     const r = dateRangeFromDays("all");
     expect(r.from).toBe("2026-04-11");
     expect(r.to).toBe("2026-04-18");
+  });
+
+  it("default UTC: bucket and started_at bounds collapse to the local-TZ range", () => {
+    // For a UTC viewer, the daemon's `bucket_day` already matches the
+    // viewer's local-TZ day so there is no UTC vs local drift to widen for.
+    const r = dateRangeFromDays("1");
+    expect(r.bucketFrom).toBe("2026-04-17");
+    expect(r.bucketTo).toBe("2026-04-18");
+    expect(r.startedAtFrom).toBe("2026-04-17T00:00:00.000Z");
+    expect(r.startedAtTo).toBe("2026-04-18T23:59:59.999Z");
+  });
+});
+
+describe("dateRangeFromDays (TZ-aware bucket bounds, #78)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("PDT user at 17:30 local (00:30 UTC next day): days=1 includes the UTC bucket their evening lands in", () => {
+    // Reproduces the bug from #78: the user works at 17:30 PDT (= 00:30 UTC
+    // the next day). The daemon writes `bucket_day` in UTC, so the user's
+    // recent evening activity lives in "tomorrow's" UTC bucket. Without
+    // TZ-awareness the cloud's `days=1` filter ran `BETWEEN today-UTC-1 AND
+    // today-UTC` and silently dropped that evening of work.
+    vi.setSystemTime(new Date("2026-04-28T00:30:00Z"));
+    const r = dateRangeFromDays("1", null, "America/Los_Angeles");
+
+    // User-facing range is PDT-local: yesterday-PDT + today-PDT.
+    expect(r.from).toBe("2026-04-26");
+    expect(r.to).toBe("2026-04-27");
+
+    // bucket_day SQL filter must cover Apr 26 / Apr 27 / Apr 28 UTC — Apr 28
+    // is the bucket that contains the user's PDT evening. Pre-#78 it stopped
+    // at Apr 27 and that evening was excluded.
+    expect(r.bucketFrom).toBe("2026-04-26");
+    expect(r.bucketTo).toBe("2026-04-28");
+
+    // started_at uses precise UTC instants — Apr 26 PDT 00:00 = Apr 26 07:00
+    // UTC; Apr 27 PDT 23:59:59.999 = Apr 28 06:59:59.999 UTC.
+    expect(r.startedAtFrom).toBe("2026-04-26T07:00:00.000Z");
+    expect(r.startedAtTo).toBe("2026-04-28T06:59:59.999Z");
+  });
+
+  it("PDT user at 09:00 local (16:00 UTC same day): days=7 still rolls 7 calendar days back in PDT", () => {
+    vi.setSystemTime(new Date("2026-04-27T16:00:00Z"));
+    const r = dateRangeFromDays("7", null, "America/Los_Angeles");
+    expect(r.from).toBe("2026-04-20");
+    expect(r.to).toBe("2026-04-27");
+  });
+
+  it("AEST user east of UTC: bucket_day widens on the *earlier* edge instead", () => {
+    // AEST is UTC+10. At 03:30 AEST (Apr 28) the UTC clock reads Apr 27
+    // 17:30. days=1 → from=Apr 27 AEST, to=Apr 28 AEST. The user's earliest
+    // wanted moment (Apr 27 AEST 00:00) is Apr 26 14:00 UTC, so we must
+    // include the Apr 26 UTC bucket — symmetric mirror of the PDT case.
+    vi.setSystemTime(new Date("2026-04-27T17:30:00Z"));
+    const r = dateRangeFromDays("1", null, "Australia/Sydney");
+    expect(r.from).toBe("2026-04-27");
+    expect(r.to).toBe("2026-04-28");
+    expect(r.bucketFrom).toBe("2026-04-26");
+    expect(r.bucketTo).toBe("2026-04-28");
+  });
+
+  it("invalid TZ string falls back to UTC instead of throwing", () => {
+    // Defends the cookie path — an attacker (or a stale browser) could send
+    // any string. The fallback should be the pre-#78 server-UTC behavior.
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+    const r = dateRangeFromDays("1", null, "Not/A_Real_Zone");
+    expect(r.from).toBe("2026-04-17");
+    expect(r.to).toBe("2026-04-18");
+  });
+
+  it("'all' preserves earliest-activity lower bound in viewer's TZ", () => {
+    vi.setSystemTime(new Date("2026-04-28T00:30:00Z"));
+    const r = dateRangeFromDays("all", "2026-01-15", "America/Los_Angeles");
+    expect(r.from).toBe("2026-01-15");
+    expect(r.to).toBe("2026-04-27");
+    // Bucket lower bound is the earliest UTC activity day — by construction
+    // the daemon already wrote it in UTC, so the literal date is correct.
+    expect(r.bucketFrom).toBe("2026-01-15");
+    expect(r.bucketTo).toBe("2026-04-28");
   });
 });

--- a/src/lib/date-range.ts
+++ b/src/lib/date-range.ts
@@ -1,6 +1,13 @@
 import { type DateRange } from "@/lib/dal";
-import { format, subDays } from "date-fns";
 import { ALL_PERIOD_VALUE, DEFAULT_PERIOD_DAYS } from "@/lib/periods";
+import {
+  isValidTimeZone,
+  localDateInTimeZone,
+  utcBucketDayForLocalEnd,
+  utcBucketDayForLocalStart,
+  utcInstantForLocalEnd,
+  utcInstantForLocalStart,
+} from "@/lib/timezone";
 
 /**
  * Build a `DateRange` from the `?days=` search param.
@@ -24,36 +31,72 @@ import { ALL_PERIOD_VALUE, DEFAULT_PERIOD_DAYS } from "@/lib/periods";
  * Default (no param) is `7d` to mirror the default developer window in the
  * CLI and statusline. Invalid or non-positive values fall back to the default.
  *
- * History: prior to #75 the cloud treated `days=1` as "today so far" (single
- * calendar day) and `days=N` as `N` days inclusive. That diverged from local
- * Budi and produced confusing apples-to-apples reconciliation gaps.
+ * History:
+ * - Prior to #75 the cloud treated `days=1` as "today so far" (single
+ *   calendar day) and `days=N` as `N` days inclusive. That diverged from
+ *   local Budi and produced confusing apples-to-apples reconciliation gaps.
+ * - Prior to #78 "today" was always the **server's UTC date**. Vercel runs
+ *   in UTC, so a US/Pacific user working at 17:30 PDT (= 00:30 UTC the next
+ *   day) saw `days=1` filter `bucket_day BETWEEN today-UTC-1 AND today-UTC`
+ *   — and silently dropped 5–7 hours of yesterday-PDT-evening activity that
+ *   the daemon had written into "today's" UTC bucket. The fix below derives
+ *   `from`/`to` in the viewer's IANA timezone and supplies a UTC bucket
+ *   range that captures every UTC bucket overlapping the local-TZ window.
  */
 export function dateRangeFromDays(
   days: string | undefined,
-  earliestActivityDate?: string | null
+  earliestActivityDate?: string | null,
+  timeZone?: string | null
 ): DateRange {
-  const to = new Date();
-  const toStr = format(to, "yyyy-MM-dd");
+  const tz = timeZone && isValidTimeZone(timeZone) ? timeZone : "UTC";
+  const now = new Date();
+  const localTo = localDateInTimeZone(now, tz);
 
+  const from = computeLocalFrom(days, localTo, earliestActivityDate);
+  return makeRange(from, localTo, tz);
+}
+
+/**
+ * Resolve the lower bound of the local-TZ range from `days` and the optional
+ * earliest-activity date. Kept separate so the rolling-window math reads
+ * cleanly without the timezone plumbing on top.
+ */
+function computeLocalFrom(
+  days: string | undefined,
+  localTo: string,
+  earliestActivityDate: string | null | undefined
+): string {
   if (days === ALL_PERIOD_VALUE) {
-    // Without a known earliest activity date (empty org, or the caller
-    // didn't fetch it) fall back to the default window rather than throwing.
-    if (earliestActivityDate) {
-      return { from: earliestActivityDate, to: toStr };
-    }
-    return {
-      from: format(subDays(to, DEFAULT_PERIOD_DAYS), "yyyy-MM-dd"),
-      to: toStr,
-    };
+    if (earliestActivityDate) return earliestActivityDate;
+    return subDaysIso(localTo, DEFAULT_PERIOD_DAYS);
   }
-
   const parsed = days === undefined ? NaN : Number(days);
   const n =
     Number.isFinite(parsed) && parsed >= 1
       ? Math.floor(parsed)
       : DEFAULT_PERIOD_DAYS;
+  return subDaysIso(localTo, n);
+}
+
+/**
+ * Subtract `n` whole calendar days from a `YYYY-MM-DD` string. Implemented
+ * against UTC to avoid pulling DST into a pure date-string operation —
+ * `dateRangeFromDays` has already converted to local-TZ-aware values, so
+ * arithmetic on the calendar-day strings themselves is timezone-neutral.
+ */
+function subDaysIso(date: string, n: number): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function makeRange(from: string, to: string, tz: string): DateRange {
   return {
-    from: format(subDays(to, n), "yyyy-MM-dd"),
-    to: toStr,
+    from,
+    to,
+    bucketFrom: utcBucketDayForLocalStart(from, tz),
+    bucketTo: utcBucketDayForLocalEnd(to, tz),
+    startedAtFrom: utcInstantForLocalStart(from, tz),
+    startedAtTo: utcInstantForLocalEnd(to, tz),
   };
 }

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,161 @@
+/**
+ * Timezone helpers for translating between the dashboard viewer's local-TZ
+ * "day" and the daemon's UTC-bucketed `daily_rollups.bucket_day`.
+ *
+ * Why this module exists: the daemon writes `bucket_day` in **UTC** while a
+ * user thinks in their wall-clock day. For anyone west of UTC working in the
+ * evening, the cloud's old `format(new Date(), "yyyy-MM-dd")` (server-UTC)
+ * filter dropped 5–7 hours of *yesterday-local* activity into "tomorrow's UTC
+ * bucket" and silently excluded it from `?days=1`. See siropkin/budi-cloud#78.
+ *
+ * The fix is to derive the bucket-side bounds from the local-TZ range:
+ *
+ *   - `localFrom 00:00:00` in the user's TZ → its UTC instant → its UTC date.
+ *   - `localTo   23:59:59` in the user's TZ → its UTC instant → its UTC date.
+ *
+ * Including those bounding UTC dates (inclusive) covers every UTC bucket that
+ * could possibly contain a message dated to the user's local-TZ window.
+ *
+ * The bound is loose by up to one UTC day on the *earlier* edge (the daytime
+ * portion of the UTC bucket whose evening overlaps `localFrom`). That extra
+ * day is acceptable: it's bounded, deterministic, and a small over-count is
+ * preferred to silently dropping the user's most recent evening of work.
+ *
+ * The earlier-edge widening cleanly disappears once the daemon also writes
+ * `bucket_day` in local time (option 3 in the issue), at which point this
+ * helper still produces the correct bound.
+ */
+
+/**
+ * Whether `tz` is a real IANA timezone identifier accepted by the JS runtime.
+ * Used to defensively accept an attacker-supplied cookie without throwing.
+ */
+export function isValidTimeZone(tz: string): boolean {
+  if (!tz || typeof tz !== "string") return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return the local-TZ calendar date (`YYYY-MM-DD`) of `instant` in `timeZone`.
+ * Uses Swedish locale because it formats dates as ISO 8601 natively, sparing
+ * us a manual reorder of US-locale month/day/year parts.
+ */
+export function localDateInTimeZone(instant: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("sv-SE", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(instant);
+}
+
+/**
+ * Return the UTC `Date` instant for the given wall-clock time interpreted in
+ * `timeZone`. Handles DST correctly by deriving the offset *at that wall
+ * clock*, not at "now".
+ *
+ * Strategy: pretend the wall clock IS UTC, ask the runtime what wall clock
+ * that pretend-UTC instant produces in the target zone, and use the
+ * difference as the offset. The actual UTC instant is the pretend-UTC minus
+ * that offset.
+ */
+function wallClockInZoneToUtc(
+  date: string,
+  time: string,
+  timeZone: string
+): Date {
+  const pretendUtc = new Date(`${date}T${time}Z`);
+  // The TZ offset is identical regardless of the fractional-second component,
+  // so we compute the offset against a second-aligned instant. This preserves
+  // the original milliseconds end-to-end (e.g. `23:59:59.999` doesn't get
+  // floored to `.998` by the seconds-only `Intl.DateTimeFormat`).
+  const secAligned = new Date(Math.floor(pretendUtc.getTime() / 1000) * 1000);
+
+  const parts = new Intl.DateTimeFormat("sv-SE", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(secAligned);
+
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  // `sv-SE` formats midnight as `00`, but `Intl` uses `24` for midnight in
+  // some implementations; normalize.
+  const hour = get("hour") === "24" ? "00" : get("hour");
+  const observedAsUtc = new Date(
+    `${get("year")}-${get("month")}-${get("day")}T${hour}:${get("minute")}:${get("second")}Z`
+  );
+
+  const offsetMs = observedAsUtc.getTime() - secAligned.getTime();
+  return new Date(pretendUtc.getTime() - offsetMs);
+}
+
+/**
+ * UTC date (`YYYY-MM-DD`) of `localDate 00:00:00` interpreted in `timeZone`.
+ * For a US/Pacific user this is the calendar date the daemon wrote into
+ * `bucket_day` for any message timestamped at the start of that local day.
+ */
+export function utcBucketDayForLocalStart(
+  localDate: string,
+  timeZone: string
+): string {
+  return wallClockInZoneToUtc(localDate, "00:00:00", timeZone)
+    .toISOString()
+    .slice(0, 10);
+}
+
+/**
+ * UTC date (`YYYY-MM-DD`) of `localDate 23:59:59.999` interpreted in
+ * `timeZone`. For users east of UTC the result is the same calendar day; for
+ * users west of UTC it is typically the next UTC day, capturing the evening
+ * activity the daemon writes into "tomorrow's" UTC bucket.
+ */
+export function utcBucketDayForLocalEnd(
+  localDate: string,
+  timeZone: string
+): string {
+  return wallClockInZoneToUtc(localDate, "23:59:59.999", timeZone)
+    .toISOString()
+    .slice(0, 10);
+}
+
+/**
+ * UTC ISO instant of `localDate 00:00:00.000` in `timeZone`. Used as the
+ * lower bound for `session_summaries.started_at`, which is a precise
+ * timestamp (not a daily bucket) so we want the actual instant rather than
+ * a calendar-day approximation.
+ */
+export function utcInstantForLocalStart(
+  localDate: string,
+  timeZone: string
+): string {
+  return wallClockInZoneToUtc(
+    localDate,
+    "00:00:00.000",
+    timeZone
+  ).toISOString();
+}
+
+/**
+ * UTC ISO instant of `localDate 23:59:59.999` in `timeZone`. Inclusive upper
+ * bound for `session_summaries.started_at`.
+ */
+export function utcInstantForLocalEnd(
+  localDate: string,
+  timeZone: string
+): string {
+  return wallClockInZoneToUtc(
+    localDate,
+    "23:59:59.999",
+    timeZone
+  ).toISOString();
+}

--- a/src/lib/viewer-timezone.ts
+++ b/src/lib/viewer-timezone.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { isValidTimeZone } from "@/lib/timezone";
+
+/**
+ * Cookie name used by the dashboard to remember the viewer's IANA timezone.
+ * The browser writes it on first dashboard render via `<TimeZoneSync />`;
+ * the server reads it here when constructing date ranges. See #78 — the
+ * cloud needs this to translate the daemon's UTC `bucket_day` into the
+ * user's local "today" without dropping evening-local activity.
+ */
+export const TIMEZONE_COOKIE = "budi_tz";
+
+/**
+ * Resolve the viewer's IANA timezone from the cookie set by the browser, or
+ * `null` if the cookie is missing/invalid. Callers fall back to UTC, which
+ * preserves the pre-#78 behavior on the very first render of a fresh session
+ * (before the client has had a chance to write the cookie).
+ */
+export async function getViewerTimeZone(): Promise<string | null> {
+  const store = await cookies();
+  const tz = store.get(TIMEZONE_COOKIE)?.value;
+  if (!tz) return null;
+  return isValidTimeZone(tz) ? tz : null;
+}


### PR DESCRIPTION
## Summary

Fixes #78. The daemon writes `daily_rollups.bucket_day` in **UTC**, but the cloud was filtering against `format(new Date(), "yyyy-MM-dd")` on Vercel — i.e. server-UTC. For anyone west of UTC working in the evening, `?days=1` silently dropped 5–7 hours of yesterday-evening-local activity that the daemon had written into "today's" UTC bucket. Reconciliation against `budi stats -p 1d` could be off by ~2× as a result.

- Detect the viewer's IANA timezone in the browser, persist as `budi_tz` cookie, read it server-side when constructing date ranges.
- `DateRange` now carries:
  - `from`/`to` — local-TZ calendar dates (display + URL semantics)
  - `bucketFrom`/`bucketTo` — UTC `bucket_day` SQL bounds derived from `from 00:00:00`/`to 23:59:59.999` interpreted in the viewer's TZ, so the UTC bucket containing the user's evening-local activity is included
  - `startedAtFrom`/`startedAtTo` — precise UTC instants for `session_summaries.started_at`
- All DAL queries are switched to the new fields.
- First paint of a fresh session still uses UTC (no cookie yet); the client component sets the cookie and triggers `router.refresh()` so the second render is correctly TZ-scoped without the user having to click a period button.

The earlier-edge UTC bucket has a bounded over-count (`24h − |TZ offset|` of activity from "two days ago" local). That disappears once the daemon also writes `bucket_day` in local time (option 3 in the issue, daemon-side change tracked separately). For now, a bounded over-count is preferred to silently dropping the user's most recent evening of work — matches the acceptance criteria in #78.

## Test plan

- [x] `npm test` (108 passing, including new TZ-aware tests for PDT, AEST, invalid TZ fallback)
- [x] `npm run build`
- [x] `npm run lint`
- [ ] Manually verify on a PDT browser at 17:30 local that `?days=1` totals match `budi stats -p 1d` ± pending sync queue
- [ ] Manually verify on a UTC browser that totals are unchanged from before
- [ ] Confirm the `budi_tz` cookie is written on dashboard load and persists across navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)