### PR TITLE
fix(settings): stack API key action buttons under code on mobile (#122)

### DIFF
--- a/src/app/dashboard/settings/api-key-section.tsx
+++ b/src/app/dashboard/settings/api-key-section.tsx
@@ -28,43 +28,51 @@ export function ApiKeySection({ apiKey }: { apiKey: string }) {
         <p className="mb-2 text-sm text-zinc-400">
           Run this on your local machine to point Budi at your cloud account.
         </p>
-        <div className="flex items-center gap-2">
-          <code className="block flex-1 whitespace-pre-wrap rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
+        {/*
+          Below sm: stack the action buttons under the code block so the
+          masked command + two 100px buttons can't push past the card's
+          right edge and force a page-level horizontal scrollbar (#122).
+          From sm: keep the original single-row layout.
+        */}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <code className="block flex-1 whitespace-pre-wrap break-all rounded-lg bg-black/50 px-4 py-3 font-mono text-sm text-emerald-400">
             {displayCommand}
           </code>
           {/*
             min-width on both toggles keeps the code column from jumping
             when labels swap (Reveal→Hide, Copy→Copied).
           */}
-          <button
-            onClick={() => setRevealed((v) => !v)}
-            aria-label={revealed ? "Hide API key" : "Reveal API key"}
-            className="inline-flex min-w-[6.25rem] items-center justify-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
-          >
-            {revealed ? (
-              <>
-                <EyeOff className="h-4 w-4" /> Hide
-              </>
-            ) : (
-              <>
-                <Eye className="h-4 w-4" /> Reveal
-              </>
-            )}
-          </button>
-          <button
-            onClick={handleCopy}
-            className="inline-flex min-w-[6.25rem] items-center justify-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15"
-          >
-            {copied ? (
-              <>
-                <Check className="h-4 w-4" /> Copied
-              </>
-            ) : (
-              <>
-                <Copy className="h-4 w-4" /> Copy
-              </>
-            )}
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setRevealed((v) => !v)}
+              aria-label={revealed ? "Hide API key" : "Reveal API key"}
+              className="inline-flex min-w-[6.25rem] flex-1 items-center justify-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15 sm:flex-none"
+            >
+              {revealed ? (
+                <>
+                  <EyeOff className="h-4 w-4" /> Hide
+                </>
+              ) : (
+                <>
+                  <Eye className="h-4 w-4" /> Reveal
+                </>
+              )}
+            </button>
+            <button
+              onClick={handleCopy}
+              className="inline-flex min-w-[6.25rem] flex-1 items-center justify-center gap-1.5 rounded-lg bg-white/10 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/15 sm:flex-none"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-4 w-4" /> Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-4 w-4" /> Copy
+                </>
+              )}
+            </button>
+          </div>
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
Closes #122.

## Summary
- Below `sm:`, the API key row laid out the masked command + Reveal (100px) + Copy (100px) in one flex row. The intrinsic width exceeded the card's content box, pushing Reveal past the right edge and giving the entire `/dashboard/settings` page a horizontal scrollbar.
- Switch the outer container to `flex-col sm:flex-row` and group the two buttons in their own flex row, so on mobile the buttons sit on a second row under the code block.
- Add `break-all` to the code element so the long key token can wrap inside the card when revealed.
- Desktop layout (`sm` and up) is unchanged.

## Test plan
- [ ] At 320–414px, no horizontal page scrollbar on `/dashboard/settings`
- [ ] Reveal and Copy buttons fully visible inside the API key card on mobile
- [ ] Toggling Reveal/Hide and Copy/Copied does not shift the surrounding layout
- [ ] Desktop (`sm:` and up) still renders the original single-row layout
- [ ] `npm test`, `npm run lint`, `npx tsc --noEmit`, `npx prettier --check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)