### PR TITLE
fix(sync-freshness): surface session-vs-rollup divergence in header badge

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -36,6 +36,7 @@ export default async function DashboardLayout({
             deviceCount={freshness.deviceCount}
             lastSeenAt={freshness.lastSeenAt}
             lastRollupAt={freshness.lastRollupAt}
+            lastSessionAt={freshness.lastSessionAt}
           />
           <UserMenu displayName={user.display_name} email={user.email} />
         </header>

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -15,14 +15,25 @@ import { ChevronDown } from "lucide-react";
  */
 const STALLED_AFTER_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Maximum gap between the latest rollup and the latest session before we
+ * call the session ingest stream "stalled" relative to rollups (#84).
+ * Rollups and sessions ride in the same envelope, so on a healthy daemon
+ * their watermarks track within minutes; a multi-hour drift means the
+ * envelope is landing partial and the Sessions page would silently empty.
+ */
+const SESSIONS_LAG_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
 export function SyncFreshness({
   deviceCount,
   lastSeenAt,
   lastRollupAt,
+  lastSessionAt,
 }: {
   deviceCount: number;
   lastSeenAt: string | null;
   lastRollupAt: string | null;
+  lastSessionAt: string | null;
 }) {
   // Not-linked is rendered as a call-to-action so it's obvious what to do
   // next instead of looking like a silent empty dashboard.
@@ -46,7 +57,11 @@ export function SyncFreshness({
   }
 
   return (
-    <LinkedSyncFreshness lastSeenAt={lastSeenAt} lastRollupAt={lastRollupAt} />
+    <LinkedSyncFreshness
+      lastSeenAt={lastSeenAt}
+      lastRollupAt={lastRollupAt}
+      lastSessionAt={lastSessionAt}
+    />
   );
 }
 
@@ -59,25 +74,50 @@ export function SyncFreshness({
 function LinkedSyncFreshness({
   lastSeenAt,
   lastRollupAt,
+  lastSessionAt,
 }: {
   lastSeenAt: string | null;
   lastRollupAt: string | null;
+  lastSessionAt: string | null;
 }) {
   const now = useNow(60_000);
   const effective = lastRollupAt ?? lastSeenAt;
   const isStalled =
     effective !== null && now - Date.parse(effective) > STALLED_AFTER_MS;
-  const state: "linked_no_data" | "stalled" | "ok" = !lastRollupAt
-    ? "linked_no_data"
-    : isStalled
-      ? "stalled"
-      : "ok";
+  // Sessions-stalled is only meaningful once the viewer has both a rollup
+  // and a previously-seen session: a brand-new account legitimately has
+  // rollups but no sessions until the daemon closes its first one. Total
+  // daemon-stalled wins, since the popover already covers that case.
+  const isSessionsStalled =
+    !isStalled &&
+    lastRollupAt !== null &&
+    lastSessionAt !== null &&
+    Date.parse(lastRollupAt) - Date.parse(lastSessionAt) >
+      SESSIONS_LAG_THRESHOLD_MS;
+  const state: "linked_no_data" | "stalled" | "sessions_stalled" | "ok" =
+    !lastRollupAt
+      ? "linked_no_data"
+      : isStalled
+        ? "stalled"
+        : isSessionsStalled
+          ? "sessions_stalled"
+          : "ok";
 
   // Stalled mirrors the `not_linked` CTA pattern: make it actionable so the
   // user can self-serve. The popover names the two CLI commands and the
   // config file that are almost always the answer (#53).
   if (state === "stalled") {
     return <StalledBadge effective={effective} now={now} />;
+  }
+
+  if (state === "sessions_stalled") {
+    return (
+      <SessionsStalledBadge
+        lastRollupAt={lastRollupAt!}
+        lastSessionAt={lastSessionAt!}
+        now={now}
+      />
+    );
   }
 
   return (
@@ -212,6 +252,106 @@ function StalledBadge({
             rel="noreferrer"
           >
             ADR-0083 — cloud sync contract
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SessionsStalledBadge({
+  lastRollupAt,
+  lastSessionAt,
+  now,
+}: {
+  lastRollupAt: string;
+  lastSessionAt: string;
+  now: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const sessionRelative = formatRelative(Date.parse(lastSessionAt), now);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        data-testid="sync-freshness"
+        data-sync-state="sessions_stalled"
+        title={`Last session: ${new Date(lastSessionAt).toLocaleString()} — last rollup: ${new Date(lastRollupAt).toLocaleString()}`}
+        className="inline-flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-400/10 px-2.5 py-1 text-xs font-medium text-amber-300 transition-colors hover:border-amber-400/60 hover:bg-amber-400/20"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-300" />
+        <span className="hidden sm:inline">Sessions stalled — last </span>
+        <span className="sm:hidden">Sessions </span>
+        <span>{sessionRelative}</span>
+        <ChevronDown
+          className={clsx(
+            "h-3 w-3 transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Session ingest is stalled"
+          className="absolute right-0 top-full z-20 mt-1 w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-white/10 bg-zinc-950 p-3 text-xs text-zinc-300 shadow-xl"
+          data-testid="sync-freshness-popover"
+        >
+          <p className="mb-1 text-zinc-100">
+            Daily totals are still landing, but new sessions stopped{" "}
+            {sessionRelative}.
+          </p>
+          <p className="mb-2 text-zinc-400">
+            The Sessions page will look empty even though Overview is up to
+            date. From your local machine:
+          </p>
+          <ol className="mb-3 list-decimal space-y-1 pl-4">
+            <li>
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                budi cloud status
+              </code>{" "}
+              — confirm the daemon is healthy
+            </li>
+            <li>
+              <code className="rounded bg-black/40 px-1 text-zinc-200">
+                budi --version
+              </code>{" "}
+              — make sure you&rsquo;re on a recent build
+            </li>
+            <li>
+              If both look fine, file an issue — sessions diverging from
+              rollups usually means a daemon-side regression.
+            </li>
+          </ol>
+          <a
+            className="text-zinc-400 underline decoration-dotted underline-offset-2 hover:text-zinc-200"
+            href="https://github.com/siropkin/budi-cloud/issues/84"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Tracking issue #84
           </a>
         </div>
       )}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -185,6 +185,7 @@ describe("getSyncFreshness (linking / freshness snapshot)", () => {
       deviceCount: 0,
       lastSeenAt: null,
       lastRollupAt: null,
+      lastSessionAt: null,
     });
   });
 
@@ -205,6 +206,7 @@ describe("getSyncFreshness (linking / freshness snapshot)", () => {
     expect(snap.deviceCount).toBe(1);
     expect(snap.lastSeenAt).toBe("2026-04-18T11:00:00Z");
     expect(snap.lastRollupAt).toBeNull();
+    expect(snap.lastSessionAt).toBeNull();
   });
 
   it("reports the most recent rollup synced_at across the viewer's own devices", async () => {
@@ -236,6 +238,90 @@ describe("getSyncFreshness (linking / freshness snapshot)", () => {
     expect(snap.deviceCount).toBe(2);
     expect(snap.lastSeenAt).toBe("2026-04-18T11:00:00Z");
     expect(snap.lastRollupAt).toBe("2026-04-18T10:30:00Z");
+  });
+
+  it("(#84) probes the most recent session_summaries.started_at across the viewer's own devices", async () => {
+    // Reproduces the bug: rollups keep landing (synced_at = today) while
+    // sessions stop ingesting (started_at frozen 3 days ago). Without the
+    // session probe the header showed "Synced 2m ago" while the Sessions
+    // page silently returned zero rows.
+    fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);
+    fake.seed("users", [{ ...baseUser }]);
+    fake.seed("devices", [
+      {
+        id: "dev_laptop",
+        user_id: "usr_ivan",
+        last_seen: "2026-04-29T15:00:00Z",
+      },
+    ]);
+    fake.seed("daily_rollups", [
+      rollup("dev_laptop", "2026-04-29", 100, {
+        synced_at: "2026-04-29T14:55:00Z",
+      }),
+    ]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_laptop",
+        session_id: "sess_old",
+        started_at: "2026-04-26T17:07:00Z",
+      },
+      {
+        device_id: "dev_laptop",
+        session_id: "sess_older",
+        started_at: "2026-04-17T21:11:00Z",
+      },
+    ]);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness(baseUser);
+    expect(snap.lastRollupAt).toBe("2026-04-29T14:55:00Z");
+    expect(snap.lastSessionAt).toBe("2026-04-26T17:07:00Z");
+  });
+
+  it("(#84) lastSessionAt is scoped to the viewer's own devices, not the org", async () => {
+    // Same self-trust contract as #74 for rollups: a manager whose own
+    // daemon stopped sending sessions should see the divergence even when a
+    // teammate's daemon is still pushing fresh sessions.
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      { ...baseUser, org_id: "org_team" },
+      {
+        id: "usr_teammate",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_t",
+        display_name: "Teammate",
+        email: "teammate@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      {
+        id: "dev_my_mac",
+        user_id: "usr_ivan",
+        last_seen: "2026-04-29T15:00:00Z",
+      },
+      {
+        id: "dev_teammate_mac",
+        user_id: "usr_teammate",
+        last_seen: "2026-04-29T15:00:00Z",
+      },
+    ]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_my_mac",
+        session_id: "sess_mine_old",
+        started_at: "2026-04-26T17:00:00Z",
+      },
+      {
+        device_id: "dev_teammate_mac",
+        session_id: "sess_teammate_fresh",
+        started_at: "2026-04-29T14:55:00Z",
+      },
+    ]);
+
+    const { getSyncFreshness } = await loadDal();
+    const snap = await getSyncFreshness({ ...baseUser, org_id: "org_team" });
+    expect(snap.lastSessionAt).toBe("2026-04-26T17:00:00Z");
   });
 
   it("(#74) badge ignores teammates' devices for a manager — own daemon stale, teammate daemon fresh", async () => {
@@ -315,6 +401,7 @@ describe("getSyncFreshness (linking / freshness snapshot)", () => {
       deviceCount: 0,
       lastSeenAt: null,
       lastRollupAt: null,
+      lastSessionAt: null,
     });
   });
 });

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -636,11 +636,19 @@ export async function getSessions(
  *   viewer's own devices. If `deviceCount > 0` but `lastRollupAt` is null,
  *   the viewer is linked but hasn't pushed any usage rows yet — that's the
  *   "initial sync in progress / no data yet" state.
+ * - `lastSessionAt` is the most recent `session_summaries.started_at` across
+ *   the viewer's own devices. The two ingest streams (rollups and sessions)
+ *   travel in the same envelope but are independent rows on the cloud side,
+ *   so a daemon-side regression can drop sessions while still landing
+ *   rollups. The header badge cross-checks the two watermarks so the
+ *   divergence surfaces in the badge instead of silently emptying the
+ *   Sessions page (#84).
  */
 export async function getSyncFreshness(user: BudiUser): Promise<{
   deviceCount: number;
   lastSeenAt: string | null;
   lastRollupAt: string | null;
+  lastSessionAt: string | null;
 }> {
   const admin = createAdminClient();
   const { data: ownDevices } = await admin
@@ -649,7 +657,12 @@ export async function getSyncFreshness(user: BudiUser): Promise<{
     .eq("user_id", user.id);
   const deviceIds = (ownDevices ?? []).map((d) => d.id as string);
   if (deviceIds.length === 0) {
-    return { deviceCount: 0, lastSeenAt: null, lastRollupAt: null };
+    return {
+      deviceCount: 0,
+      lastSeenAt: null,
+      lastRollupAt: null,
+      lastSessionAt: null,
+    };
   }
 
   const { data: lastSeenRow } = await admin
@@ -673,10 +686,23 @@ export async function getSyncFreshness(user: BudiUser): Promise<{
     .limit(1)
     .maybeSingle();
 
+  // Probe `started_at` rather than `synced_at`: the user-facing Sessions
+  // page sorts by `started_at`, and a "session that never closes" daemon
+  // bug would keep upserting the same row's `synced_at` while no new
+  // sessions land, masking the divergence we want to detect.
+  const { data: lastSessionRow } = await admin
+    .from("session_summaries")
+    .select("started_at")
+    .in("device_id", deviceIds)
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
   return {
     deviceCount: deviceIds.length,
     lastSeenAt: (lastSeenRow?.last_seen as string | null) ?? null,
     lastRollupAt: (lastRollupRow?.synced_at as string | null) ?? null,
+    lastSessionAt: (lastSessionRow?.started_at as string | null) ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `lastSessionAt` to `getSyncFreshness` — `MAX(session_summaries.started_at)` scoped to the viewer's own devices, mirroring the self-trust contract used for `lastRollupAt` (#74).
- Adds a `sessions_stalled` state to the header badge that renders when rollups are fresh but sessions are 24h+ behind. Includes a popover explaining the divergence and surfacing `budi cloud status` / `budi --version` as first-line debug steps.
- Total daemon-stalled keeps winning over sessions-stalled, and a brand-new account with rollups but no sessions yet stays in the `ok` state until its first session closes (avoids false positives on first-run users).

## Why this matters

Closes #84. Rollups and sessions ride in the same envelope, but a daemon-side regression that drops sessions while still upserting rollups was invisible from the cloud — the header badge said \"Synced 2m ago\" while `/dashboard/sessions` silently returned zero rows for ~3 days. With the cross-check, the divergence shows up where managers already look (header), not by users discovering an empty Sessions page.

The probe targets `started_at` rather than `synced_at` on purpose: a \"session that never closes\" daemon bug would keep refreshing the same row's `synced_at` while no new sessions land, so `started_at` is the load-bearing signal.

## Test plan

- [x] `npm test` — 109 tests pass; new tests reproduce the #84 ingest pattern (rollups today, sessions frozen 3 days ago) and the #74-style self-trust scoping for sessions.
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds (pre-existing TS errors in `route.test.ts` / `cost-bar-chart.test.tsx` are unrelated and present on `main`).
- [ ] Manual: link a daemon, simulate the divergence by inserting an old `session_summaries` row + fresh `daily_rollups` row, confirm the header shows \"Sessions stalled — last 3d ago\" with the popover.

## Related

- #74 — original self-trust scoping for the badge (this PR extends the same contract to sessions).
- #85 — sessions pagination (separate ticket; this PR doesn't change `getSessions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)