### PR TITLE
fix(types): clear tsc --noEmit errors in test files (#109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Build
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",

--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -54,7 +54,12 @@ class FakeSupabase {
         String(r.bucket_day ?? "") >= from &&
         String(r.bucket_day ?? "") <= to
     );
-    const totals = rollups.reduce(
+    const totals = rollups.reduce<{
+      total_cost_cents: number;
+      total_input_tokens: number;
+      total_output_tokens: number;
+      total_messages: number;
+    }>(
       (acc, r) => ({
         total_cost_cents: acc.total_cost_cents + Number(r.cost_cents),
         total_input_tokens: acc.total_input_tokens + Number(r.input_tokens),
@@ -419,7 +424,31 @@ describe("POST /v1/ingest + dashboard read path (#14)", () => {
 
     const { POST } = await import("./route");
 
-    const baseEnvelope = {
+    type SessionSummary = {
+      session_id: string;
+      provider: string;
+      started_at: string | null;
+      ended_at: string;
+      duration_ms: number;
+      repo_id: string | null;
+      git_branch: string | null;
+      ticket: string | null;
+      message_count: number;
+      total_input_tokens: number;
+      total_output_tokens: number;
+      total_cost_cents: number;
+    };
+    type Envelope = {
+      schema_version: number;
+      device_id: string;
+      org_id: string;
+      synced_at: string;
+      payload: {
+        daily_rollups: never[];
+        session_summaries: SessionSummary[];
+      };
+    };
+    const baseEnvelope: Envelope = {
       schema_version: 1,
       device_id: "dev_test",
       org_id: "org_test",

--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -61,22 +61,29 @@ describe("CostBarChart", () => {
 
     const bar = nodes.find((n) => n.type === Bar);
     expect(bar, "Bar should be in the rendered tree").toBeDefined();
-    expect(bar!.props.minPointSize).toBeGreaterThanOrEqual(4);
-    expect(bar!.props.isAnimationActive).toBe(false);
+    const barProps = bar!.props as {
+      minPointSize: number;
+      isAnimationActive: boolean;
+    };
+    expect(barProps.minPointSize).toBeGreaterThanOrEqual(4);
+    expect(barProps.isAnimationActive).toBe(false);
 
     const labelList = nodes.find((n) => n.type === LabelList);
     expect(
       labelList,
       "LabelList should be inside Bar so each row gets a $X.XX suffix"
     ).toBeDefined();
-    expect(labelList!.props.dataKey).toBe("cost_cents");
-    expect(labelList!.props.position).toBe("right");
+    const labelListProps = labelList!.props as {
+      dataKey: string;
+      position: string;
+      formatter: (v: unknown) => string | number;
+    };
+    expect(labelListProps.dataKey).toBe("cost_cents");
+    expect(labelListProps.position).toBe("right");
 
     // Formatter must round-trip a cents amount into the fmtCost form so the
     // regression where `$X.XX` goes missing can't sneak back in.
-    const formatter = labelList!.props.formatter as (
-      v: unknown
-    ) => string | number;
+    const formatter = labelListProps.formatter;
     expect(formatter).toBeTypeOf("function");
     expect(formatter(3000)).toBe(fmtCost(3000));
     expect(formatter(81)).toBe(fmtCost(81));

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -83,7 +83,12 @@ function rollupsForRange(
 const RPC_HANDLERS: Record<string, RpcHandler> = {
   dashboard_overview_stats(tables, args) {
     const rows = rollupsForRange(tables, args);
-    const totals = rows.reduce(
+    const totals = rows.reduce<{
+      total_cost_cents: number;
+      total_input_tokens: number;
+      total_output_tokens: number;
+      total_messages: number;
+    }>(
       (acc, r) => ({
         total_cost_cents: acc.total_cost_cents + Number(r.cost_cents),
         total_input_tokens: acc.total_input_tokens + Number(r.input_tokens),


### PR DESCRIPTION
Closes #109.

## Summary

- Annotated reducer accumulators in `route.test.ts` and `dal.test.ts` with explicit generics so `acc.total_cost_cents` etc. are typed as `number` instead of `unknown`.
- Typed the `baseEnvelope` fixture in `route.test.ts` as `Envelope` with `started_at: string | null`, so the second envelope (which sets `started_at: null` to exercise the fallback path) is assignable.
- Cast Recharts element `props` to a local shape in `cost-bar-chart.test.tsx` — React 19's `ReactElement.props` defaults to `unknown`, so direct property access errored.
- Added a `typecheck` npm script (`tsc --noEmit`) and a CI step between Lint and Build, per the issue's bonus suggestion. This way future drift is caught before it lands.

`npx tsc --noEmit` now exits clean. `npm test`, `npm run lint`, and `npm run format:check` still pass (19 files / 176 tests).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 176/176 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)