### PR TITLE
fix(sessions): compute Duration from timestamps when duration_ms is null (#88)

### DIFF
--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -14,19 +14,10 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
-import { fmtCost, fmtNum, repoName } from "@/lib/format";
+import { fmtCost, fmtNum, formatDuration, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UserFilter } from "@/components/user-filter";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-
-function formatDuration(ms: number | null): string {
-  if (!ms) return "-";
-  const minutes = Math.floor(ms / 60_000);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const remaining = minutes % 60;
-  return `${hours}h ${remaining}m`;
-}
 
 function formatTimestamp(ts: string | null): string {
   if (!ts) return "-";
@@ -152,7 +143,11 @@ export default async function SessionsPage({
                         {formatTimestamp(s.started_at)}
                       </td>
                       <td className="py-2 text-zinc-400">
-                        {formatDuration(s.duration_ms)}
+                        {formatDuration(
+                          s.duration_ms,
+                          s.started_at,
+                          s.ended_at
+                        )}
                       </td>
                       <td className="py-2 text-zinc-400">
                         {repoName(s.repo_id)}

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration } from "./format";
+
+describe("formatDuration (#88)", () => {
+  it("uses duration_ms when provided", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+    expect(formatDuration(30 * 60_000)).toBe("30m");
+    expect(formatDuration(2 * 60 * 60_000 + 15 * 60_000)).toBe("2h 15m");
+  });
+
+  it("falls back to ended_at - started_at when duration_ms is null", () => {
+    const startedAt = "2026-04-29T10:00:00Z";
+    const endedAt = "2026-04-29T10:45:00Z";
+    expect(formatDuration(null, startedAt, endedAt)).toBe("45m");
+  });
+
+  it("returns '<1m' for sub-minute durations", () => {
+    const startedAt = "2026-04-29T10:00:00Z";
+    const endedAt = "2026-04-29T10:00:30Z";
+    expect(formatDuration(null, startedAt, endedAt)).toBe("<1m");
+    expect(formatDuration(30_000)).toBe("<1m");
+  });
+
+  it("returns '-' when both duration_ms and timestamps are missing", () => {
+    expect(formatDuration(null)).toBe("-");
+    expect(formatDuration(null, null, null)).toBe("-");
+    expect(formatDuration(undefined, undefined, undefined)).toBe("-");
+  });
+
+  it("returns '-' when only one timestamp is present", () => {
+    expect(formatDuration(null, "2026-04-29T10:00:00Z", null)).toBe("-");
+    expect(formatDuration(null, null, "2026-04-29T10:00:00Z")).toBe("-");
+  });
+
+  it("returns '-' for negative deltas (clock skew)", () => {
+    expect(
+      formatDuration(null, "2026-04-29T11:00:00Z", "2026-04-29T10:00:00Z")
+    ).toBe("-");
+  });
+
+  it("returns '-' for unparseable timestamps", () => {
+    expect(formatDuration(null, "not-a-date", "also-bad")).toBe("-");
+  });
+
+  it("prefers duration_ms over the timestamp fallback when both are usable", () => {
+    expect(
+      formatDuration(60_000, "2026-04-29T10:00:00Z", "2026-04-29T11:00:00Z")
+    ).toBe("1m");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -20,6 +20,36 @@ export function fmtNum(n: number): string {
 }
 
 /**
+ * Format a session duration. Falls back to `ended_at - started_at` when
+ * `duration_ms` is null because the daemon doesn't populate that column for
+ * `claude_code` / `codex` sessions — without the fallback, every row in the
+ * dashboard renders "-" despite both timestamps being reliable post-#14 (#88).
+ */
+export function formatDuration(
+  durationMs: number | null | undefined,
+  startedAt?: string | null,
+  endedAt?: string | null
+): string {
+  let ms: number | null = null;
+  if (typeof durationMs === "number" && durationMs > 0) {
+    ms = durationMs;
+  } else if (startedAt && endedAt) {
+    const start = Date.parse(startedAt);
+    const end = Date.parse(endedAt);
+    if (Number.isFinite(start) && Number.isFinite(end) && end >= start) {
+      ms = end - start;
+    }
+  }
+  if (ms === null) return "-";
+  if (ms < 60_000) return "<1m";
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  return `${hours}h ${remaining}m`;
+}
+
+/**
  * Extract a short repo name from a hashed repo_id.
  *
  * The daemon emits two historical sentinels when a session's directory has


### PR DESCRIPTION
Closes #88 (partial — render-side fix for the **Duration** column).

## Summary

- Reuse `started_at` / `ended_at` to compute the duration when the daemon ships `duration_ms = NULL`, which is the case for every `claude_code` / `codex` session post-#14.
- Move `formatDuration` from the page to `src/lib/format.ts` so the helper is unit-testable.
- New `src/lib/format.test.ts` covers all of: ms-supplied path, timestamp fallback, sub-minute rendering, `-` when both inputs missing, single-timestamp guard, negative-delta guard (clock skew), unparseable ISO guard, and the precedence rule (`duration_ms` wins when usable).

## Out of scope

The **Repo** (`(unknown)`) and **Branch** (`-`) columns are also empty in the same screenshots, but the rendering path already does the right thing — `repoName(repo_id)` and `git_branch?.replace(...) || "-"` faithfully render whatever the DB holds. Those columns are NULL in the DB because the daemon's session-summary writer doesn't populate them for `claude_code` / `codex` sessions yet (issue #88 §3 *Local-side follow-up*). That fix belongs in `siropkin/budi`, not here.

## Test plan

- [x] `pnpm run test` — 11 files / 122 tests pass (8 new in `format.test.ts`).
- [x] `pnpm run lint` — clean.
- [x] `npx tsc --noEmit` on changed files — clean (pre-existing errors in `ingest/route.test.ts` and `cost-bar-chart.test.tsx` are unrelated).
- [ ] Manual: load `/dashboard/sessions` in production and confirm Duration column now shows `Xm` / `Xh Ym` for `claude_code` rows whose `duration_ms` is NULL but `started_at` and `ended_at` are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)