### PR TITLE
feat(dashboard): manager per-user filter on Overview / Models / Repos / Sessions / Devices

### DIFF
--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -3,38 +3,49 @@ import {
   getCurrentUser,
   getCostByDevice,
   getEarliestActivity,
+  getOrgMembers,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { deviceLabel, fmtCost, fmtRelative } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function DevicesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ days?: string; user?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const scope = { scopedUserId: params.user || null };
   const earliestActivity =
-    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const devices = await getCostByDevice(user, range);
+  const [devices, members] = await Promise.all([
+    getCostByDevice(user, range, scope),
+    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+  ]);
 
   const showOwnerColumn = user.role === "manager";
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h1 className="text-xl font-bold">Devices</h1>
         <Suspense>
-          <PeriodSelector />
+          <div className="flex items-center gap-3">
+            <UserFilter members={members} role={user.role} />
+            <PeriodSelector />
+          </div>
         </Suspense>
       </div>
 

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -1,34 +1,49 @@
 import { Suspense } from "react";
-import { getCurrentUser, getCostByModel, getEarliestActivity } from "@/lib/dal";
+import {
+  getCurrentUser,
+  getCostByModel,
+  getEarliestActivity,
+  getOrgMembers,
+} from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { formatModelName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function ModelsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ days?: string; user?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const scope = { scopedUserId: params.user || null };
   const earliestActivity =
-    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const models = await getCostByModel(user, range);
+  const [models, members] = await Promise.all([
+    getCostByModel(user, range, scope),
+    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+  ]);
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h1 className="text-xl font-bold">Models</h1>
         <Suspense>
-          <PeriodSelector />
+          <div className="flex items-center gap-3">
+            <UserFilter members={members} role={user.role} />
+            <PeriodSelector />
+          </div>
         </Suspense>
       </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import {
   getOverviewStats,
   getDailyActivity,
   getEarliestActivity,
+  getOrgMembers,
   getSyncFreshness,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
@@ -12,6 +13,7 @@ import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { fmtCost, fmtNum } from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
 import { PeriodSelector } from "@/components/period-selector";
+import { UserFilter } from "@/components/user-filter";
 import { ActivityChart } from "@/components/charts/activity-chart";
 import {
   LinkDaemonBanner,
@@ -22,20 +24,25 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function OverviewPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ days?: string; user?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const scopedUserId = params.user || null;
+  const scope = { scopedUserId };
   const earliestActivity =
-    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [stats, activity, freshness] = await Promise.all([
-    getOverviewStats(user, range),
-    getDailyActivity(user, range),
+  const [stats, activity, freshness, members] = await Promise.all([
+    getOverviewStats(user, range, scope),
+    getDailyActivity(user, range, scope),
     getSyncFreshness(user),
+    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
   ]);
 
   // Decide which empty-state banner (if any) is most informative. The
@@ -48,10 +55,13 @@ export default async function OverviewPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h1 className="text-xl font-bold">Overview</h1>
         <Suspense>
-          <PeriodSelector />
+          <div className="flex items-center gap-3">
+            <UserFilter members={members} role={user.role} />
+            <PeriodSelector />
+          </div>
         </Suspense>
       </div>
 

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -5,32 +5,38 @@ import {
   getCostByBranch,
   getCostByTicket,
   getEarliestActivity,
+  getOrgMembers,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function ReposPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ days?: string; user?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const scope = { scopedUserId: params.user || null };
   const earliestActivity =
-    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [repos, branches, tickets] = await Promise.all([
-    getCostByRepo(user, range),
-    getCostByBranch(user, range),
-    getCostByTicket(user, range),
+  const [repos, branches, tickets, members] = await Promise.all([
+    getCostByRepo(user, range, scope),
+    getCostByBranch(user, range, scope),
+    getCostByTicket(user, range, scope),
+    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
   ]);
 
   // Multiple raw `repo_id` sentinels can collapse to the same display label
@@ -49,10 +55,13 @@ export default async function ReposPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h1 className="text-xl font-bold">Repos</h1>
         <Suspense>
-          <PeriodSelector />
+          <div className="flex items-center gap-3">
+            <UserFilter members={members} role={user.role} />
+            <PeriodSelector />
+          </div>
         </Suspense>
       </div>
 

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -1,10 +1,16 @@
 import { Suspense } from "react";
-import { getCurrentUser, getEarliestActivity, getSessions } from "@/lib/dal";
+import {
+  getCurrentUser,
+  getEarliestActivity,
+  getOrgMembers,
+  getSessions,
+} from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UserFilter } from "@/components/user-filter";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 function formatDuration(ms: number | null): string {
@@ -29,24 +35,33 @@ function formatTimestamp(ts: string | null): string {
 export default async function SessionsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ days?: string; user?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const scope = { scopedUserId: params.user || null };
   const earliestActivity =
-    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const sessions = await getSessions(user, range);
+  const [sessions, members] = await Promise.all([
+    getSessions(user, range, scope),
+    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+  ]);
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <h1 className="text-xl font-bold">Sessions</h1>
         <Suspense>
-          <PeriodSelector />
+          <div className="flex items-center gap-3">
+            <UserFilter members={members} role={user.role} />
+            <PeriodSelector />
+          </div>
         </Suspense>
       </div>
 

--- a/src/components/user-filter.tsx
+++ b/src/components/user-filter.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const ALL_TEAM_VALUE = "";
+const ALL_TEAM_LABEL = "All team";
+
+export interface UserFilterMember {
+  id: string;
+  display_name: string | null;
+  email: string | null;
+}
+
+/**
+ * Manager-only header dropdown that scopes the rest of the dashboard to a
+ * single teammate's data via `?user=<id>`. Mirrors `<PeriodSelector />`:
+ * lifts the URL into the source of truth so the breakdown queries can read
+ * it on the server without prop drilling, and preserves any other params
+ * (`?days=…`) on every change. Members never see this control — they're
+ * already DAL-scoped to themselves (ADR-0083 §6) so the dropdown would have
+ * a single trivial option (#80).
+ */
+export function UserFilter({
+  members,
+  role,
+}: {
+  members: UserFilterMember[];
+  role: string;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  if (role !== "manager") return null;
+
+  const current = searchParams.get("user") ?? ALL_TEAM_VALUE;
+
+  function selectUser(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === ALL_TEAM_VALUE) {
+      params.delete("user");
+    } else {
+      params.set("user", value);
+    }
+    const qs = params.toString();
+    router.push(qs ? `?${qs}` : "?");
+  }
+
+  return (
+    <label
+      className="flex items-center gap-2 text-sm"
+      data-testid="user-filter"
+    >
+      <span className="sr-only">Filter by teammate</span>
+      <select
+        value={current}
+        onChange={(e) => selectUser(e.target.value)}
+        className="rounded-lg border border-white/10 bg-white/[0.02] px-3 py-1.5 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/[0.04] focus:outline-none focus:ring-1 focus:ring-white/20"
+      >
+        <option value={ALL_TEAM_VALUE}>{ALL_TEAM_LABEL}</option>
+        {members.map((m) => (
+          <option key={m.id} value={m.id}>
+            {memberLabel(m)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function memberLabel(m: UserFilterMember): string {
+  return m.display_name?.trim() || m.email?.trim() || m.id.slice(0, 8);
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -588,6 +588,125 @@ describe("getCostByDevice", () => {
   });
 });
 
+describe("per-user scoping (#80)", () => {
+  // Three-org world so we can prove that an out-of-org id silently collapses
+  // to the org-wide view and never leaks the other org's data.
+  function seedTwoOrgs() {
+    fake.seed("orgs", [
+      { id: "org_team", name: "team" },
+      { id: "org_other", name: "other" },
+    ]);
+    fake.seed("users", [
+      {
+        id: "usr_ivan",
+        org_id: "org_team",
+        role: "manager",
+        api_key: "budi_i",
+        display_name: "Ivan",
+        email: "ivan@example.com",
+      },
+      {
+        id: "usr_jane",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_j",
+        display_name: "Jane",
+        email: "jane@example.com",
+      },
+      {
+        id: "usr_outsider",
+        org_id: "org_other",
+        role: "manager",
+        api_key: "budi_o",
+        display_name: "Outsider",
+        email: "outsider@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      { id: "dev_ivan", user_id: "usr_ivan", label: "ivan-mbp" },
+      { id: "dev_jane", user_id: "usr_jane", label: "jane-mbp" },
+      { id: "dev_outsider", user_id: "usr_outsider", label: "outsider-mbp" },
+    ]);
+    fake.seed("daily_rollups", [
+      rollup("dev_ivan", "2026-04-10", 800_00),
+      rollup("dev_jane", "2026-04-10", 1500_00),
+      rollup("dev_outsider", "2026-04-10", 9000_00),
+    ]);
+  }
+
+  const manager = {
+    id: "usr_ivan",
+    org_id: "org_team",
+    role: "manager",
+    api_key: "budi_i",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+  const range = utcRange("2026-04-01", "2026-04-30");
+
+  it("manager: scopedUserId narrows breakdowns to that teammate's data", async () => {
+    seedTwoOrgs();
+    const { getOverviewStats, getCostByDevice } = await loadDal();
+
+    const overview = await getOverviewStats(manager, range, {
+      scopedUserId: "usr_jane",
+    });
+    expect(overview.totalCostCents).toBe(1500_00);
+
+    const byDevice = await getCostByDevice(manager, range, {
+      scopedUserId: "usr_jane",
+    });
+    expect(byDevice.map((d) => d.id)).toEqual(["dev_jane"]);
+    expect(byDevice[0].cost_cents).toBe(1500_00);
+  });
+
+  it("manager: scopedUserId for an out-of-org user silently falls back to org-wide", async () => {
+    // Defense in depth — the URL parameter must not leak `org_other`'s 9000$
+    // bucket. Falling back to org-wide preserves the manager's own visibility
+    // without confirming that `usr_outsider` exists.
+    seedTwoOrgs();
+    const { getOverviewStats } = await loadDal();
+
+    const scoped = await getOverviewStats(manager, range, {
+      scopedUserId: "usr_outsider",
+    });
+    const orgWide = await getOverviewStats(manager, range);
+    expect(scoped.totalCostCents).toBe(orgWide.totalCostCents);
+    expect(scoped.totalCostCents).toBe(800_00 + 1500_00);
+  });
+
+  it("manager: missing/empty scopedUserId is the same as org-wide", async () => {
+    seedTwoOrgs();
+    const { getOverviewStats } = await loadDal();
+
+    const noScope = await getOverviewStats(manager, range);
+    const emptyScope = await getOverviewStats(manager, range, {
+      scopedUserId: null,
+    });
+    expect(emptyScope.totalCostCents).toBe(noScope.totalCostCents);
+  });
+
+  it("member: scopedUserId is ignored — they only ever see their own devices", async () => {
+    // ADR-0083 §6: members are DAL-scoped to themselves. Even if a member
+    // crafts `?user=usr_ivan` they must not see Ivan's data.
+    seedTwoOrgs();
+    const { getOverviewStats } = await loadDal();
+
+    const jane = {
+      id: "usr_jane",
+      org_id: "org_team",
+      role: "member",
+      api_key: "budi_j",
+      display_name: "Jane",
+      email: "jane@example.com",
+    };
+    const scoped = await getOverviewStats(jane, range, {
+      scopedUserId: "usr_ivan",
+    });
+    expect(scoped.totalCostCents).toBe(1500_00);
+  });
+});
+
 function rollup(
   deviceId: string,
   bucketDay: string,

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -39,6 +39,21 @@ interface BudiUser {
 }
 
 /**
+ * Optional scoping options for the dashboard breakdown queries.
+ *
+ * `scopedUserId` narrows the visible-device set to a single teammate's devices
+ * — the manager-only header filter introduced in #80. It is silently ignored
+ * for member viewers (their visibility is already self-only per ADR-0083 §6)
+ * and silently falls back to the org-wide set when the id is unknown or
+ * belongs to another org, mirroring the existing role branch in
+ * `getVisibleDeviceIds`. We deliberately do not surface a 4xx so an attacker
+ * can't enumerate other-org user ids by probing this parameter.
+ */
+export interface ScopeOptions {
+  scopedUserId?: string | null;
+}
+
+/**
  * Get the current budi user and verify they have an org.
  * Uses admin client because the auth→users mapping needs to bypass RLS
  * during the initial lookup.
@@ -63,11 +78,16 @@ export async function getCurrentUser(): Promise<BudiUser | null> {
 /**
  * Get overview stats visible to the current user.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getOverviewStats(user: BudiUser, range: DateRange) {
+export async function getOverviewStats(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
 
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) {
     return {
       totalCostCents: 0,
@@ -118,10 +138,15 @@ export async function getOverviewStats(user: BudiUser, range: DateRange) {
 /**
  * Get daily cost activity for charts.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getDailyActivity(user: BudiUser, range: DateRange) {
+export async function getDailyActivity(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -170,10 +195,11 @@ export async function getDailyActivity(user: BudiUser, range: DateRange) {
  * range-scoped queries so their signatures stay unchanged.
  */
 export async function getEarliestActivity(
-  user: BudiUser
+  user: BudiUser,
+  options?: ScopeOptions
 ): Promise<string | null> {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return null;
 
   const { data } = await admin
@@ -320,10 +346,11 @@ export interface DeviceCost {
  */
 export async function getCostByDevice(
   user: BudiUser,
-  range: DateRange
+  range: DateRange,
+  options?: ScopeOptions
 ): Promise<DeviceCost[]> {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -403,10 +430,15 @@ export async function getCostByDevice(
 /**
  * Get cost breakdown by model.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getCostByModel(user: BudiUser, range: DateRange) {
+export async function getCostByModel(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -442,10 +474,15 @@ export async function getCostByModel(user: BudiUser, range: DateRange) {
 /**
  * Get cost breakdown by repo.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getCostByRepo(user: BudiUser, range: DateRange) {
+export async function getCostByRepo(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -469,10 +506,15 @@ export async function getCostByRepo(user: BudiUser, range: DateRange) {
 /**
  * Get cost breakdown by branch.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getCostByBranch(user: BudiUser, range: DateRange) {
+export async function getCostByBranch(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -508,10 +550,15 @@ export async function getCostByBranch(user: BudiUser, range: DateRange) {
 /**
  * Get cost breakdown by ticket.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getCostByTicket(user: BudiUser, range: DateRange) {
+export async function getCostByTicket(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: rollups } = await admin
@@ -541,10 +588,15 @@ export async function getCostByTicket(user: BudiUser, range: DateRange) {
 /**
  * Get sessions list.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
  */
-export async function getSessions(user: BudiUser, range: DateRange) {
+export async function getSessions(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
-  const deviceIds = await getVisibleDeviceIds(admin, user);
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
   const { data: sessions } = await admin
@@ -649,15 +701,22 @@ export async function getOrgMembers(orgId: string) {
  * Per ADR-0083 §6:
  *   - Manager: sees all devices in the org
  *   - Member: sees only their own devices
+ *
+ * `options.scopedUserId` (manager-only, #80) narrows the result further to a
+ * single teammate's devices. If the id is missing, unknown, or belongs to
+ * another org we silently fall back to the org-wide set rather than 4xxing,
+ * so the URL parameter cannot be used to probe other orgs' user ids. Members
+ * already collapse to themselves and ignore the option entirely.
  */
 async function getVisibleDeviceIds(
   admin: ReturnType<typeof createAdminClient>,
-  user: BudiUser
+  user: BudiUser,
+  options?: ScopeOptions
 ): Promise<string[]> {
   if (user.role === "manager") {
-    return getOrgDeviceIds(admin, user.org_id!);
+    return getOrgDeviceIds(admin, user.org_id!, options?.scopedUserId ?? null);
   }
-  // Member: own devices only
+  // Member: own devices only — `scopedUserId` is intentionally ignored.
   const { data: devices } = await admin
     .from("devices")
     .select("id")
@@ -667,7 +726,8 @@ async function getVisibleDeviceIds(
 
 async function getOrgDeviceIds(
   admin: ReturnType<typeof createAdminClient>,
-  orgId: string
+  orgId: string,
+  scopedUserId: string | null
 ): Promise<string[]> {
   const { data: users } = await admin
     .from("users")
@@ -676,13 +736,19 @@ async function getOrgDeviceIds(
 
   if (!users?.length) return [];
 
+  const orgUserIds = users.map((u) => u.id as string);
+  // Narrow to a single teammate when the manager picked one — but only if
+  // they're actually in the manager's org. Anything else collapses back to
+  // org-wide so an out-of-org id can't leak the existence of another org.
+  const userIds =
+    scopedUserId && orgUserIds.includes(scopedUserId)
+      ? [scopedUserId]
+      : orgUserIds;
+
   const { data: devices } = await admin
     .from("devices")
     .select("id")
-    .in(
-      "user_id",
-      users.map((u) => u.id)
-    );
+    .in("user_id", userIds);
 
   return (devices ?? []).map((d) => d.id);
 }


### PR DESCRIPTION
Closes #80.

## Summary
- Adds a manager-only `<UserFilter />` dropdown in the in-page header, before the period selector, on Overview / Models / Repos / Sessions / Devices.
- Wires `?user=<id>` through the DAL via a new `ScopeOptions.scopedUserId` so every breakdown reuses the existing `getVisibleDeviceIds` plumbing — narrows a manager view to one teammate, silently falls back to org-wide for unknown/cross-org ids (no probing other orgs), and is ignored for members (already DAL-scoped to themselves per ADR-0083 §6).
- Filter component is hidden entirely for members so they don't see a one-option dropdown.
- The Team page intentionally stays as the leaderboard (out of scope for this PR per the issue).

## Test plan
- [x] `npm test` — 112 passing, including 4 new `dal.test.ts` cases covering: manager scoping narrows correctly, out-of-org id silently falls back to org-wide, missing scope == org-wide, member ignores the param.
- [x] `npm run build` — succeeds.
- [x] `npm run lint` — clean.
- [ ] Manual: as manager, pick a teammate from the header on each of the 5 pages and confirm stat tiles, charts, and breakdowns narrow. Switching back to "All team" restores org-wide.
- [ ] Manual: navigate via period selector — `?user=` survives.
- [ ] Manual: as a member, the filter never renders.
- [ ] Manual: forge `?user=<id-from-another-org>` as a manager — view collapses silently to org-wide rather than 4xxing or leaking.

## Notes
- Sidebar nav already gates Team to managers (`managerOnly: true` in `src/components/sidebar.tsx`, added in #64) — confirmed during this work, no change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)