### PR TITLE
test(dashboard): add page-level tests for dashboard pages (#112)

### DIFF
--- a/src/app/dashboard/models/page.test.tsx
+++ b/src/app/dashboard/models/page.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard/models` (#112).
+ */
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/viewer-timezone", () => ({
+  getViewerTimeZone: async () => "UTC",
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getCostByModel: vi.fn(),
+  getEarliestActivity: vi.fn(),
+  getOrgMembers: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+beforeEach(() => {
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getCostByModel.mockReset().mockResolvedValue([
+    {
+      provider: "claude_code",
+      model: "claude-sonnet-4-5",
+      cost_cents: 800_00,
+    },
+  ]);
+  dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
+  dal.getOrgMembers.mockReset().mockResolvedValue([]);
+});
+
+async function render(searchParams: Record<string, string> = {}) {
+  const mod = await import("./page");
+  return mod.default({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe("dashboard/models /page", () => {
+  it("smoke: renders the headline + the Cost by Model card with populated DAL data", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Models");
+    expect(text).toContain("Cost by Model");
+  });
+
+  it("empty: renders the chart's empty-state copy when the DAL returns no models", async () => {
+    dal.getCostByModel.mockResolvedValue([]);
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("No model data for this period");
+  });
+
+  it("loading: composes a Suspense boundary around the filter cluster", async () => {
+    const node = await render();
+    expect(containsSuspense(node)).toBe(true);
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getCostByModel.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard` (the Overview page).
+ *
+ * Locks in four contracts the recent dashboard PRs have shipped without
+ * page-level integration tests (#112):
+ *   1. Smoke — the page renders against a populated DAL response.
+ *   2. Empty — empty totals + empty activity series render the page chrome
+ *      instead of crashing on a missing field.
+ *   3. Loading — the page composes a `<Suspense>` boundary around the
+ *      filter cluster so the rest of the tree streams while filters load.
+ *   4. Error — DAL faults propagate so the framework's error boundary can
+ *      render its fallback (rather than the page silently rendering empty).
+ */
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/viewer-timezone", () => ({
+  getViewerTimeZone: async () => "UTC",
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getOverviewStats: vi.fn(),
+  getDailyActivity: vi.fn(),
+  getEarliestActivity: vi.fn(),
+  getOrgMembers: vi.fn(),
+  getSyncFreshness: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+beforeEach(() => {
+  for (const fn of Object.values(dal)) fn.mockReset();
+  dal.getCurrentUser.mockResolvedValue(MANAGER);
+  dal.getOverviewStats.mockResolvedValue({
+    totalCostCents: 1_234_56,
+    totalInputTokens: 4000,
+    totalOutputTokens: 2000,
+    totalMessages: 17,
+    totalSessions: 5,
+  });
+  dal.getDailyActivity.mockResolvedValue([
+    {
+      bucket_day: "2026-04-15",
+      input_tokens: 4000,
+      output_tokens: 2000,
+      cost_cents: 1_234_56,
+      message_count: 17,
+    },
+  ]);
+  dal.getEarliestActivity.mockResolvedValue("2026-04-01");
+  dal.getOrgMembers.mockResolvedValue([]);
+  dal.getSyncFreshness.mockResolvedValue({
+    deviceCount: 1,
+    lastSeenAt: "2026-04-15T10:00:00Z",
+    lastRollupAt: "2026-04-15T10:00:00Z",
+    lastSessionAt: "2026-04-15T10:00:00Z",
+  });
+});
+
+async function render(searchParams: Record<string, string> = {}) {
+  const mod = await import("./page");
+  return mod.default({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe("dashboard /page (Overview)", () => {
+  it("smoke: renders headline, stat cards, and the daily-activity card with populated DAL data", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Overview");
+    expect(text).toContain("Daily Activity (Tokens)");
+    // The four stat-card titles are part of the page's primary contract.
+    expect(text).toContain("Total Cost");
+    expect(text).toContain("Total Tokens");
+    expect(text).toContain("Messages");
+    expect(text).toContain("Sessions");
+  });
+
+  it("empty: renders headline + zero-value stat cards (not a crash) when the org has no devices yet", async () => {
+    dal.getOverviewStats.mockResolvedValue({
+      totalCostCents: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalMessages: 0,
+      totalSessions: 0,
+    });
+    dal.getDailyActivity.mockResolvedValue([]);
+    dal.getSyncFreshness.mockResolvedValue({
+      deviceCount: 0,
+      lastSeenAt: null,
+      lastRollupAt: null,
+      lastSessionAt: null,
+    });
+
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    // Page deliberately distinguishes "no devices" from "no data" — the
+    // empty-org case must still render the headline + stat cards (zero
+    // values), not throw.
+    expect(text).toContain("Overview");
+    expect(text).toContain("Total Cost");
+  });
+
+  it("loading: composes a Suspense boundary around the filter cluster so the page can stream", async () => {
+    const node = await render();
+    expect(containsSuspense(node)).toBe(true);
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getOverviewStats.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/app/dashboard/repos/page.test.tsx
+++ b/src/app/dashboard/repos/page.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard/repos` (#112).
+ */
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/viewer-timezone", () => ({
+  getViewerTimeZone: async () => "UTC",
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getCostByRepo: vi.fn(),
+  getCostByBranch: vi.fn(),
+  getCostByTicket: vi.fn(),
+  getEarliestActivity: vi.fn(),
+  getOrgMembers: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+beforeEach(() => {
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getCostByRepo
+    .mockReset()
+    .mockResolvedValue([{ repo_id: "repo_x", cost_cents: 800_00 }]);
+  dal.getCostByBranch
+    .mockReset()
+    .mockResolvedValue([
+      { repo_id: "repo_x", git_branch: "refs/heads/main", cost_cents: 600_00 },
+    ]);
+  dal.getCostByTicket
+    .mockReset()
+    .mockResolvedValue([{ ticket: "TICKET-1", cost_cents: 200_00 }]);
+  dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
+  dal.getOrgMembers.mockReset().mockResolvedValue([]);
+});
+
+async function render(searchParams: Record<string, string> = {}) {
+  const mod = await import("./page");
+  return mod.default({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe("dashboard/repos /page", () => {
+  it("smoke: renders all three cards (Project / Branch / Ticket) with populated DAL data", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Repos");
+    expect(text).toContain("Cost by Project");
+    expect(text).toContain("Cost by Branch");
+    expect(text).toContain("Cost by Ticket");
+  });
+
+  it("empty: renders all three empty-state copies when every breakdown is empty", async () => {
+    dal.getCostByRepo.mockResolvedValue([]);
+    dal.getCostByBranch.mockResolvedValue([]);
+    dal.getCostByTicket.mockResolvedValue([]);
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("No project data for this period");
+    expect(text).toContain("No branch data for this period");
+    expect(text).toContain("No ticket data for this period");
+  });
+
+  it("loading: composes a Suspense boundary around the filter cluster", async () => {
+    const node = await render();
+    expect(containsSuspense(node)).toBe(true);
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getCostByRepo.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard/sessions/[id]` (#99 + #112).
+ *
+ * Locks in:
+ *   1. Smoke — populated `getSessionDetail` renders the back link, vitals
+ *      card, and summary fields.
+ *   2. Empty — a missing `device` query param 404s rather than silently
+ *      guessing (the composite PK requires both halves).
+ *   3. Loading — there's no Suspense on this page; instead we pin the
+ *      back-link round-trip contract that survives the loading→detail→back
+ *      navigation (#101).
+ *   4. Error — DAL faults propagate so the framework error boundary fires.
+ */
+
+vi.mock("server-only", () => ({}));
+const notFoundMock = vi.fn(() => {
+  throw new Error("__NOT_FOUND__");
+});
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => notFoundMock(),
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getSessionDetail: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+const SESSION = {
+  device_id: "dev_ivan",
+  session_id: "sess_v",
+  provider: "claude_code",
+  started_at: "2026-04-15T10:00:00.000Z",
+  ended_at: "2026-04-15T11:00:00.000Z",
+  duration_ms: 3_600_000,
+  repo_id: "repo_x",
+  git_branch: "refs/heads/main",
+  ticket: null,
+  message_count: 12,
+  total_input_tokens: 2000,
+  total_output_tokens: 800,
+  total_cost_cents: 250,
+  vital_context_drag_state: "yellow" as const,
+  vital_context_drag_metric: 18.2,
+  vital_cache_efficiency_state: "green" as const,
+  vital_cache_efficiency_metric: 87,
+  vital_thrashing_state: "red" as const,
+  vital_thrashing_metric: 0.95,
+  vital_cost_acceleration_state: "yellow" as const,
+  vital_cost_acceleration_metric: 42,
+  vital_overall_state: "red" as const,
+};
+
+beforeEach(() => {
+  notFoundMock.mockClear();
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getSessionDetail.mockReset().mockResolvedValue(SESSION);
+});
+
+async function render(
+  id: string = "sess_v",
+  searchParams: Record<string, string> = { device: "dev_ivan" }
+) {
+  const mod = await import("./page");
+  return mod.default({
+    params: Promise.resolve({ id }),
+    searchParams: Promise.resolve(searchParams),
+  });
+}
+
+/**
+ * The back link is rendered as a Next `<Link>` whose `href` is a prop, not a
+ * child — so it doesn't show up in `extractText`. Walk the tree to pluck the
+ * Sessions back-link href explicitly.
+ */
+function findSessionsBackHref(node: unknown): string | null {
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): string | null {
+    if (!n || typeof n !== "object") return null;
+    if (seen.has(n as object)) return null;
+    seen.add(n as object);
+    if (Array.isArray(n)) {
+      for (const c of n) {
+        const found = walk(c);
+        if (found) return found;
+      }
+      return null;
+    }
+    const el = n as {
+      props?: { href?: string; children?: unknown };
+    };
+    const href = el.props?.href;
+    if (
+      typeof href === "string" &&
+      (href === "/dashboard/sessions" ||
+        href.startsWith("/dashboard/sessions?"))
+    ) {
+      return href;
+    }
+    return walk(el.props?.children);
+  }
+  return walk(node);
+}
+
+describe("dashboard/sessions/[id] /page", () => {
+  it("smoke: renders the back link, Session Vitals card, and Summary fields", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("← Sessions");
+    expect(text).toContain("Session Vitals");
+    expect(text).toContain("Summary");
+    // Lock down the summary field labels so a refactor that drops one shows up.
+    for (const label of [
+      "Provider",
+      "Started",
+      "Duration",
+      "Repo",
+      "Branch",
+      "Messages",
+      "Tokens",
+      "Cost",
+    ]) {
+      expect(text).toContain(label);
+    }
+  });
+
+  it("empty: 404s when the `device` query param is missing — composite PK can't be resolved", async () => {
+    await expect(render("sess_v", {})).rejects.toThrow("__NOT_FOUND__");
+    expect(notFoundMock).toHaveBeenCalled();
+    // Must not have called the DAL at all — bail before any visibility probe
+    // so we don't leak existence of a session via timing/error shape.
+    expect(dal.getSessionDetail).not.toHaveBeenCalled();
+  });
+
+  it("empty: 404s for a session not visible to the viewer (DAL returns null)", async () => {
+    // Per ADR-0083 §6: a foreign-org session collapses with not-found rather
+    // than leaking existence. The page-level contract for that is `notFound()`.
+    dal.getSessionDetail.mockResolvedValue(null);
+    await expect(render()).rejects.toThrow("__NOT_FOUND__");
+    expect(notFoundMock).toHaveBeenCalled();
+  });
+
+  it("loading: round-trips list-page filters onto the back link so loading→detail→back preserves state", async () => {
+    // The page has no Suspense of its own — instead, the load-aware contract
+    // is that filters survive the round-trip (#101). Pin it here since this
+    // is the loading-state behavior users actually see.
+    const node = await render("sess_v", {
+      device: "dev_ivan",
+      days: "7",
+      user: "usr_jane",
+      cursor: "abc",
+      p: "2",
+    });
+    const href = findSessionsBackHref(node);
+    expect(href).not.toBeNull();
+    expect(href).toContain("days=7");
+    expect(href).toContain("user=usr_jane");
+    expect(href).toContain("cursor=abc");
+    expect(href).toContain("p=2");
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getSessionDetail.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard/sessions`.
+ *
+ * The sessions surface has been the busiest area of the codebase recently
+ * (5 of the last 5 merged PRs touched it), and shipped without page-level
+ * coverage. This pins the four contracts called out in #112:
+ *   1. Smoke — populated session rows render the table headers + filter cluster.
+ *   2. Empty — empty `rows` renders the "No sessions found" copy without
+ *      throwing on the missing pagination range.
+ *   3. Loading — `<Suspense>` wraps the filter cluster so the table can stream.
+ *   4. Error — DAL faults propagate so the framework error boundary takes over.
+ */
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/viewer-timezone", () => ({
+  getViewerTimeZone: async () => "UTC",
+}));
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getEarliestActivity: vi.fn(),
+  getOrgMembers: vi.fn(),
+  getSessions: vi.fn(),
+  SESSIONS_PAGE_SIZE: 50,
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+beforeEach(() => {
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
+  dal.getOrgMembers.mockReset().mockResolvedValue([]);
+  dal.getSessions.mockReset().mockResolvedValue({
+    rows: [
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_a",
+        provider: "claude_code",
+        started_at: "2026-04-15T10:00:00.000Z",
+        ended_at: "2026-04-15T11:00:00.000Z",
+        duration_ms: 3_600_000,
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        ticket: null,
+        message_count: 12,
+        total_input_tokens: 2000,
+        total_output_tokens: 800,
+        total_cost_cents: 250,
+      },
+    ],
+    nextCursor: null,
+  });
+});
+
+async function render(searchParams: Record<string, string> = {}) {
+  const mod = await import("./page");
+  return mod.default({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe("dashboard/sessions /page", () => {
+  it("smoke: renders the table with headers + a session row when DAL returns rows", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Sessions");
+    expect(text).toContain("Recent Sessions");
+    // Lock down the column contract so a regression that drops one shows up.
+    for (const col of [
+      "Provider",
+      "Started",
+      "Duration",
+      "Repo",
+      "Branch",
+      "Messages",
+      "Tokens",
+      "Cost",
+    ]) {
+      expect(text).toContain(col);
+    }
+  });
+
+  it("empty: renders the 'No sessions' empty-state copy and skips pagination chrome", async () => {
+    dal.getSessions.mockResolvedValue({ rows: [], nextCursor: null });
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("No sessions found");
+    // The "← Newest" / "Older →" labels live in the pagination nav — neither
+    // should render when there are no rows + no next cursor.
+    expect(text).not.toContain("Newest");
+    expect(text).not.toContain("Older");
+  });
+
+  it("loading: composes a Suspense boundary around the filter cluster so the table can stream", async () => {
+    const node = await render();
+    expect(containsSuspense(node)).toBe(true);
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getSessions.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/app/dashboard/settings/page.test.tsx
+++ b/src/app/dashboard/settings/page.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard/settings` (#112).
+ *
+ * The settings page is the only dashboard page that bypasses the DAL for
+ * one of its reads (`createAdminClient().from("orgs").select(...)`), so the
+ * mock surface here is split across `@/lib/dal` and `@/lib/supabase/admin`.
+ */
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getOrgMembers: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const orgRow = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: () => orgRow(),
+        }),
+      }),
+    }),
+  }),
+}));
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+beforeEach(() => {
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getOrgMembers.mockReset().mockResolvedValue([
+    {
+      id: "usr_ivan",
+      display_name: "Ivan",
+      email: "ivan@example.com",
+      role: "manager",
+    },
+    {
+      id: "usr_jane",
+      display_name: "Jane",
+      email: "jane@example.com",
+      role: "member",
+    },
+  ]);
+  orgRow.mockReset().mockResolvedValue({
+    data: { id: "org_team", name: "Acme" },
+    error: null,
+  });
+});
+
+async function render() {
+  const mod = await import("./page");
+  return mod.default();
+}
+
+describe("dashboard/settings /page", () => {
+  it("smoke: renders Organization, API Key, and Team Members sections with populated data", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Settings");
+    expect(text).toContain("Organization");
+    expect(text).toContain("Acme");
+    // The team members section header includes the count — pin it so a
+    // refactor that drops the count or the header is caught.
+    expect(text).toContain("Team Members");
+    expect(text).toContain("2");
+    expect(text).toContain("Ivan");
+    expect(text).toContain("Jane");
+  });
+
+  it("empty: renders the 'No members yet' copy when the org has no members", async () => {
+    dal.getOrgMembers.mockResolvedValue([]);
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Team Members");
+    expect(text).toContain("0");
+    expect(text).toContain("No members yet");
+  });
+
+  it("loading: pins the no-Suspense contract — settings has no period-driven data, so it ships without a streaming boundary", async () => {
+    // The other dashboard pages wrap their filter cluster in `<Suspense>`
+    // so the page can stream while filters resolve. Settings has no
+    // searchParams-driven UI, so it intentionally skips that boundary.
+    // Pin the absence so a future change adds it deliberately rather than
+    // by accident — and so the test grid stays parallel with #112's spec.
+    const node = await render();
+    expect(node).toBeTruthy();
+    expect(containsSuspense(node)).toBe(false);
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getOrgMembers.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/app/dashboard/team/page.test.tsx
+++ b/src/app/dashboard/team/page.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+/**
+ * Page-level coverage for `/dashboard/team` (#112).
+ *
+ * Defense-in-depth ladder is the moving part to lock down here:
+ *   1. Smoke — manager view renders Team headline, chart card, and member table.
+ *   2. Empty — empty `getCostByUser` still renders the chart-empty fallback.
+ *   3. Loading — `<Suspense>` wraps the period selector.
+ *   4. Error — DAL faults propagate so the framework error boundary fires.
+ *   5. Members are redirected to /dashboard (ADR-0083 §6).
+ */
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/viewer-timezone", () => ({
+  getViewerTimeZone: async () => "UTC",
+}));
+
+const redirectMock = vi.fn((to: string) => {
+  throw new Error(`__REDIRECT__:${to}`);
+});
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => redirectMock(to),
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getCostByUser: vi.fn(),
+  getEarliestActivity: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  org_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+beforeEach(() => {
+  redirectMock.mockClear();
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getCostByUser.mockReset().mockResolvedValue([
+    { id: "usr_ivan", name: "Ivan", cost_cents: 2_500_00 },
+    { id: "usr_jane", name: "Jane", cost_cents: 1_500_00 },
+  ]);
+  dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
+});
+
+async function render(searchParams: Record<string, string> = {}) {
+  const mod = await import("./page");
+  return mod.default({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe("dashboard/team /page", () => {
+  it("smoke: renders Team headline, the cost chart, and the member table", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Team");
+    expect(text).toContain("Cost by Team Member");
+    expect(text).toContain("Team Members");
+    expect(text).toContain("Ivan");
+    expect(text).toContain("Jane");
+  });
+
+  it("empty: renders the chart's empty-state copy and skips the member table", async () => {
+    dal.getCostByUser.mockResolvedValue([]);
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("No team cost data for this period");
+    // Members table is gated on `userCosts.length > 0` — must not render here.
+    expect(text).not.toContain("Team Members");
+  });
+
+  it("loading: composes a Suspense boundary around the filter cluster", async () => {
+    const node = await render();
+    expect(containsSuspense(node)).toBe(true);
+  });
+
+  it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
+    dal.getCostByUser.mockRejectedValue(new Error("__DAL_BOOM__"));
+    await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("redirects members to /dashboard (ADR-0083 §6 — page is self-only for non-managers)", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, role: "member" });
+    await expect(render()).rejects.toThrow("__REDIRECT__:/dashboard");
+    expect(redirectMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("returns null (no leak) when the viewer has no org_id yet", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+});

--- a/src/test-utils/page-tree.ts
+++ b/src/test-utils/page-tree.ts
@@ -1,0 +1,113 @@
+// Test-only helpers for inspecting an async server component's returned
+// React tree. Page-level tests in src/app/**/page.test.tsx import these so
+// they avoid round-tripping through JSON.stringify (which trips on Next's
+// lazy/circular references) without pulling in React Testing Library.
+//
+// Lives under src/test-utils/ — the directory is excluded from production
+// bundles by virtue of every consumer being a *.test.tsx file.
+
+import type { ReactElement } from "react";
+
+type Node = unknown;
+
+/**
+ * Concatenate every string/number child reachable from `node` into a single
+ * search-friendly haystack. Walks `props.children` recursively, guards
+ * against cycles, and tolerates `null` / `undefined` / boolean leaves the
+ * way React itself does. The result is a whitespace-separated bag-of-words
+ * — order is preserved, but layout characters (newlines, indentation) are
+ * not, so use `.toContain(substring)` rather than equality.
+ */
+export function extractText(node: Node): string {
+  const seen = new WeakSet<object>();
+  const parts: string[] = [];
+  walk(node, parts, seen);
+  return parts.join(" ");
+}
+
+// Props worth scanning for user-visible text. The dashboard pages use a
+// thin "label/value" wrapper (Field, CardTitle, CostBarChart#emptyLabel) and
+// Verkada-style icon/aria labels — text on those components lives in props,
+// not in children. Class names / hrefs / styling props are skipped because
+// they would otherwise pollute the haystack with CSS.
+const TEXT_PROPS = new Set([
+  "label",
+  "value",
+  "emptyLabel",
+  "title",
+  "alt",
+  "placeholder",
+  "ariaLabel",
+  "aria-label",
+  "subtitle",
+  "name",
+  "fallback",
+]);
+
+function walk(node: Node, parts: string[], seen: WeakSet<object>): void {
+  if (node == null || typeof node === "boolean") return;
+  if (typeof node === "string") {
+    parts.push(node);
+    return;
+  }
+  if (typeof node === "number") {
+    parts.push(String(node));
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, parts, seen);
+    return;
+  }
+  if (typeof node !== "object") return;
+  if (seen.has(node as object)) return;
+  seen.add(node as object);
+
+  const el = node as ReactElement & {
+    props?: Record<string, unknown> & { children?: unknown };
+  };
+  if (el.props) {
+    for (const key of Object.keys(el.props)) {
+      if (key === "children") continue;
+      if (!TEXT_PROPS.has(key)) continue;
+      walk(el.props[key], parts, seen);
+    }
+    walk(el.props.children, parts, seen);
+  }
+}
+
+/**
+ * Walk the tree looking for a `<Suspense>` boundary. Pages that opt into
+ * streaming wrap their filter cluster in `<Suspense>` (no fallback prop —
+ * default `null`); these tests pin the presence of that boundary so a
+ * refactor that strips it shows up rather than silently regressing.
+ */
+export function containsSuspense(node: Node): boolean {
+  const seen = new WeakSet<object>();
+  return findSuspense(node, seen);
+}
+
+function findSuspense(node: Node, seen: WeakSet<object>): boolean {
+  if (node == null || typeof node !== "object") return false;
+  if (Array.isArray(node)) return node.some((c) => findSuspense(c, seen));
+  if (seen.has(node as object)) return false;
+  seen.add(node as object);
+
+  const el = node as ReactElement & { props?: { children?: unknown } };
+  const t = el.type as
+    | { displayName?: string; name?: string }
+    | string
+    | symbol
+    | undefined;
+  if (typeof t === "symbol" && t.toString().includes("react.suspense")) {
+    return true;
+  }
+  if (
+    t &&
+    typeof t === "object" &&
+    ((t as { displayName?: string }).displayName === "Suspense" ||
+      (t as { name?: string }).name === "Suspense")
+  ) {
+    return true;
+  }
+  return findSuspense(el.props?.children, seen);
+}


### PR DESCRIPTION
## Summary

Closes #112.

Adds page-level tests for every page listed in the issue:

- `src/app/dashboard/page.tsx`
- `src/app/dashboard/sessions/page.tsx`
- `src/app/dashboard/sessions/[id]/page.tsx`
- `src/app/dashboard/team/page.tsx`
- `src/app/dashboard/models/page.tsx`
- `src/app/dashboard/repos/page.tsx`
- `src/app/dashboard/settings/page.tsx`

Each page test pins the four contracts called out in the issue:

1. **Smoke render** — page renders against a populated DAL response, with the headline + primary cards in the haystack.
2. **Empty state** — DAL returns `[]` / zero values; the page surfaces the right empty-state copy without crashing.
3. **Loading state** — pages that wrap their filter cluster in `<Suspense>` keep that boundary; the one page without it (`/dashboard/settings`) pins the absence so a future addition is intentional. The `[id]` page pins the back-link filter round-trip (#101) instead, since that's the load-state behavior users actually see.
4. **Error state** — when the DAL throws, the page invocation rejects so the framework's error boundary can render its fallback (rather than the page silently rendering empty).

A few bonus assertions per page where they pin a real contract — e.g. team-page redirects members to `/dashboard` (ADR-0083 §6), `null` returns when the viewer has no `org_id`, and the `[id]` page bails to `notFound()` when the `device` query param is missing without ever hitting the DAL (avoids leaking session existence via timing/error shape).

## Implementation notes

- Round-tripping through `JSON.stringify` trips on Next.js's lazy/circular references and on numeric children (e.g. `[\"Team Members (\", 2, \")\"]`). A small `src/test-utils/page-tree.ts` helper walks the React node tree, concatenating string/number children plus a curated set of text-bearing props (`label`, `value`, `emptyLabel`, `title`, …) into a single search-friendly haystack. It also exposes a `containsSuspense` walker for the loading-state assertions.
- The pre-existing `tsc` errors (#109) and prettier drift (#110) are not addressed here — kept the diff scoped to #112.

## Test plan

- [x] `npm test` passes (176 / 176, +37 new)
- [x] `npx prettier --check` clean for new files
- [x] `npx eslint` clean for new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)