### PR TITLE
fix(dashboard): push breakdown aggregation into Postgres (#92)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -30,6 +30,56 @@ class FakeSupabase {
     return new FakeQuery(this.tables.get(name)!);
   }
 
+  /**
+   * Mirrors `dashboard_overview_stats` from `004_dashboard_aggregates.sql`
+   * (#92). The full RPC suite lives next to the dal tests; this test only
+   * exercises the overview path on the read side, so we keep the shim minimal
+   * — extend if a future ingest test calls another breakdown.
+   */
+  rpc(name: string, args: Record<string, unknown>) {
+    if (name !== "dashboard_overview_stats") {
+      return Promise.resolve({
+        data: null,
+        error: { message: `unsupported rpc: ${name}` },
+      });
+    }
+    const deviceIds = new Set(args.p_device_ids as string[]);
+    const from = args.p_bucket_from as string;
+    const to = args.p_bucket_to as string;
+    const startedFrom = args.p_started_from as string;
+    const startedTo = args.p_started_to as string;
+    const rollups = (this.tables.get("daily_rollups") ?? []).filter(
+      (r) =>
+        deviceIds.has(r.device_id as string) &&
+        String(r.bucket_day ?? "") >= from &&
+        String(r.bucket_day ?? "") <= to
+    );
+    const totals = rollups.reduce(
+      (acc, r) => ({
+        total_cost_cents: acc.total_cost_cents + Number(r.cost_cents),
+        total_input_tokens: acc.total_input_tokens + Number(r.input_tokens),
+        total_output_tokens: acc.total_output_tokens + Number(r.output_tokens),
+        total_messages: acc.total_messages + Number(r.message_count),
+      }),
+      {
+        total_cost_cents: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_messages: 0,
+      }
+    );
+    const total_sessions = (this.tables.get("session_summaries") ?? []).filter(
+      (s) =>
+        deviceIds.has(s.device_id as string) &&
+        String(s.started_at ?? "") >= startedFrom &&
+        String(s.started_at ?? "") <= startedTo
+    ).length;
+    return Promise.resolve({
+      data: [{ ...totals, total_sessions }],
+      error: null,
+    });
+  }
+
   seed(name: string, rows: Row[]) {
     this.tables.set(name, [...rows]);
   }

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -36,10 +36,189 @@ class FakeSupabase {
     return new FakeQuery(this.tables.get(name)!);
   }
 
+  /**
+   * Mirrors the SQL aggregate functions added in `004_dashboard_aggregates.sql`
+   * (#92). Each handler reproduces the WHERE / GROUP BY shape of its Postgres
+   * counterpart over the in-memory tables so the test contract is what the
+   * server contract is — no row cap, full aggregation. A handler that drifts
+   * from its SQL definition will silently mask the bug class #92 was created
+   * to prevent, so both should be edited together.
+   */
+  rpc(name: string, args: Record<string, unknown>) {
+    const handler = RPC_HANDLERS[name];
+    if (!handler) {
+      return Promise.resolve({
+        data: null,
+        error: { message: `unsupported rpc: ${name}` },
+      });
+    }
+    return Promise.resolve({ data: handler(this.tables, args), error: null });
+  }
+
   seed(name: string, rows: Row[]) {
     this.tables.set(name, [...rows]);
   }
 }
