### PR TITLE
fix(security): add baseline security response headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,32 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  // Start with frame-ancestors only; expand CSP after auditing inline scripts/styles.
+  { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+];
+
 const nextConfig: NextConfig = {
+  poweredByHeader: false,
   async rewrites() {
     return [
       {
         source: "/v1/:path*",
         destination: "/api/v1/:path*",
+      },
+    ];
+  },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
       },
     ];
   },


### PR DESCRIPTION
## Summary

- Add `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (camera/mic/geo/cohorts off), and a minimal `Content-Security-Policy: frame-ancestors 'none'` to every response via `next.config.ts#headers()`.
- Disable the `x-powered-by: Next.js` fingerprint header (`poweredByHeader: false`).
- A full CSP (`script-src` etc.) is deliberately deferred — Next.js inlines runtime scripts, so the safer rollout is `frame-ancestors 'none'` first, then a Report-Only audit, then enforced.

Closes #111

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] `npm test` — 176 passed
- [ ] After deploy, verify with:
  ```
  curl -sI https://app.getbudi.dev/ | grep -iE 'x-frame|content-type-options|referrer|permissions|content-security|powered'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)