### PR TITLE
test(dashboard): render test for SessionVitals state classes (#102)

### DIFF
--- a/src/components/session-vitals.test.tsx
+++ b/src/components/session-vitals.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SessionVitals } from "@/components/session-vitals";
+
+// We render to static HTML rather than pulling in React Testing Library —
+// the goal here is to lock down the green/yellow/red Tailwind class map in
+// `STATE_STYLES`, so a stringly diff over the markup is enough.
+function row(label: string, html: string): string {
+  const block = html
+    .split("<li")
+    .slice(1)
+    .map((b) => "<li" + b)
+    .find((b) => b.includes(label));
+  if (!block) throw new Error(`row for "${label}" not found in markup`);
+  return block;
+}
+
+describe("SessionVitals", () => {
+  it("renders every row with emerald classes when all vitals are green", () => {
+    const html = renderToStaticMarkup(
+      <SessionVitals
+        contextDrag={{ state: "green", metric: 18.2 }}
+        cacheEfficiency={{ state: "green", metric: 90 }}
+        thrashing={{ state: "green", metric: 0.42 }}
+        costAcceleration={{ state: "green", metric: 250 }}
+        overall="green"
+      />
+    );
+
+    // 4 row badges + 1 overall badge = 5 emerald hits, no amber, no red.
+    expect(html.match(/emerald-500\/15/g)?.length).toBe(5);
+    expect(html).not.toMatch(/amber-500\/15/);
+    expect(html).not.toMatch(/red-500\/15/);
+    // Each badge carries its accessible state text ("green") in the body.
+    expect(html.match(/>green</g)?.length).toBe(5);
+  });
+
+  it("picks the right state class per row when vitals are mixed", () => {
+    const html = renderToStaticMarkup(
+      <SessionVitals
+        contextDrag={{ state: "green", metric: 5 }}
+        cacheEfficiency={{ state: "yellow", metric: 60 }}
+        thrashing={{ state: "red", metric: 1.5 }}
+        costAcceleration={{ state: "green", metric: 250 }}
+        overall="yellow"
+      />
+    );
+
+    expect(row("Prompt Growth", html)).toMatch(/emerald-500\/15/);
+    expect(row("Cache Reuse", html)).toMatch(/amber-500\/15/);
+    expect(row("Cache Reuse", html)).toMatch(/>yellow</);
+    expect(row("Retry Loops", html)).toMatch(/red-500\/15/);
+    expect(row("Retry Loops", html)).toMatch(/>red</);
+    expect(row("Cost Acceleration", html)).toMatch(/emerald-500\/15/);
+
+    // Overall badge sits outside any <li>; it should also be amber here.
+    const beforeFirstLi = html.split("<li")[0];
+    expect(beforeFirstLi).toMatch(/amber-500\/15/);
+  });
+
+  it("renders the upgrade-daemon notice when every vital is null", () => {
+    const html = renderToStaticMarkup(
+      <SessionVitals
+        contextDrag={{ state: null, metric: null }}
+        cacheEfficiency={{ state: null, metric: null }}
+        thrashing={{ state: null, metric: null }}
+        costAcceleration={{ state: null, metric: null }}
+        overall={null}
+      />
+    );
+
+    expect(html).toContain(
+      "Vitals not yet available — upgrade local daemon to ≥ 8.3.15."
+    );
+    // No badges, no row scaffolding.
+    expect(html).not.toMatch(/emerald-500\/15/);
+    expect(html).not.toMatch(/amber-500\/15/);
+    expect(html).not.toMatch(/red-500\/15/);
+    expect(html).not.toContain("<li");
+    expect(html).not.toContain("Prompt Growth");
+  });
+
+  it("formats each metric with its expected suffix", () => {
+    const html = renderToStaticMarkup(
+      <SessionVitals
+        contextDrag={{ state: "green", metric: 18.2 }}
+        cacheEfficiency={{ state: "green", metric: 90 }}
+        thrashing={{ state: "green", metric: 0.42 }}
+        costAcceleration={{ state: "green", metric: 250 }}
+        overall="green"
+      />
+    );
+
+    expect(row("Prompt Growth", html)).toContain("18.2%/hr");
+    expect(row("Cache Reuse", html)).toContain("90%");
+    expect(row("Retry Loops", html)).toContain("0.42");
+    expect(row("Cost Acceleration", html)).toContain("$2.50/turn");
+  });
+
+  it("falls back to an em-dash when a single metric is null", () => {
+    const html = renderToStaticMarkup(
+      <SessionVitals
+        contextDrag={{ state: "green", metric: null }}
+        cacheEfficiency={{ state: "green", metric: 90 }}
+        thrashing={{ state: "green", metric: 0.42 }}
+        costAcceleration={{ state: "green", metric: 250 }}
+        overall="green"
+      />
+    );
+
+    expect(row("Prompt Growth", html)).toContain("—");
+    expect(row("Prompt Growth", html)).toMatch(/emerald-500\/15/);
+  });
+});


### PR DESCRIPTION
Closes #102.

## Summary

- New `src/components/session-vitals.test.tsx` exercises the green / yellow / red branches of `STATE_STYLES` end-to-end through the rendered markup, plus the all-null upgrade-daemon fallback path that #100 left uncovered.
- Asserts the four metric formatters render with their expected suffixes (`%/hr`, `%`, ratio, `$…/turn`) and that a single-row null metric still falls through to the em-dash while keeping its state badge.
- Uses `react-dom/server.renderToStaticMarkup` rather than pulling in React Testing Library — this is purely a class/string regression net, and the existing `vitest` `node` environment already supports it without new deps.

## Test plan

- [x] `npm test` — 139 passing (5 new in `SessionVitals`, all prior suites unaffected).
- [x] `npm run lint` — clean.
- [x] `npx prettier --check src/components/session-vitals.test.tsx` — clean.
- [x] Spot-check the acceptance criterion: renaming a key in `STATE_STYLES` (e.g. `green` → `ok`) flips `>green</` to `>ok</` and the `emerald-500/15` count drops, both of which are asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)