+
+type RpcHandler = (
+  tables: Map<string, Row[]>,
+  args: Record<string, unknown>
+) => Row[];
+
+function rollupsForRange(
+  tables: Map<string, Row[]>,
+  args: Record<string, unknown>
+): Row[] {
+  const deviceIds = new Set(args.p_device_ids as string[]);
+  const from = args.p_bucket_from as string;
+  const to = args.p_bucket_to as string;
+  return (tables.get("daily_rollups") ?? []).filter(
+    (r) =>
+      deviceIds.has(r.device_id as string) &&
+      String(r.bucket_day ?? "") >= from &&
+      String(r.bucket_day ?? "") <= to
+  );
+}
+
+const RPC_HANDLERS: Record<string, RpcHandler> = {
+  dashboard_overview_stats(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const totals = rows.reduce(
+      (acc, r) => ({
+        total_cost_cents: acc.total_cost_cents + Number(r.cost_cents),
+        total_input_tokens: acc.total_input_tokens + Number(r.input_tokens),
+        total_output_tokens: acc.total_output_tokens + Number(r.output_tokens),
+        total_messages: acc.total_messages + Number(r.message_count),
+      }),
+      {
+        total_cost_cents: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_messages: 0,
+      }
+    );
+
+    const deviceIds = new Set(args.p_device_ids as string[]);
+    const startedFrom = args.p_started_from as string;
+    const startedTo = args.p_started_to as string;
+    const total_sessions = (tables.get("session_summaries") ?? []).filter(
+      (s) =>
+        deviceIds.has(s.device_id as string) &&
+        String(s.started_at ?? "") >= startedFrom &&
+        String(s.started_at ?? "") <= startedTo
+    ).length;
+
+    return [{ ...totals, total_sessions }];
+  },
+  dashboard_daily_activity(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const byDay = new Map<
+      string,
+      {
+        bucket_day: string;
+        input_tokens: number;
+        output_tokens: number;
+        cost_cents: number;
+        message_count: number;
+      }
+    >();
+    for (const r of rows) {
+      const day = r.bucket_day as string;
+      const existing = byDay.get(day) ?? {
+        bucket_day: day,
+        input_tokens: 0,
+        output_tokens: 0,
+        cost_cents: 0,
+        message_count: 0,
+      };
+      existing.input_tokens += Number(r.input_tokens);
+      existing.output_tokens += Number(r.output_tokens);
+      existing.cost_cents += Number(r.cost_cents);
+      existing.message_count += Number(r.message_count);
+      byDay.set(day, existing);
+    }
+    return Array.from(byDay.values()).sort((a, b) =>
+      a.bucket_day.localeCompare(b.bucket_day)
+    );
+  },
+  dashboard_cost_by_device(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const byDevice = new Map<string, number>();
+    for (const r of rows) {
+      const id = r.device_id as string;
+      byDevice.set(id, (byDevice.get(id) ?? 0) + Number(r.cost_cents));
+    }
+    return Array.from(byDevice.entries()).map(([device_id, cost_cents]) => ({
+      device_id,
+      cost_cents,
+    }));
+  },
+  dashboard_cost_by_model(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const byModel = new Map<
+      string,
+      { provider: string; model: string; cost_cents: number }
+    >();
+    for (const r of rows) {
+      const provider = r.provider as string;
+      const model = r.model as string;
+      const key = `${provider}:${model}`;
+      const existing = byModel.get(key) ?? {
+        provider,
+        model,
+        cost_cents: 0,
+      };
+      existing.cost_cents += Number(r.cost_cents);
+      byModel.set(key, existing);
+    }
+    return Array.from(byModel.values());
+  },
+  dashboard_cost_by_repo(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const byRepo = new Map<string, number>();
+    for (const r of rows) {
+      const id = r.repo_id as string;
+      byRepo.set(id, (byRepo.get(id) ?? 0) + Number(r.cost_cents));
+    }
+    return Array.from(byRepo.entries()).map(([repo_id, cost_cents]) => ({
+      repo_id,
+      cost_cents,
+    }));
+  },
+  dashboard_cost_by_branch(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const byBranch = new Map<
+      string,
+      { repo_id: string; git_branch: string; cost_cents: number }
+    >();
+    for (const r of rows) {
+      const repo_id = r.repo_id as string;
+      const git_branch = r.git_branch as string;
+      const key = `${repo_id}:${git_branch}`;
+      const existing = byBranch.get(key) ?? {
+        repo_id,
+        git_branch,
+        cost_cents: 0,
+      };
+      existing.cost_cents += Number(r.cost_cents);
+      byBranch.set(key, existing);
+    }
+    return Array.from(byBranch.values());
+  },
+  dashboard_cost_by_ticket(tables, args) {
+    const rows = rollupsForRange(tables, args);
+    const byTicket = new Map<string, number>();
+    for (const r of rows) {
+      const ticket = r.ticket as string | null | undefined;
+      if (ticket == null) continue;
+      byTicket.set(ticket, (byTicket.get(ticket) ?? 0) + Number(r.cost_cents));
+    }
+    return Array.from(byTicket.entries()).map(([ticket, cost_cents]) => ({
+      ticket,
+      cost_cents,
+    }));
+  },
+};
 
 /**
  * Mirrors PostgREST's default `db-max-rows` cap of 1000. Production code that
@@ -594,17 +773,12 @@ describe("PostgREST 1000-row cap on chart and breakdown queries (#90)", () => {
         // Spread across 30 days so the daily series exposes any prefix
         // truncation at the most-recent end.
         const day = `2026-04-${String((i % 30) + 1).padStart(2, "0")}`;
-        return rollup(
-          i % 2 === 0 ? "dev_laptop" : "dev_desktop",
-          day,
-          100,
-          {
-            model: `model-${i % 50}`,
-            repo_id: `repo-${i % 25}`,
-            git_branch: `branch-${i}`,
-            ticket: `TICKET-${i % 40}`,
-          }
-        );
+        return rollup(i % 2 === 0 ? "dev_laptop" : "dev_desktop", day, 100, {
+          model: `model-${i % 50}`,
+          repo_id: `repo-${i % 25}`,
+          git_branch: `branch-${i}`,
+          ticket: `TICKET-${i % 40}`,
+        });
       })
     );
   }
@@ -666,6 +840,196 @@ describe("PostgREST 1000-row cap on chart and breakdown queries (#90)", () => {
     const byTicket = await getCostByTicket(user, range);
 
     expect(byTicket.reduce((s, t) => s + t.cost_cents, 0)).toBe(1200 * 100);
+  });
+});
+
+describe("server-side aggregation (#92)", () => {
+  // PR #90 raised the row cap from 1,000 to 100,000, but a real org with
+  // `device × day × role × provider × model × repo_id × git_branch`
+  // cardinality crosses 100,000 the same way it crossed 1,000. Bumping the
+  // ceiling never closes the bug class — every breakdown must aggregate
+  // server-side so no row count is exposed to the app at all. The fixture
+  // here is sized just above the prior 100,000 ceiling so a regression that
+  // reintroduces a JS-side reduce-with-`.limit(N)` would fail this test.
+  const ROLLUP_COUNT = 100_500;
+
+  // Deterministic distribution so every assertion is exact rather than
+  // approximate: each user gets a fixed share of the row count, each row
+  // contributes one unit of cost, and the daily spread is bounded so we can
+  // assert sums per-window without re-counting the fixture.
+  function seedAtScale() {
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      {
+        id: "usr_ivan",
+        org_id: "org_team",
+        role: "manager",
+        api_key: "budi_i",
+        display_name: "Ivan",
+        email: "ivan@example.com",
+      },
+      {
+        id: "usr_jane",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_j",
+        display_name: "Jane",
+        email: "jane@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      { id: "dev_ivan", user_id: "usr_ivan" },
+      { id: "dev_jane", user_id: "usr_jane" },
+    ]);
+
+    // Spread across 60 days (March 1 → April 29) so 7d / 30d / All cleanly
+    // partition the row set and we can reason about subset relationships.
+    fake.seed(
+      "daily_rollups",
+      Array.from({ length: ROLLUP_COUNT }, (_, i) => {
+        const dayIndex = i % 60;
+        const start = new Date(Date.UTC(2026, 2, 1));
+        start.setUTCDate(start.getUTCDate() + dayIndex);
+        const day = start.toISOString().slice(0, 10);
+        return rollup(i % 2 === 0 ? "dev_ivan" : "dev_jane", day, 100, {
+          // Wide cardinality on the rollup PK so a buggy reintroduction of a
+          // 100k cap would truncate rather than coincidentally pass.
+          model: `model-${i % 50}`,
+          repo_id: `repo-${i % 25}`,
+          git_branch: `branch-${i % 1000}`,
+          ticket: `TICKET-${i % 40}`,
+        });
+      })
+    );
+  }
+
+  const manager = {
+    id: "usr_ivan",
+    org_id: "org_team",
+    role: "manager" as const,
+    api_key: "budi_i",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+
+  it("breakdown sums equal Overview total beyond the prior 100k cap", async () => {
+    // Acceptance criterion (a): per-user breakdown sums equal overview total
+    // for the same (user, range).
+    seedAtScale();
+    const range = utcRange("2026-03-01", "2026-04-30");
+
+    const {
+      getOverviewStats,
+      getCostByUser,
+      getCostByDevice,
+      getCostByModel,
+      getCostByRepo,
+      getCostByBranch,
+      getCostByTicket,
+      getDailyActivity,
+    } = await loadDal();
+
+    const overview = await getOverviewStats(manager, range);
+    const expected = ROLLUP_COUNT * 100;
+    expect(overview.totalCostCents).toBe(expected);
+
+    const byUser = await getCostByUser(manager, range);
+    expect(byUser.reduce((s, u) => s + u.cost_cents, 0)).toBe(expected);
+
+    const byDevice = await getCostByDevice(manager, range);
+    expect(byDevice.reduce((s, d) => s + d.cost_cents, 0)).toBe(expected);
+
+    const byModel = await getCostByModel(manager, range);
+    expect(byModel.reduce((s, m) => s + m.cost_cents, 0)).toBe(expected);
+
+    const byRepo = await getCostByRepo(manager, range);
+    expect(byRepo.reduce((s, r) => s + r.cost_cents, 0)).toBe(expected);
+
+    const byBranch = await getCostByBranch(manager, range);
+    expect(byBranch.reduce((s, b) => s + b.cost_cents, 0)).toBe(expected);
+
+    const byTicket = await getCostByTicket(manager, range);
+    expect(byTicket.reduce((s, t) => s + t.cost_cents, 0)).toBe(expected);
+
+    const series = await getDailyActivity(manager, range);
+    expect(series.reduce((s, d) => s + d.cost_cents, 0)).toBe(expected);
+  });
+
+  it("per-user breakdowns are monotonic across 7d ⊆ 30d ⊆ All windows", async () => {
+    // Acceptance criterion (b). Under the prior pull-and-reduce pattern a
+    // wider window could return a *smaller* sum because which rollups
+    // survived the row cap was window-dependent.
+    seedAtScale();
+
+    const { getCostByUser } = await loadDal();
+    const week = await getCostByUser(
+      manager,
+      utcRange("2026-04-23", "2026-04-29")
+    );
+    const month = await getCostByUser(
+      manager,
+      utcRange("2026-03-31", "2026-04-29")
+    );
+    const all = await getCostByUser(
+      manager,
+      utcRange("2026-03-01", "2026-04-30")
+    );
+
+    function ivanCost(rows: Array<{ id: string; cost_cents: number }>) {
+      return rows.find((r) => r.id === "usr_ivan")?.cost_cents ?? 0;
+    }
+    const ivanWeek = ivanCost(week);
+    const ivanMonth = ivanCost(month);
+    const ivanAll = ivanCost(all);
+
+    expect(ivanWeek).toBeGreaterThan(0);
+    expect(ivanMonth).toBeGreaterThanOrEqual(ivanWeek);
+    expect(ivanAll).toBeGreaterThanOrEqual(ivanMonth);
+  });
+
+  it("getDailyActivity covers the full window — no leftmost-day truncation", async () => {
+    // Acceptance criterion: leftmost day equals the seeded earliest day.
+    // The pre-#92 `.order("bucket_day").limit(100_000)` would have silently
+    // dropped the most-recent days at scale, but past 100k rollup rows
+    // matching the predicate the cliff appears regardless of order direction.
+    seedAtScale();
+
+    const { getDailyActivity } = await loadDal();
+    const series = await getDailyActivity(
+      manager,
+      utcRange("2026-03-01", "2026-04-30")
+    );
+
+    expect(series[0].bucket_day).toBe("2026-03-01");
+    expect(series[series.length - 1].bucket_day).toBe("2026-04-29");
+    expect(series).toHaveLength(60);
+  });
+
+  it("a single device's All-window cost equals the sum across its daily activity", async () => {
+    // Acceptance criterion (c): the smoking gun in the bug report — a single
+    // device's total is window/scope-dependent under truncation. Once
+    // aggregation is server-side, the per-device total reconciles with the
+    // per-day series for the same device, scoped or unscoped.
+    seedAtScale();
+
+    const range = utcRange("2026-03-01", "2026-04-30");
+    const { getCostByDevice, getDailyActivity } = await loadDal();
+
+    const byDevice = await getCostByDevice(manager, range);
+    const ivanDeviceCost =
+      byDevice.find((d) => d.id === "dev_ivan")?.cost_cents ?? 0;
+
+    // Same device through the user-scoped path: rollups survive a different
+    // device-id filter and still sum to the same number once aggregation is
+    // server-side. Pre-#92 these two paths diverged because the row cap
+    // truncated each query independently.
+    const scopedSeries = await getDailyActivity(manager, range, {
+      scopedUserId: "usr_ivan",
+    });
+    const scopedTotal = scopedSeries.reduce((s, d) => s + d.cost_cents, 0);
+
+    expect(ivanDeviceCost).toBeGreaterThan(0);
+    expect(ivanDeviceCost).toBe(scopedTotal);
   });
 });
 

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -79,6 +79,10 @@ export async function getCurrentUser(): Promise<BudiUser | null> {
  * Get overview stats visible to the current user.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
  * `options.scopedUserId` further narrows a manager view to a single teammate.
+ *
+ * Aggregation runs server-side via `dashboard_overview_stats` (#92) so the
+ * sums are independent of any PostgREST row cap — `getOverviewStats` and
+ * every breakdown query agree on the same row set regardless of org size.
  */
 export async function getOverviewStats(
   user: BudiUser,
@@ -98,47 +102,41 @@ export async function getOverviewStats(
     };
   }
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select(
-      "cost_cents, input_tokens, output_tokens, message_count, cache_creation_tokens, cache_read_tokens"
-    )
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    // Defeat the default PostgREST max-rows cap so Overview and Team sum the
-    // same complete row set (#15).
-    .limit(100_000);
+  const { data, error } = await admin.rpc("dashboard_overview_stats", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+    p_started_from: range.startedAtFrom,
+    p_started_to: range.startedAtTo,
+  });
+  if (error) throw error;
 
