### PR TITLE
chore(ci): fix prettier drift and gate CI on format:check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Format check
+        run: npm run format:check
+
       - name: Lint
         run: npm run lint
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -10,11 +10,11 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ## Product boundaries
 
-| Product | Repo | Role |
-|---------|------|------|
-| **budi-core** | [`siropkin/budi`](https://github.com/siropkin/budi) | Rust daemon + CLI. Owns SQLite, pushes aggregates to this service. |
-| **budi-cursor** | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) | VS Code/Cursor extension. Unrelated to the cloud. |
-| **budi-cloud** | **this repo** (`siropkin/budi-cloud`) | Cloud dashboard + ingest API. |
+| Product         | Repo                                                              | Role                                                                                     |
+| --------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **budi-core**   | [`siropkin/budi`](https://github.com/siropkin/budi)               | Rust daemon + CLI. Owns SQLite, pushes aggregates to this service.                       |
+| **budi-cursor** | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) | VS Code/Cursor extension. Unrelated to the cloud.                                        |
+| **budi-cloud**  | **this repo** (`siropkin/budi-cloud`)                             | Cloud dashboard + ingest API.                                                            |
 | **getbudi.dev** | [`siropkin/getbudi.dev`](https://github.com/siropkin/getbudi.dev) | Public marketing landing page. Different subdomain (`getbudi.dev` vs `app.getbudi.dev`). |
 
 Extraction boundaries are defined in [ADR-0086](https://github.com/siropkin/budi/blob/main/docs/adr/0086-extraction-boundaries.md) in the main repo. The privacy contract is [ADR-0083](https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md). Read both before touching the ingest path.
@@ -57,13 +57,13 @@ The daemon pushes **pre-aggregated daily rollups and session summaries** — num
 
 ## Team model (v1)
 
-| Aspect | Detail |
-|--------|--------|
-| **Roles** | `manager` (view all org data, manage members) and `member` (sync own data, view own data) |
-| **Granularity** | Daily aggregates; no per-message, per-hour, or real-time views |
-| **Retention** | 90 days |
-| **Multi-org** | One user, one org (no multi-tenancy per user in v1) |
-| **SSO / SAML** | Not supported in v1 |
+| Aspect          | Detail                                                                                    |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| **Roles**       | `manager` (view all org data, manage members) and `member` (sync own data, view own data) |
+| **Granularity** | Daily aggregates; no per-message, per-hour, or real-time views                            |
+| **Retention**   | 90 days                                                                                   |
+| **Multi-org**   | One user, one org (no multi-tenancy per user in v1)                                       |
+| **SSO / SAML**  | Not supported in v1                                                                       |
 
 ## Ingest API contract
 

--- a/src/app/actions/org.test.ts
+++ b/src/app/actions/org.test.ts
@@ -519,7 +519,12 @@ describe("switchOrganization", () => {
     fake.seed("users", [
       { id: "usr_ivan", org_id: "org_other", role: "manager", api_key: "k1" },
       { id: "usr_alice", org_id: "org_other", role: "member", api_key: "k2" },
-      { id: "usr_acme_mgr", org_id: "org_acme", role: "manager", api_key: "k3" },
+      {
+        id: "usr_acme_mgr",
+        org_id: "org_acme",
+        role: "manager",
+        api_key: "k3",
+      },
     ]);
     fake.seed("devices", [{ id: "dev_alice", user_id: "usr_alice" }]);
     fake.seed("daily_rollups", [

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -134,7 +134,9 @@ export function buildSessionRows(
     // partial signal — the dashboard already renders missing slots as a
     // dash.
     vital_context_drag_state: normalizeVitalState(s.vital_context_drag_state),
-    vital_context_drag_metric: normalizeVitalMetric(s.vital_context_drag_metric),
+    vital_context_drag_metric: normalizeVitalMetric(
+      s.vital_context_drag_metric
+    ),
     vital_cache_efficiency_state: normalizeVitalState(
       s.vital_cache_efficiency_state
     ),

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -118,14 +118,9 @@ export default async function SessionDetailPage({
               <Field label="Repo" value={repoName(session.repo_id)} />
               <Field
                 label="Branch"
-                value={
-                  session.git_branch?.replace(/^refs\/heads\//, "") || "-"
-                }
+                value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
               />
-              <Field
-                label="Messages"
-                value={fmtNum(session.message_count)}
-              />
+              <Field label="Messages" value={fmtNum(session.message_count)} />
               <Field label="Tokens" value={fmtNum(totalTokens)} />
               <Field
                 label="Cost"
@@ -142,9 +137,7 @@ export default async function SessionDetailPage({
 function Field({ label, value }: { label: string; value: string | number }) {
   return (
     <div>
-      <dt className="text-xs uppercase tracking-wide text-zinc-500">
-        {label}
-      </dt>
+      <dt className="text-xs uppercase tracking-wide text-zinc-500">{label}</dt>
       <dd className="mt-0.5 text-zinc-200">{value}</dd>
     </div>
   );

--- a/src/app/dashboard/settings/copy-button.tsx
+++ b/src/app/dashboard/settings/copy-button.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 
-export function CopyButton({
-  value,
-  label,
-}: {
-  value: string;
-  label: string;
-}) {
+export function CopyButton({ value, label }: { value: string; label: string }) {
   const [copied, setCopied] = useState(false);
 
   function handleCopy() {

--- a/src/app/dashboard/settings/danger-zone.tsx
+++ b/src/app/dashboard/settings/danger-zone.tsx
@@ -89,16 +89,16 @@ function DeleteOrgButton({ orgName }: { orgName: string }) {
           description={
             <>
               This will permanently remove <strong>{orgName}</strong>, every
-              member, and all synced data. Other members will be signed out
-              the next time they open the dashboard.
+              member, and all synced data. Other members will be signed out the
+              next time they open the dashboard.
             </>
           }
           error={error}
         >
           <form action={submit} className="space-y-3">
             <label className="block text-xs text-zinc-400">
-              Type <span className="font-mono text-zinc-200">{orgName}</span>{" "}
-              to confirm:
+              Type <span className="font-mono text-zinc-200">{orgName}</span> to
+              confirm:
             </label>
             <input
               type="text"
@@ -175,8 +175,8 @@ function LeaveOrgButton({ orgName }: { orgName: string }) {
           description={
             <>
               This removes your devices and sync history from{" "}
-              <strong>{orgName}</strong>. Your sign-in account stays, so you
-              can rejoin or create a different org later.
+              <strong>{orgName}</strong>. Your sign-in account stays, so you can
+              rejoin or create a different org later.
             </>
           }
           error={error}

--- a/src/app/invite/[token]/cross-org-switch.tsx
+++ b/src/app/invite/[token]/cross-org-switch.tsx
@@ -50,9 +50,7 @@ export function CrossOrgSwitch({
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
       <div className="w-full max-w-md rounded-xl border border-white/10 bg-zinc-950 p-6 shadow-xl">
-        <h1 className="text-xl font-bold text-white">
-          Switch organizations?
-        </h1>
+        <h1 className="text-xl font-bold text-white">Switch organizations?</h1>
         <div className="mt-4 space-y-3 text-sm text-zinc-300">
           <p>
             You&rsquo;re currently a member of{" "}
@@ -63,11 +61,10 @@ export function CrossOrgSwitch({
             <strong className="text-zinc-100">{targetOrgName}</strong>.
           </p>
           <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-amber-200">
-            If you switch, all of your devices, sessions, and cost history
-            will move with you to{" "}
-            <strong>{targetOrgName}</strong>.{" "}
-            <strong>{currentOrgName}</strong>&rsquo;s manager will no longer
-            see your usage.
+            If you switch, all of your devices, sessions, and cost history will
+            move with you to <strong>{targetOrgName}</strong>.{" "}
+            <strong>{currentOrgName}</strong>&rsquo;s manager will no longer see
+            your usage.
           </p>
         </div>
 
@@ -82,8 +79,8 @@ export function CrossOrgSwitch({
           <input type="hidden" name="targetOrgId" value={targetOrgId} />
           <label className="block text-xs text-zinc-400">
             Type{" "}
-            <span className="font-mono text-zinc-200">{targetOrgName}</span>{" "}
-            to confirm:
+            <span className="font-mono text-zinc-200">{targetOrgName}</span> to
+            confirm:
           </label>
           <input
             type="text"

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -80,7 +80,11 @@ export default async function InvitePage({
     // switching out would orphan their current org, so they get a refusal
     // instead of a switch button.
     const [{ data: currentOrg }, { data: targetOrg }] = await Promise.all([
-      admin.from("orgs").select("id, name").eq("id", existingUser.org_id).single(),
+      admin
+        .from("orgs")
+        .select("id, name")
+        .eq("id", existingUser.org_id)
+        .single(),
       admin.from("orgs").select("id, name").eq("id", invite.org_id).single(),
     ]);
 

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -199,10 +199,7 @@ function StalledBadge({
         <span className="hidden sm:inline">Stalled — last synced </span>
         <span>{relative}</span>
         <ChevronDown
-          className={clsx(
-            "h-3 w-3 transition-transform",
-            open && "rotate-180"
-          )}
+          className={clsx("h-3 w-3 transition-transform", open && "rotate-180")}
         />
       </button>
       {open && (
@@ -306,10 +303,7 @@ function SessionsStalledBadge({
         <span className="sm:hidden">Sessions </span>
         <span>{sessionRelative}</span>
         <ChevronDown
-          className={clsx(
-            "h-3 w-3 transition-transform",
-            open && "rotate-180"
-          )}
+          className={clsx("h-3 w-3 transition-transform", open && "rotate-180")}
         />
       </button>
       {open && (
@@ -341,8 +335,8 @@ function SessionsStalledBadge({
               — make sure you&rsquo;re on a recent build
             </li>
             <li>
-              If both look fine, file an issue — sessions diverging from
-              rollups usually means a daemon-side regression.
+              If both look fine, file an issue — sessions diverging from rollups
+              usually means a daemon-side regression.
             </li>
           </ol>
           <a

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -106,7 +106,10 @@ export function deviceLabel(
  * low-precision (minute granularity, no ticking) — the dashboard layout is
  * `force-dynamic` so each page load recomputes against a fresh `Date.now()`.
  */
-export function fmtRelative(iso: string | null, now: number = Date.now()): string {
+export function fmtRelative(
+  iso: string | null,
+  now: number = Date.now()
+): string {
   if (!iso) return "never";
   const diff = Math.max(0, now - Date.parse(iso));
   const s = Math.floor(diff / 1000);


### PR DESCRIPTION
## Summary
- Run `npm run format` to clean up 10 files that drifted out of prettier compliance on `main`.
- Add `npm run format:check` to the CI build job so unformatted code cannot land again — closing the gap that allowed the drift to accumulate (lint was in CI, formatting was not).

Closes #110.

## Test plan
- [x] `npm run format:check` is clean locally
- [x] `npm run lint` still passes
- [ ] CI passes (format-check, lint, build, migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)