### PR TITLE
fix(dashboard): tone down chart hover cursor to match dark theme (#107)

### DIFF
--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -102,6 +102,7 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
           }}
         />
         <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
           contentStyle={{
             background: "#18181b",
             border: "1px solid rgba(255,255,255,0.1)",

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -100,6 +100,7 @@ export function CostBarChart({
           tick={{ fill: "#71717a", fontSize: 12 }}
         />
         <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
           contentStyle={{
             background: "#18181b",
             border: "1px solid rgba(255,255,255,0.1)",


### PR DESCRIPTION
## Summary

- Fixes #107.
- recharts ships a default `rgba(204,204,204,0.5)` `<Tooltip>` cursor that paints a near-white block behind the hovered bar/row. Against the dark dashboard theme it reads as a glaring light-gray overlay rather than a subtle hover affordance.
- Two charts were affected: the **Daily Activity (Tokens)** vertical bar chart on `/dashboard` and the **Cost by Project** horizontal bar chart on `/dashboard/repos`. Neither passed an explicit `cursor` prop.
- Pass `cursor={{ fill: "rgba(255,255,255,0.05)" }}` on both `<Tooltip>` instances so the hover backdrop matches the `hover:bg-white/5` tint used elsewhere on the dashboard (sessions row hover, sidebar, settings buttons, etc.).
- No bar colors, tooltip popover styling, or layout changes — only the hover backdrop, as called out in the ticket's "Out of scope".

## Test plan

- [ ] `npm run lint` is clean.
- [ ] `npm test` — 139 tests pass.
- [ ] Hover a day on `/dashboard` Daily Activity chart: backdrop is a faint white tint, not a glaring light-gray column.
- [ ] Hover a row on `/dashboard/repos` Cost by Project chart: backdrop is a faint white tint, not a light-gray strip.
- [ ] Tooltip popover styling (dark `#18181b` background, white/10 border) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)