### PR TITLE
fix(charts): cut mobile y-axis label to 14 chars to prevent clipping (#120)

### DIFF
--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -44,7 +44,10 @@ export function CostBarChart({
   const yAxisWidth = isCompact ? 110 : 180;
   const rightMargin = isCompact ? 24 : 56;
   const leftMargin = isCompact ? 4 : 20;
-  const labelMaxLen = isCompact ? 18 : 28;
+  // On compact, 18 chars at fontSize 12 can exceed the 110px label column,
+  // pushing right-anchored text into negative X so leading characters get
+  // clipped (#120). 14 chars fits comfortably.
+  const labelMaxLen = isCompact ? 14 : 28;
 
   const sorted = [...data]
     .sort((a, b) => b.cost_cents - a.cost_cents)


### PR DESCRIPTION
## Summary
- Closes #120
- On compact viewports (`max-width: 639px`) the Y-axis `<text>` is right-anchored against a 110px label column. At `fontSize=12`, an 18-char string can be wider than 110px, so leading characters render in negative X and get clipped.
- Drop `labelMaxLen` from 18 → 14 on compact only; desktop unchanged.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npx vitest run src/components/charts/cost-bar-chart.test.tsx`
- [ ] Visual check at 320–414px on `/dashboard/devices`: no row label has its first character chopped off

🤖 Generated with [Claude Code](https://claude.com/claude-code)