### PR TITLE
feat(dashboard): surface session vitals on /dashboard/sessions/[id] (#99)

### DIFF
--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -22,6 +22,31 @@ export interface IngestDailyRollup {
   cost_cents: number;
 }
 
+/**
+ * Allowed values for the per-vital traffic-light score (#99). Mirrors the
+ * `Score::{Green,Yellow,Red}` enum on `VitalScore` in budi-core. The cloud
+ * mirrors the column-level CHECK in `006_session_vitals.sql`, but we also
+ * filter at the ingest layer so a malformed envelope never reaches the
+ * database in the first place.
+ */
+export type VitalState = "green" | "yellow" | "red";
+
+const VITAL_STATE_VALUES: ReadonlySet<string> = new Set([
+  "green",
+  "yellow",
+  "red",
+]);
+
+function normalizeVitalState(raw: unknown): VitalState | null {
+  if (typeof raw !== "string") return null;
+  return VITAL_STATE_VALUES.has(raw) ? (raw as VitalState) : null;
+}
+
+function normalizeVitalMetric(raw: unknown): number | null {
+  if (typeof raw !== "number") return null;
+  return Number.isFinite(raw) ? raw : null;
+}
+
 export interface IngestSessionSummary {
   session_id: string;
   provider: string;
@@ -35,6 +60,17 @@ export interface IngestSessionSummary {
   total_input_tokens: number;
   total_output_tokens: number;
   total_cost_cents: number;
+  // Vitals (#99). Optional — older daemons (< 8.3.15) omit these, and budi-core
+  // legitimately skips emission for sessions with too few assistant messages.
+  vital_context_drag_state?: string | null;
+  vital_context_drag_metric?: number | null;
+  vital_cache_efficiency_state?: string | null;
+  vital_cache_efficiency_metric?: number | null;
+  vital_thrashing_state?: string | null;
+  vital_thrashing_metric?: number | null;
+  vital_cost_acceleration_state?: string | null;
+  vital_cost_acceleration_metric?: number | null;
+  vital_overall_state?: string | null;
 }
 
 export function buildRollupRows(
@@ -93,6 +129,27 @@ export function buildSessionRows(
     total_input_tokens: s.total_input_tokens,
     total_output_tokens: s.total_output_tokens,
     total_cost_cents: s.total_cost_cents,
+    // Vitals (#99). Each field is normalized independently so a daemon that
+    // emits e.g. only the overall state (or only some vitals) still lands the
+    // partial signal — the dashboard already renders missing slots as a
+    // dash.
+    vital_context_drag_state: normalizeVitalState(s.vital_context_drag_state),
+    vital_context_drag_metric: normalizeVitalMetric(s.vital_context_drag_metric),
+    vital_cache_efficiency_state: normalizeVitalState(
+      s.vital_cache_efficiency_state
+    ),
+    vital_cache_efficiency_metric: normalizeVitalMetric(
+      s.vital_cache_efficiency_metric
+    ),
+    vital_thrashing_state: normalizeVitalState(s.vital_thrashing_state),
+    vital_thrashing_metric: normalizeVitalMetric(s.vital_thrashing_metric),
+    vital_cost_acceleration_state: normalizeVitalState(
+      s.vital_cost_acceleration_state
+    ),
+    vital_cost_acceleration_metric: normalizeVitalMetric(
+      s.vital_cost_acceleration_metric
+    ),
+    vital_overall_state: normalizeVitalState(s.vital_overall_state),
     synced_at: syncedAt,
   }));
 }

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -1,0 +1,153 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getCurrentUser, getSessionDetail, type VitalState } from "@/lib/dal";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { SessionVitals } from "@/components/session-vitals";
+import { fmtCost, fmtNum, formatDuration, repoName } from "@/lib/format";
+
+/**
+ * Session detail page (#99). The id segment is the daemon-emitted
+ * `session_id`; we also need the `device_id` to resolve a row, since
+ * `(device_id, session_id)` is the composite PK on `session_summaries`.
+ *
+ * Privacy: no prompt / response / file path content is read, written, or
+ * rendered here — see ADR-0083 §1 and `006_session_vitals.sql`. The page
+ * shows numeric metrics + traffic-light scores only.
+ */
+export default async function SessionDetailPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ device?: string }>;
+}) {
+  const user = await getCurrentUser();
+  if (!user?.org_id) return null;
+
+  const { id: sessionId } = await params;
+  const { device: deviceId } = await searchParams;
+  if (!deviceId) {
+    // The composite PK requires both halves; without `device` the page can't
+    // disambiguate two daemons that happen to share a session_id. Send the
+    // viewer back to the list rather than guessing.
+    notFound();
+  }
+
+  const session = await getSessionDetail(user, deviceId, sessionId);
+  if (!session) notFound();
+
+  const totalTokens =
+    Number(session.total_input_tokens) + Number(session.total_output_tokens);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          href="/dashboard/sessions"
+          className="text-sm text-zinc-400 hover:text-zinc-200"
+        >
+          ← Sessions
+        </Link>
+        <h1 className="mt-2 text-xl font-bold">Session {sessionId}</h1>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Session Vitals</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <SessionVitals
+              contextDrag={{
+                state: toState(session.vital_context_drag_state),
+                metric: toMetric(session.vital_context_drag_metric),
+              }}
+              cacheEfficiency={{
+                state: toState(session.vital_cache_efficiency_state),
+                metric: toMetric(session.vital_cache_efficiency_metric),
+              }}
+              thrashing={{
+                state: toState(session.vital_thrashing_state),
+                metric: toMetric(session.vital_thrashing_metric),
+              }}
+              costAcceleration={{
+                state: toState(session.vital_cost_acceleration_state),
+                metric: toMetric(session.vital_cost_acceleration_metric),
+              }}
+              overall={toState(session.vital_overall_state)}
+            />
+            <p className="mt-4 text-xs text-zinc-500">
+              Vitals refresh on the next sync tick — the dashboard does not
+              receive live updates.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Summary</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+              <Field label="Provider" value={session.provider} />
+              <Field
+                label="Started"
+                value={
+                  session.started_at
+                    ? new Date(session.started_at).toLocaleString()
+                    : "-"
+                }
+              />
+              <Field
+                label="Duration"
+                value={formatDuration(
+                  session.duration_ms,
+                  session.started_at,
+                  session.ended_at
+                )}
+              />
+              <Field label="Repo" value={repoName(session.repo_id)} />
+              <Field
+                label="Branch"
+                value={
+                  session.git_branch?.replace(/^refs\/heads\//, "") || "-"
+                }
+              />
+              <Field
+                label="Messages"
+                value={fmtNum(session.message_count)}
+              />
+              <Field label="Tokens" value={fmtNum(totalTokens)} />
+              <Field
+                label="Cost"
+                value={fmtCost(Number(session.total_cost_cents))}
+              />
+            </dl>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wide text-zinc-500">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-zinc-200">{value}</dd>
+    </div>
+  );
+}
+
+function toState(raw: string | null | undefined): VitalState {
+  if (raw === "green" || raw === "yellow" || raw === "red") return raw;
+  return null;
+}
+
+function toMetric(raw: number | string | null | undefined): number | null {
+  if (raw == null) return null;
+  const n = typeof raw === "string" ? Number(raw) : raw;
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -138,7 +138,16 @@ export default async function SessionsPage({
                       key={`${s.device_id}-${s.session_id}`}
                       className="border-b border-white/5"
                     >
-                      <td className="py-2 text-zinc-300">{s.provider}</td>
+                      <td className="py-2 text-zinc-300">
+                        <Link
+                          href={`/dashboard/sessions/${encodeURIComponent(
+                            s.session_id
+                          )}?device=${encodeURIComponent(s.device_id)}`}
+                          className="hover:text-white hover:underline"
+                        >
+                          {s.provider}
+                        </Link>
+                      </td>
                       <td className="py-2 text-zinc-400">
                         {formatTimestamp(s.started_at)}
                       </td>

--- a/src/components/session-vitals.tsx
+++ b/src/components/session-vitals.tsx
@@ -1,0 +1,145 @@
+import { clsx } from "clsx";
+import type { VitalState } from "@/lib/dal";
+
+/**
+ * Vitals panel for `/dashboard/sessions/[id]` (#99). Mirrors the four
+ * CLI-rendered scores from `budi sessions <id>` — Prompt Growth,
+ * Cache Reuse, Retry Loops, Cost Acceleration — plus the rolled-up overall
+ * state. The cloud only ever sees the score and the metric (no prompt /
+ * response content); see ADR-0083 §1 and `006_session_vitals.sql`.
+ *
+ * When *all* vitals are null, the daemon either hasn't been upgraded or the
+ * session was too short to score. We show a single inline notice rather than
+ * five empty rows so the surface stays useful for older daemons.
+ */
+
+export interface SessionVitalsProps {
+  contextDrag: { state: VitalState; metric: number | null };
+  cacheEfficiency: { state: VitalState; metric: number | null };
+  thrashing: { state: VitalState; metric: number | null };
+  costAcceleration: { state: VitalState; metric: number | null };
+  overall: VitalState;
+}
+
+interface VitalRowDef {
+  label: string;
+  /** Short hint shown under the label so a manager who isn't a budi power-user knows what they're looking at. */
+  hint: string;
+  state: VitalState;
+  metric: number | null;
+  /** Format the numeric metric for display ("18.2%/hr", "0.42 retries/turn", …). */
+  format: (m: number) => string;
+}
+
+function fmtPct(n: number): string {
+  return `${n.toFixed(1)}%/hr`;
+}
+
+function fmtRatio(n: number): string {
+  return n.toFixed(2);
+}
+
+function fmtCurrency(n: number): string {
+  return `$${(n / 100).toFixed(2)}/turn`;
+}
+
+export function SessionVitals(props: SessionVitalsProps) {
+  const rows: VitalRowDef[] = [
+    {
+      label: "Prompt Growth",
+      hint: "Context-window growth rate",
+      state: props.contextDrag.state,
+      metric: props.contextDrag.metric,
+      format: fmtPct,
+    },
+    {
+      label: "Cache Reuse",
+      hint: "Cache-read efficiency",
+      state: props.cacheEfficiency.state,
+      metric: props.cacheEfficiency.metric,
+      format: (m) => `${m.toFixed(0)}%`,
+    },
+    {
+      label: "Retry Loops",
+      hint: "Assistant retry / thrashing rate",
+      state: props.thrashing.state,
+      metric: props.thrashing.metric,
+      format: fmtRatio,
+    },
+    {
+      label: "Cost Acceleration",
+      hint: "Cost per assistant turn",
+      state: props.costAcceleration.state,
+      metric: props.costAcceleration.metric,
+      format: fmtCurrency,
+    },
+  ];
+
+  const allEmpty = rows.every((r) => r.state == null) && props.overall == null;
+  if (allEmpty) {
+    return (
+      <p className="text-sm text-zinc-400">
+        Vitals not yet available — upgrade local daemon to ≥ 8.3.15.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium text-zinc-400">Overall</span>
+        <StateBadge state={props.overall} size="lg" />
+      </div>
+      <ul className="divide-y divide-white/5 border-y border-white/10">
+        {rows.map((row) => (
+          <li
+            key={row.label}
+            className="flex items-center justify-between gap-4 py-3"
+          >
+            <div className="min-w-0">
+              <div className="text-sm font-medium text-zinc-200">
+                {row.label}
+              </div>
+              <div className="text-xs text-zinc-500">{row.hint}</div>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="tabular-nums text-sm text-zinc-300">
+                {row.metric != null ? row.format(row.metric) : "—"}
+              </span>
+              <StateBadge state={row.state} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const STATE_STYLES: Record<NonNullable<VitalState>, string> = {
+  green: "bg-emerald-500/15 text-emerald-300 border-emerald-500/30",
+  yellow: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  red: "bg-red-500/15 text-red-300 border-red-500/30",
+};
+
+function StateBadge({
+  state,
+  size = "sm",
+}: {
+  state: VitalState;
+  size?: "sm" | "lg";
+}) {
+  if (state == null) {
+    return <span className="text-xs text-zinc-500">—</span>;
+  }
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center rounded-full border font-medium uppercase tracking-wide",
+        STATE_STYLES[state],
+        size === "lg" ? "px-3 py-1 text-xs" : "px-2 py-0.5 text-[10px]"
+      )}
+    >
+      {state}
+    </span>
+  );
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -1372,6 +1372,126 @@ function splitTopLevel(s: string, sep: string): string[] {
   return parts;
 }
 
+describe("getSessionDetail (#99)", () => {
+  const manager = {
+    id: "usr_ivan",
+    org_id: "org_team",
+    role: "manager" as const,
+    api_key: "budi_i",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+
+  function seedSession(extras: Partial<Row> = {}) {
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [
+      { ...manager },
+      {
+        id: "usr_jane",
+        org_id: "org_team",
+        role: "member",
+        api_key: "budi_j",
+        display_name: "Jane",
+        email: "jane@example.com",
+      },
+      {
+        id: "usr_outsider",
+        org_id: "org_other",
+        role: "manager",
+        api_key: "budi_o",
+        display_name: "Outsider",
+        email: "outsider@example.com",
+      },
+    ]);
+    fake.seed("orgs", [
+      { id: "org_team", name: "team" },
+      { id: "org_other", name: "other" },
+    ]);
+    fake.seed("devices", [
+      { id: "dev_ivan", user_id: "usr_ivan" },
+      { id: "dev_jane", user_id: "usr_jane" },
+      { id: "dev_outsider", user_id: "usr_outsider" },
+    ]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_v",
+        provider: "claude_code",
+        started_at: "2026-04-15T10:00:00.000Z",
+        ended_at: "2026-04-15T11:00:00.000Z",
+        duration_ms: 3_600_000,
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        ticket: null,
+        message_count: 12,
+        total_input_tokens: 2000,
+        total_output_tokens: 800,
+        total_cost_cents: 250,
+        vital_context_drag_state: "yellow",
+        vital_context_drag_metric: 18.2,
+        vital_cache_efficiency_state: "green",
+        vital_cache_efficiency_metric: 87,
+        vital_thrashing_state: "red",
+        vital_thrashing_metric: 0.95,
+        vital_cost_acceleration_state: "yellow",
+        vital_cost_acceleration_metric: 42,
+        vital_overall_state: "red",
+        ...extras,
+      },
+      {
+        device_id: "dev_outsider",
+        session_id: "sess_outsider",
+        provider: "claude_code",
+        started_at: "2026-04-15T10:00:00.000Z",
+      },
+    ]);
+  }
+
+  it("returns the session with vital fields when visible to the viewer", async () => {
+    seedSession();
+    const { getSessionDetail } = await loadDal();
+
+    const detail = await getSessionDetail(manager, "dev_ivan", "sess_v");
+    expect(detail).not.toBeNull();
+    expect(detail?.vital_overall_state).toBe("red");
+    expect(detail?.vital_context_drag_state).toBe("yellow");
+    expect(Number(detail?.vital_context_drag_metric)).toBe(18.2);
+    expect(detail?.vital_cache_efficiency_state).toBe("green");
+    expect(detail?.vital_thrashing_state).toBe("red");
+    expect(detail?.vital_cost_acceleration_state).toBe("yellow");
+  });
+
+  it("returns null for a foreign-org session — collapses with not-found", async () => {
+    // Per ADR-0083 §6: visibility branch must not leak existence of a session
+    // belonging to another org. A 404-equivalent (null) keeps that contract.
+    seedSession();
+    const { getSessionDetail } = await loadDal();
+
+    const detail = await getSessionDetail(
+      manager,
+      "dev_outsider",
+      "sess_outsider"
+    );
+    expect(detail).toBeNull();
+  });
+
+  it("returns null for a member viewer asking about a teammate's session", async () => {
+    seedSession();
+    const { getSessionDetail } = await loadDal();
+
+    const jane = {
+      id: "usr_jane",
+      org_id: "org_team",
+      role: "member" as const,
+      api_key: "budi_j",
+      display_name: "Jane",
+      email: "jane@example.com",
+    };
+    const detail = await getSessionDetail(jane, "dev_ivan", "sess_v");
+    expect(detail).toBeNull();
+  });
+});
+
 describe("getSessions cursor pagination (#85)", () => {
   // Unbounded range so the per-page cursor is the only thing trimming output.
   const wideRange = utcRange("2026-01-01", "2026-12-31");

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -650,7 +650,14 @@ export async function getSessions(
   return { rows, nextCursor };
 }
 
-interface SessionRow {
+/**
+ * One of the four CLI-side `VitalScore` colours, or `null` when the daemon
+ * didn't emit a score for this session (older daemons, or a session with too
+ * few assistant messages — see `006_session_vitals.sql` and #99).
+ */
+export type VitalState = "green" | "yellow" | "red" | null;
+
+export interface SessionRow {
   device_id: string;
   session_id: string;
   provider: string;
@@ -664,6 +671,44 @@ interface SessionRow {
   total_input_tokens: number | string;
   total_output_tokens: number | string;
   total_cost_cents: number | string;
+  // Vitals (#99). Nullable for older daemons / low-signal sessions.
+  vital_context_drag_state?: VitalState;
+  vital_context_drag_metric?: number | string | null;
+  vital_cache_efficiency_state?: VitalState;
+  vital_cache_efficiency_metric?: number | string | null;
+  vital_thrashing_state?: VitalState;
+  vital_thrashing_metric?: number | string | null;
+  vital_cost_acceleration_state?: VitalState;
+  vital_cost_acceleration_metric?: number | string | null;
+  vital_overall_state?: VitalState;
+}
+
+/**
+ * Fetch a single session by `(device_id, session_id)` for the session-detail
+ * page (#99). Returns `null` when the session does not exist *or* when it
+ * exists but is not visible to the viewer (manager: anywhere in the org;
+ * member: only on a device they own — same scoping as `getSessions`). The
+ * "not visible" → `null` branch deliberately collapses with "not found" so
+ * the URL parameter cannot be used to probe whether a foreign-org session
+ * exists.
+ */
+export async function getSessionDetail(
+  user: BudiUser,
+  deviceId: string,
+  sessionId: string
+): Promise<SessionRow | null> {
+  const admin = createAdminClient();
+  const visibleDeviceIds = await getVisibleDeviceIds(admin, user);
+  if (!visibleDeviceIds.includes(deviceId)) return null;
+
+  const { data } = await admin
+    .from("session_summaries")
+    .select("*")
+    .eq("device_id", deviceId)
+    .eq("session_id", sessionId)
+    .maybeSingle();
+
+  return (data as SessionRow | null) ?? null;
 }
 
 /**

--- a/supabase/migrations/006_session_vitals.sql
+++ b/supabase/migrations/006_session_vitals.sql
@@ -1,0 +1,49 @@
+-- Per-session vital scores (#99).
+--
+-- The local CLI renders four vitals on `budi sessions <id>`:
+--   - Prompt Growth      (context-window growth rate)
+--   - Cache Reuse        (cache-read efficiency)
+--   - Retry Loops        (assistant thrashing / retry rate)
+--   - Cost Acceleration  (cost per assistant turn, derivative)
+-- backed by `session_health` in budi-core. The marketing site advertises
+-- these as a budi feature, but the cloud envelope did not carry them, so a
+-- manager looking at the team dashboard could not see *which* sessions were
+-- bloating even though every individual user could see it locally.
+--
+-- This migration extends `session_summaries` with the four state colours,
+-- their numeric metrics, and the rolled-up `overall_state`. Per the privacy
+-- review tracked in ADR-0083 §1, **only** the score (green/yellow/red),
+-- the numeric metric, and the overall state cross the wire — no prompt
+-- content, no per-message data, no file paths.
+--
+-- All columns are NULLABLE because:
+--   1. Older daemons (< 8.3.15) won't emit these fields. The dashboard
+--      degrades by rendering a "Vitals not yet available — upgrade local
+--      daemon to ≥ 8.3.15" notice rather than 5xxing.
+--   2. Sessions with too few assistant messages legitimately have no vital
+--      score to report; budi-core skips emission rather than guessing.
+--
+-- A single CHECK CONSTRAINT pins the four state columns + overall_state to
+-- the colour vocabulary so a daemon-side regression that ships
+-- `"yelllow"` (sic) gets bounced at write time rather than silently
+-- rendering as an unknown badge.
+
+ALTER TABLE session_summaries
+    ADD COLUMN vital_context_drag_state       TEXT,
+    ADD COLUMN vital_context_drag_metric      NUMERIC(12,4),
+    ADD COLUMN vital_cache_efficiency_state   TEXT,
+    ADD COLUMN vital_cache_efficiency_metric  NUMERIC(12,4),
+    ADD COLUMN vital_thrashing_state          TEXT,
+    ADD COLUMN vital_thrashing_metric         NUMERIC(12,4),
+    ADD COLUMN vital_cost_acceleration_state  TEXT,
+    ADD COLUMN vital_cost_acceleration_metric NUMERIC(12,4),
+    ADD COLUMN vital_overall_state            TEXT;
+
+ALTER TABLE session_summaries
+    ADD CONSTRAINT session_summaries_vital_states_check CHECK (
+        (vital_context_drag_state      IS NULL OR vital_context_drag_state      IN ('green', 'yellow', 'red'))
+        AND (vital_cache_efficiency_state  IS NULL OR vital_cache_efficiency_state  IN ('green', 'yellow', 'red'))
+        AND (vital_thrashing_state         IS NULL OR vital_thrashing_state         IN ('green', 'yellow', 'red'))
+        AND (vital_cost_acceleration_state IS NULL OR vital_cost_acceleration_state IN ('green', 'yellow', 'red'))
+        AND (vital_overall_state           IS NULL OR vital_overall_state           IN ('green', 'yellow', 'red'))
+    );


### PR DESCRIPTION
Closes #99 (cloud half — the daemon envelope extension is tracked in [siropkin/budi#602](https://github.com/siropkin/budi/issues/602)).

## Summary
- Adds `/dashboard/sessions/[id]?device=…` with a vitals panel mirroring the CLI: Prompt Growth, Cache Reuse, Retry Loops, Cost Acceleration, and the rolled-up overall state.
- Extends `session_summaries` with nullable vital state + numeric metric columns (`006_session_vitals.sql`). State columns are pinned to `green/yellow/red` via a CHECK so a daemon-side typo bounces at write time rather than silently rendering as an unknown badge.
- Ingest accepts the new optional fields per session, normalising unknown states to `null` so a malformed envelope never reaches Postgres. Older daemons that omit the fields keep working unchanged.
- DAL gains `getSessionDetail`, scoped the same way as `getSessions` (manager: org-wide; member: own devices only). Foreign-org and out-of-scope lookups collapse to `null` to avoid leaking session existence (ADR-0083 §6).
- Sessions list now links each row into the detail page from the provider cell.
- When a session has no vitals at all, the panel renders a single "Vitals not yet available — upgrade local daemon to ≥ 8.3.15" notice inline rather than five empty rows.

## Privacy
Only the score (`green/yellow/red`) and the numeric metric traverse the new fields. No prompt content, no per-message data, no file paths (ADR-0083 §1). New columns are added to the existing `session_summaries` table so the same RLS / org-scoping rules apply unchanged.

## Test plan
- [x] `npm test` (134 passed) — adds `getSessionDetail` coverage incl. foreign-org and member visibility paths.
- [x] `npm run lint`
- [x] `npm run build` — new `/dashboard/sessions/[id]` route registers as expected.
- [ ] Manual: with a local daemon ≥ 8.3.15 (when available), verify each of the four state colours renders correctly.
- [ ] Manual: confirm older-daemon sessions render the upgrade notice instead of the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)