### PR TITLE
chore(dashboard): match user filter height to period selector

### DIFF
--- a/src/components/user-filter.tsx
+++ b/src/components/user-filter.tsx
@@ -54,7 +54,7 @@ export function UserFilter({
       <select
         value={current}
         onChange={(e) => selectUser(e.target.value)}
-        className="rounded-lg border border-white/10 bg-white/[0.02] px-3 py-1.5 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/[0.04] focus:outline-none focus:ring-1 focus:ring-white/20"
+        className="rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2.5 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/[0.04] focus:outline-none focus:ring-1 focus:ring-white/20"
       >
         <option value={ALL_TEAM_VALUE}>{ALL_TEAM_LABEL}</option>
         {members.map((m) => (


### PR DESCRIPTION
## Summary
- The `<UserFilter />` select rendered ~8px shorter than the period pills because the latter wrap their buttons in an outer `p-1` container.
- Bumping the select's vertical padding (`py-1.5` → `py-2.5`) brings them onto the same baseline.

## Test plan
- [x] `npm test` — 107 passing.
- [x] `npm run lint` — clean.
- [ ] Manual: confirm the user dropdown and period pills line up in the dashboard header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)