-  const { count: sessionCount } = await admin
-    .from("session_summaries")
-    .select("*", { count: "exact", head: true })
-    .in("device_id", deviceIds)
-    .gte("started_at", range.startedAtFrom)
-    .lte("started_at", range.startedAtTo);
+  const row = (data?.[0] ?? null) as OverviewRow | null;
+  return {
+    totalCostCents: Number(row?.total_cost_cents ?? 0),
+    totalInputTokens: Number(row?.total_input_tokens ?? 0),
+    totalOutputTokens: Number(row?.total_output_tokens ?? 0),
+    totalMessages: Number(row?.total_messages ?? 0),
+    totalSessions: Number(row?.total_sessions ?? 0),
+  };
+}
 
-  const totals = (rollups ?? []).reduce(
-    (acc, r) => ({
-      totalCostCents: acc.totalCostCents + Number(r.cost_cents),
-      totalInputTokens: acc.totalInputTokens + Number(r.input_tokens),
-      totalOutputTokens: acc.totalOutputTokens + Number(r.output_tokens),
-      totalMessages: acc.totalMessages + r.message_count,
-    }),
-    {
-      totalCostCents: 0,
-      totalInputTokens: 0,
-      totalOutputTokens: 0,
-      totalMessages: 0,
-    }
-  );
-
-  return { ...totals, totalSessions: sessionCount ?? 0 };
+interface OverviewRow {
+  total_cost_cents: number | string;
+  total_input_tokens: number | string;
+  total_output_tokens: number | string;
+  total_messages: number | string;
+  total_sessions: number | string;
 }
 
 /**
  * Get daily cost activity for charts.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
  * `options.scopedUserId` further narrows a manager view to a single teammate.
+ *
+ * Aggregation runs server-side via `dashboard_daily_activity` (#92). Prior to
+ * #92 this client-side reduce silently dropped the *oldest* days at the left
+ * edge of the chart once the predicate matched > 100,000 rollup rows.
  */
 export async function getDailyActivity(
   user: BudiUser,
@@ -149,44 +147,30 @@ export async function getDailyActivity(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select(
-      "bucket_day, input_tokens, output_tokens, cost_cents, message_count"
-    )
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    .order("bucket_day")
-    .limit(100_000);
+  const { data, error } = await admin.rpc("dashboard_daily_activity", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
 
-  // Aggregate by day
-  const byDay = new Map<
-    string,
-    {
-      input_tokens: number;
-      output_tokens: number;
-      cost_cents: number;
-      message_count: number;
-    }
-  >();
-  for (const r of rollups ?? []) {
-    const existing = byDay.get(r.bucket_day) ?? {
-      input_tokens: 0,
-      output_tokens: 0,
-      cost_cents: 0,
-      message_count: 0,
-    };
-    existing.input_tokens += Number(r.input_tokens);
-    existing.output_tokens += Number(r.output_tokens);
-    existing.cost_cents += Number(r.cost_cents);
-    existing.message_count += r.message_count;
-    byDay.set(r.bucket_day, existing);
-  }
+  return ((data ?? []) as DailyActivityRow[])
+    .map((r) => ({
+      bucket_day: r.bucket_day,
+      input_tokens: Number(r.input_tokens),
+      output_tokens: Number(r.output_tokens),
+      cost_cents: Number(r.cost_cents),
+      message_count: Number(r.message_count),
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}
 
-  return Array.from(byDay.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([day, data]) => ({ bucket_day: day, ...data }));
+interface DailyActivityRow {
+  bucket_day: string;
+  input_tokens: number | string;
+  output_tokens: number | string;
+  cost_cents: number | string;
+  message_count: number | string;
 }
 
 /**
@@ -240,15 +224,16 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
   const deviceIds = await getVisibleDeviceIds(admin, user);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select("device_id, cost_cents")
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    // Defeat the default PostgREST max-rows cap so we sum every row instead
-    // of a silently-truncated subset.
-    .limit(100_000);
+  // Aggregate rollups server-side (#92). The owner mapping lives in the small,
+  // bounded `devices` + `users` tables, so the secondary join still happens in
+  // JS without risk of row-cap truncation.
+  const { data: rows, error } = await admin.rpc("dashboard_cost_by_device", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
+  const deviceCostRows = (rows ?? []) as DeviceCostRow[];
 
   const { data: devices } = await admin
     .from("devices")
@@ -287,8 +272,8 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
 
   type Bucket = { id: string; name: string; cost_cents: number };
   const byUser = new Map<string, Bucket>();
-  for (const r of rollups ?? []) {
-    const ownerId = deviceToUser.get(r.device_id as string);
+  for (const r of deviceCostRows) {
+    const ownerId = deviceToUser.get(r.device_id);
     const bucketId =
       ownerId && visibleOwnerIds.has(ownerId) ? ownerId : UNASSIGNED_USER_ID;
     const cost = Number(r.cost_cents);
@@ -315,6 +300,11 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
       if (b.id === UNASSIGNED_USER_ID) return -1;
       return b.cost_cents - a.cost_cents;
     });
+}
+
+interface DeviceCostRow {
+  device_id: string;
+  cost_cents: number | string;
 }
 
 interface UserLookup {
@@ -354,14 +344,17 @@ export async function getCostByDevice(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select("device_id, cost_cents")
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    // Match the cap used elsewhere so we never silently truncate the sum.
-    .limit(100_000);
+  // Aggregate rollups server-side (#92). The cap-truncation that #15 / #90
+  // chased lives entirely on the rollup-row pull, so removing that pull is
+  // the fix; the secondary metadata reads below are bounded by org device
+  // count and never exceed the 1k PostgREST default.
+  const { data: rows, error } = await admin.rpc("dashboard_cost_by_device", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
+  const rollups = (rows ?? []) as DeviceCostRow[];
 
   const { data: devices } = await admin
     .from("devices")
@@ -401,10 +394,11 @@ export async function getCostByDevice(
     }
   }
 
+  // The RPC already aggregates by device_id, so each row is a (device, sum)
+  // pair — no further reduction needed.
   const costByDevice = new Map<string, number>();
-  for (const r of rollups ?? []) {
-    const id = r.device_id as string;
-    costByDevice.set(id, (costByDevice.get(id) ?? 0) + Number(r.cost_cents));
+  for (const r of rollups) {
+    costByDevice.set(r.device_id, Number(r.cost_cents));
   }
 
   // Surface every visible device — including zero-cost ones — so a brand-new
@@ -442,35 +436,27 @@ export async function getCostByModel(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select("provider, model, cost_cents")
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    .limit(100_000);
+  const { data, error } = await admin.rpc("dashboard_cost_by_model", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
 
-  const byModel = new Map<
-    string,
-    { provider: string; model: string; cost_cents: number }
-  >();
-  for (const r of rollups ?? []) {
-    const key = `${r.provider}:${r.model}`;
-    const existing = byModel.get(key);
-    if (existing) {
-      existing.cost_cents += Number(r.cost_cents);
-    } else {
-      byModel.set(key, {
-        provider: r.provider,
-        model: r.model,
-        cost_cents: Number(r.cost_cents),
-      });
-    }
-  }
-
-  return Array.from(byModel.values())
+  return ((data ?? []) as ModelCostRow[])
+    .map((r) => ({
+      provider: r.provider,
+      model: r.model,
+      cost_cents: Number(r.cost_cents),
+    }))
     .filter((m) => m.cost_cents > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+interface ModelCostRow {
+  provider: string;
+  model: string;
+  cost_cents: number | string;
 }
 
 /**
@@ -487,23 +473,25 @@ export async function getCostByRepo(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select("repo_id, cost_cents")
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    .limit(100_000);
+  const { data, error } = await admin.rpc("dashboard_cost_by_repo", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
 
-  const byRepo = new Map<string, number>();
-  for (const r of rollups ?? []) {
-    byRepo.set(r.repo_id, (byRepo.get(r.repo_id) ?? 0) + Number(r.cost_cents));
-  }
-
-  return Array.from(byRepo.entries())
-    .map(([repo_id, cost_cents]) => ({ repo_id, cost_cents }))
+  return ((data ?? []) as RepoCostRow[])
+    .map((r) => ({
+      repo_id: r.repo_id,
+      cost_cents: Number(r.cost_cents),
+    }))
     .filter((r) => r.cost_cents > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+interface RepoCostRow {
+  repo_id: string;
+  cost_cents: number | string;
 }
 
 /**
@@ -520,35 +508,27 @@ export async function getCostByBranch(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select("repo_id, git_branch, cost_cents")
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    .limit(100_000);
+  const { data, error } = await admin.rpc("dashboard_cost_by_branch", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
 
-  const byBranch = new Map<
-    string,
-    { repo_id: string; git_branch: string; cost_cents: number }
-  >();
-  for (const r of rollups ?? []) {
-    const key = `${r.repo_id}:${r.git_branch}`;
-    const existing = byBranch.get(key);
-    if (existing) {
-      existing.cost_cents += Number(r.cost_cents);
-    } else {
-      byBranch.set(key, {
-        repo_id: r.repo_id,
-        git_branch: r.git_branch,
-        cost_cents: Number(r.cost_cents),
-      });
-    }
-  }
-
-  return Array.from(byBranch.values())
+  return ((data ?? []) as BranchCostRow[])
+    .map((r) => ({
+      repo_id: r.repo_id,
+      git_branch: r.git_branch,
+      cost_cents: Number(r.cost_cents),
+    }))
     .filter((b) => b.cost_cents > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+interface BranchCostRow {
+  repo_id: string;
+  git_branch: string;
+  cost_cents: number | string;
 }
 
 /**
@@ -565,29 +545,25 @@ export async function getCostByTicket(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return [];
 
-  const { data: rollups } = await admin
-    .from("daily_rollups")
-    .select("ticket, cost_cents")
-    .in("device_id", deviceIds)
-    .gte("bucket_day", range.bucketFrom)
-    .lte("bucket_day", range.bucketTo)
-    .not("ticket", "is", null)
-    .limit(100_000);
+  const { data, error } = await admin.rpc("dashboard_cost_by_ticket", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
 
-  const byTicket = new Map<string, number>();
-  for (const r of rollups ?? []) {
-    if (r.ticket) {
-      byTicket.set(
-        r.ticket,
-        (byTicket.get(r.ticket) ?? 0) + Number(r.cost_cents)
-      );
-    }
-  }
-
-  return Array.from(byTicket.entries())
-    .map(([ticket, cost_cents]) => ({ ticket, cost_cents }))
+  return ((data ?? []) as TicketCostRow[])
+    .map((r) => ({
+      ticket: r.ticket,
+      cost_cents: Number(r.cost_cents),
+    }))
     .filter((t) => t.cost_cents > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+interface TicketCostRow {
+  ticket: string;
+  cost_cents: number | string;
 }
 
 /**

--- a/supabase/migrations/004_dashboard_aggregates.sql
+++ b/supabase/migrations/004_dashboard_aggregates.sql
@@ -1,0 +1,218 @@
+-- Push dashboard aggregation into Postgres (#92).
+--
+-- Before this migration every breakdown query in `src/lib/dal.ts` selected raw
+-- rollup rows over PostgREST (`.from("daily_rollups").select(...)`) and reduced
+-- them to sums in JavaScript. PostgREST imposes a default 1,000-row cap; #15
+-- and #90 successively raised it to `.limit(100_000)` for each query. Real-world
+-- orgs cross 100,000 rollup rows once `device × day × role × provider × model
+-- × repo_id × git_branch` cardinality multiplies out, so the cap recurs and
+-- breakdowns fall non-monotonic across time windows.
+--
+-- The fix is structural: aggregate inside Postgres so no row count is ever
+-- exposed to the app. These functions are called via Supabase RPC. Indexes
+-- already cover the predicate (`daily_rollups` PK leads with `device_id`,
+-- plus `idx_daily_rollups_bucket_day`). Functions are `security definer` so
+-- future non-service-role callers don't lose visibility, but the dashboard
+-- still uses the service-role admin client and the JS-side scoping in
+-- `getVisibleDeviceIds` remains the authoritative gate (per ADR-0083 §6).
+
+-- ============================================================
+-- Overview: totals across rollups + session count.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_overview_stats(
+    p_device_ids   TEXT[],
+    p_bucket_from  DATE,
+    p_bucket_to    DATE,
+    p_started_from TIMESTAMPTZ,
+    p_started_to   TIMESTAMPTZ
+)
+RETURNS TABLE (
+    total_cost_cents     NUMERIC,
+    total_input_tokens   BIGINT,
+    total_output_tokens  BIGINT,
+    total_messages       BIGINT,
+    total_sessions       BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH r AS (
+        SELECT
+            COALESCE(SUM(cost_cents), 0)             AS total_cost_cents,
+            COALESCE(SUM(input_tokens), 0)::BIGINT   AS total_input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT  AS total_output_tokens,
+            COALESCE(SUM(message_count), 0)::BIGINT  AS total_messages
+        FROM daily_rollups
+        WHERE device_id = ANY(p_device_ids)
+          AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    ),
+    s AS (
+        SELECT COUNT(*)::BIGINT AS total_sessions
+        FROM session_summaries
+        WHERE device_id = ANY(p_device_ids)
+          AND started_at BETWEEN p_started_from AND p_started_to
+    )
+    SELECT r.total_cost_cents, r.total_input_tokens, r.total_output_tokens,
+           r.total_messages, s.total_sessions
+    FROM r, s;
+$$;
+
+-- ============================================================
+-- Daily activity series for the Overview chart.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_daily_activity(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    bucket_day     DATE,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT,
+    cost_cents     NUMERIC,
+    message_count  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        SUM(input_tokens)::BIGINT     AS input_tokens,
+        SUM(output_tokens)::BIGINT    AS output_tokens,
+        SUM(cost_cents)               AS cost_cents,
+        SUM(message_count)::BIGINT    AS message_count
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;
+
+-- ============================================================
+-- Per-device cost breakdown. Powers Devices and Team pages
+-- (Team groups by owner in JS using the bounded devices+users tables).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_device(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    device_id  TEXT,
+    cost_cents NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT device_id, SUM(cost_cents) AS cost_cents
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY device_id;
+$$;
+
+-- ============================================================
+-- Per-(provider, model) cost breakdown.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_model(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    provider   TEXT,
+    model      TEXT,
+    cost_cents NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT provider, model, SUM(cost_cents) AS cost_cents
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY provider, model;
+$$;
+
+-- ============================================================
+-- Per-repo cost breakdown.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_repo(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    repo_id    TEXT,
+    cost_cents NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT repo_id, SUM(cost_cents) AS cost_cents
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY repo_id;
+$$;
+
+-- ============================================================
+-- Per-(repo, branch) cost breakdown.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_branch(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    repo_id    TEXT,
+    git_branch TEXT,
+    cost_cents NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT repo_id, git_branch, SUM(cost_cents) AS cost_cents
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY repo_id, git_branch;
+$$;
+
+-- ============================================================
+-- Per-ticket cost breakdown (rows with ticket IS NULL are excluded —
+-- the Tickets table on /dashboard/repos has no "Unassigned" bucket).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_ticket(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    ticket     TEXT,
+    cost_cents NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT ticket, SUM(cost_cents) AS cost_cents
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND ticket IS NOT NULL
+    GROUP BY ticket;
+$$;


### PR DESCRIPTION
## Summary

- Replaces the pull-and-reduce-in-JS pattern in every dashboard breakdown query with a Supabase RPC that aggregates server-side, so no row count is ever exposed to the app.
- Adds `supabase/migrations/004_dashboard_aggregates.sql` with `dashboard_overview_stats`, `dashboard_daily_activity`, and five breakdown functions (`cost_by_device`, `cost_by_model`, `cost_by_repo`, `cost_by_branch`, `cost_by_ticket`). `getCostByUser` reuses `dashboard_cost_by_device` and joins owner metadata against the bounded `devices` + `users` tables.
- Adds a > 100,000-row test fixture that proves the prior cap is gone and asserts monotonicity across `7d ⊆ 30d ⊆ All` plus same-device reconciliation between scoped and unscoped views.

Closes #92.

## Why

PR #90 raised PostgREST's row cap on the breakdown queries from 1,000 to 100,000, but the underlying architecture — pulling raw `daily_rollups` rows and summing in JavaScript — still trips whatever ceiling we pick once `device × day × role × provider × model × repo_id × git_branch` cardinality multiplies out. Real orgs cross 100,000 rollup rows the same way they crossed 1,000, and per-user/device totals drift non-monotonically across nested time windows because *which* rows survived the cap was window-dependent.

The fix is structural: aggregate in Postgres. Indexes already cover the predicate (`daily_rollups` PK leads with `device_id`, plus `idx_daily_rollups_bucket_day`), so this is a planner-friendly change.

## Acceptance criteria

- [x] `daily_rollups` is never read row-by-row by the app for aggregation purposes — `grep 'from("daily_rollups")' src/lib/dal.ts` only matches the `.limit(1)` finders in `getEarliestActivity` and `getSyncFreshness`.
- [x] All eight affected functions call `admin.rpc(...)`.
- [x] Test seeds > 100,000 rollup rows and asserts breakdown sums equal Overview total.
- [x] Test asserts monotonicity of per-user breakdowns across `7d ⊆ 30d ⊆ All`.
- [x] Daily activity chart's leftmost day equals the seeded earliest day at scale.

## Adjacent risk noted

Production audit turned up a related-but-separate scaling concern in `getOrgDeviceIds` (`src/lib/dal.ts:803,815,831`): selects all org users + their devices without an explicit `.limit()`, so the 1,000-row PostgREST default truncates once an org exceeds 1,000 members or 1,000 devices. Different symptom (missing teammates rather than non-monotonic sums) and well below current realistic org sizes — left out of this PR to keep the scope on #92 but worth a follow-up issue.

## Test plan

- [x] `npm test` — 131 / 131 pass, including the new `> 100,000-row` fixture.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Apply `004_dashboard_aggregates.sql` against staging Supabase and verify `EXPLAIN` on each new function picks an indexed scan.
- [ ] Smoke-test `/dashboard`, `/dashboard/team`, `/dashboard/devices`, `/dashboard/models`, `/dashboard/repos` against staging on `7d` / `30d` / `All` and confirm per-user totals are monotonic and reconcile with Overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)