### PR TITLE
chore(supabase): no-op migration to validate deploy pipeline

### DIFF
--- a/supabase/migrations/005_pipeline_validation.sql
+++ b/supabase/migrations/005_pipeline_validation.sql
@@ -1,0 +1,14 @@
+-- No-op migration — validates the deploy pipeline added in #95.
+--
+-- Contains zero DDL on purpose. The point is to exercise:
+--   1. The PR-time `migrations` job in `.github/workflows/ci.yml` (Postgres
+--      service container replays every migration; this file must apply
+--      cleanly).
+--   2. The post-merge `.github/workflows/db-push.yml` workflow
+--      (`supabase db push --include-all` should register version `005`
+--      in the remote `supabase_migrations.schema_migrations` table).
+--
+-- After merging this PR, `supabase migration list --linked` should show
+-- `005` on both Local and Remote. Schema is unchanged either way.
+
+SELECT 1;


### PR DESCRIPTION
End-to-end validation for the workflows added in #95.

## Summary

- Adds `supabase/migrations/005_pipeline_validation.sql` containing only `SELECT 1;` — zero DDL, schema unchanged.

## What this exercises

- **PR time** — the `migrations` job in `.github/workflows/ci.yml` boots a Postgres 15 service container, stubs `auth.uid()`, and replays all migrations. If this PR's CI is green, `005` applies cleanly on a vanilla Postgres.
- **Post-merge** — `.github/workflows/db-push.yml` is gated on `paths: supabase/migrations/**`, so merging this PR should fire the workflow and `supabase db push --include-all` should register version `005` in the remote migration history.

## How to read the result

After merging, the `Apply Supabase migrations` workflow run should show:

- `Push migrations` step exits 0 with `005` listed as newly applied.
- `Show migration list` step prints a table where Local and Remote both have `005`.

If `db push` reports `0 migrations to apply`, that means the prior `migration repair` step in #92's recovery left an inconsistent history — flag and we'll handle the cleanup separately.

## Cleanup

Safe to keep this file in the tree (it's a no-op and serves as the documented first proof point for #94's pipeline). Happy to delete it in a follow-up if the convention is to keep migrations meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)