### PR TITLE
fix(dashboard): stack header below sm: so mobile filters stop overflowing (#117)

### DIFF
--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -39,10 +39,10 @@ export default async function DevicesPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-bold">Devices</h1>
         <Suspense>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -37,10 +37,10 @@ export default async function ModelsPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-bold">Models</h1>
         <Suspense>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { containsSuspense, extractText } from "@/test-utils/page-tree";
+import {
+  collectClassNames,
+  containsSuspense,
+  extractText,
+} from "@/test-utils/page-tree";
 
 /**
  * Page-level coverage for `/dashboard` (the Overview page).
@@ -129,6 +133,28 @@ describe("dashboard /page (Overview)", () => {
   it("error: a DAL fault propagates so the framework error boundary can render its fallback", async () => {
     dal.getOverviewStats.mockRejectedValue(new Error("__DAL_BOOM__"));
     await expect(render()).rejects.toThrow("__DAL_BOOM__");
+  });
+
+  it("mobile: header stacks below sm: and the filter cluster wraps so the time-range buttons cannot be clipped (#117)", async () => {
+    const node = await render();
+    const classes = collectClassNames(node);
+    // Outer header row stacks vertically by default and only switches to a
+    // horizontal layout at the `sm` breakpoint — this is what keeps the
+    // title + team scope + period buttons from sharing one ~470px row on
+    // a 375px phone.
+    const stacked = classes.find(
+      (c) =>
+        c.includes("flex-col") &&
+        c.includes("sm:flex-row") &&
+        c.includes("sm:justify-between")
+    );
+    expect(stacked).toBeTruthy();
+    // Inner filter cluster must opt into wrapping; without `flex-wrap` the
+    // PeriodSelector's "All" button is what gets pushed off-screen.
+    const wrapping = classes.find(
+      (c) => c.includes("flex-wrap") && c.includes("items-center")
+    );
+    expect(wrapping).toBeTruthy();
   });
 
   it("returns null (no leak) when the viewer has no org_id yet", async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -55,10 +55,10 @@ export default async function OverviewPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-bold">Overview</h1>
         <Suspense>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -55,10 +55,10 @@ export default async function ReposPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-bold">Repos</h1>
         <Suspense>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -94,10 +94,10 @@ export default async function SessionsPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-bold">Sessions</h1>
         <Suspense>
-          <div className="flex items-center gap-3">
+          <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
             <PeriodSelector />
           </div>

--- a/src/test-utils/page-tree.ts
+++ b/src/test-utils/page-tree.ts
@@ -111,3 +111,33 @@ function findSuspense(node: Node, seen: WeakSet<object>): boolean {
   }
   return findSuspense(el.props?.children, seen);
 }
+
+/**
+ * Collect every `className` string reachable from `node` in tree order. Used
+ * by mobile-layout regression tests (#117) to assert the page header opts
+ * into responsive stacking (`flex-col … sm:flex-row`) and that the inner
+ * filter cluster wraps (`flex-wrap`) instead of overflowing the viewport.
+ */
+export function collectClassNames(node: Node): string[] {
+  const seen = new WeakSet<object>();
+  const out: string[] = [];
+  walkClass(node, out, seen);
+  return out;
+}
+
+function walkClass(node: Node, out: string[], seen: WeakSet<object>): void {
+  if (node == null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const child of node) walkClass(child, out, seen);
+    return;
+  }
+  if (seen.has(node as object)) return;
+  seen.add(node as object);
+
+  const el = node as ReactElement & {
+    props?: Record<string, unknown> & { children?: unknown };
+  };
+  const className = el.props?.className;
+  if (typeof className === "string") out.push(className);
+  walkClass(el.props?.children, out, seen);
+}


### PR DESCRIPTION
Closes #117.

## Summary
- Outer dashboard header rows now use `flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` so the title, team-scope dropdown, and period buttons stack vertically on phone widths instead of sharing one ~470px row.
- Inner filter clusters use `flex-wrap items-center gap-3` so the rightmost period buttons (notably "All") cannot be clipped or pushed off-screen by `<main>`'s `overflow-x: auto`.
- Applied consistently across `overview`, `models`, `repos`, `devices`, and `sessions` pages.
- Added a `collectClassNames` helper in `src/test-utils/page-tree.ts` plus a regression test on `dashboard/page.test.tsx` that pins the responsive classnames so this layout cannot silently regress.

## Test plan
- [x] `npm test` (177 tests, 19 files, all pass — includes new mobile regression test)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Manual smoke at 375 / 390 / 414 / 480 px viewports — header stacks, no horizontal scroll on `<main>`