### PR TITLE
chore(ci): bump supabase/setup-cli to v2 (#97)

### DIFF
--- a/.github/workflows/db-push.yml
+++ b/.github/workflows/db-push.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 


### PR DESCRIPTION
## Summary

- Bumps `supabase/setup-cli` from `@v1` to `@v2` in `.github/workflows/db-push.yml`.
- v2.0.0 (released 2026-04-21) ships as a composite action with no pinned Node runtime, so the workflow stops emitting GitHub's Node 20 deprecation annotation ahead of the **2026-06-02** force-flip and **2026-09-16** Node 20 removal.
- `db-push.yml` is the only consumer of this action in the repo, so no other workflows need touching.

## Test plan

- [ ] After merge, run `gh workflow run db-push.yml --ref main` and confirm:
  - [ ] No Node 20 deprecation annotation in the run logs.
  - [ ] `supabase db push --include-all` succeeds.
  - [ ] `supabase migration list --linked` shows Local == Remote.

Closes #97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)