### PR TITLE
fix(charts): drop shared label prefix on mobile so rows stay distinct (#121)

### DIFF
--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ReactElement } from "react";
-import { Bar, LabelList } from "recharts";
+import { Bar, BarChart, LabelList } from "recharts";
 import { fmtCost } from "@/lib/format";
 
 // CostBarChart now calls `useMediaQuery` to shrink the y-axis column on
-// narrow viewports. The test walks the React element tree without rendering,
-// so stub the hook with a plain function — this keeps the test in the node
-// env and still exercises the non-compact prop values.
+// narrow viewports. The hook is stubbed by a controllable function so each
+// test can switch between the desktop and compact code paths.
+let isCompact = false;
 vi.mock("@/lib/use-media-query", () => ({
-  useMediaQuery: () => false,
+  useMediaQuery: () => isCompact,
 }));
 
 // Lazy import so the mock is applied before the component module evaluates.
@@ -87,5 +87,55 @@ describe("CostBarChart", () => {
     expect(formatter).toBeTypeOf("function");
     expect(formatter(3000)).toBe(fmtCost(3000));
     expect(formatter(81)).toBe(fmtCost(81));
+  });
+
+  it("strips the shared label prefix on compact widths so rows are visibly distinct (#121)", () => {
+    isCompact = true;
+    try {
+      const collidingPrefix = [
+        { label: "claude_code / claude-sonnet-4-5", cost_cents: 5000 },
+        { label: "claude_code / claude-haiku-4-5", cost_cents: 3000 },
+        { label: "claude_code / claude-opus-4-7", cost_cents: 1000 },
+      ];
+      const tree = CostBarChart({
+        data: collidingPrefix,
+        emptyLabel: "unused",
+      });
+      const nodes = Array.from(walk(tree));
+      const barChart = nodes.find((n) => n.type === BarChart);
+      expect(barChart).toBeDefined();
+      const data = (barChart!.props as { data: { displayLabel: string }[] })
+        .data;
+      // Common prefix `claude_code / claude-` is stripped so the model id is
+      // what reaches the y-axis renderer (and stays distinct after truncation).
+      expect(data.map((d) => d.displayLabel)).toEqual([
+        "sonnet-4-5",
+        "haiku-4-5",
+        "opus-4-7",
+      ]);
+    } finally {
+      isCompact = false;
+    }
+  });
+
+  it("leaves labels alone when truncation alone keeps rows distinct", () => {
+    isCompact = true;
+    try {
+      const distinctEnough = [
+        { label: "alpha", cost_cents: 100 },
+        { label: "beta", cost_cents: 50 },
+      ];
+      const tree = CostBarChart({
+        data: distinctEnough,
+        emptyLabel: "unused",
+      });
+      const nodes = Array.from(walk(tree));
+      const barChart = nodes.find((n) => n.type === BarChart);
+      const data = (barChart!.props as { data: { displayLabel: string }[] })
+        .data;
+      expect(data.map((d) => d.displayLabel)).toEqual(["alpha", "beta"]);
+    } finally {
+      isCompact = false;
+    }
   });
 });

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -30,6 +30,40 @@ function truncateLabel(value: string, maxLen = 28): string {
   return value.slice(0, maxLen - 1) + "\u2026";
 }
 
+/**
+ * Longest common prefix shared by all strings. Returns "" for fewer than two
+ * inputs so we never strip from a single-row chart.
+ */
+function commonPrefix(values: string[]): string {
+  if (values.length < 2) return "";
+  let prefix = values[0];
+  for (let i = 1; i < values.length && prefix.length > 0; i++) {
+    const v = values[i];
+    let j = 0;
+    const max = Math.min(prefix.length, v.length);
+    while (j < max && prefix.charCodeAt(j) === v.charCodeAt(j)) j++;
+    prefix = prefix.slice(0, j);
+  }
+  return prefix;
+}
+
+/**
+ * Drop the longest common prefix from every label when truncation would
+ * otherwise collapse rows onto each other \u2014 e.g. four rows of
+ * `claude_code / claude-\u2026` lose the differentiating model id at mobile
+ * widths. Only kicks in when the truncated forms actually collide and the
+ * stripped forms are non-empty (#121).
+ */
+function stripSharedPrefix(labels: string[], maxLen: number): string[] {
+  const truncated = labels.map((l) => truncateLabel(l, maxLen));
+  if (new Set(truncated).size === truncated.length) return labels;
+  const prefix = commonPrefix(labels);
+  if (prefix.length === 0) return labels;
+  const stripped = labels.map((l) => l.slice(prefix.length));
+  if (stripped.some((l) => l.length === 0)) return labels;
+  return stripped;
+}
+
 export function CostBarChart({
   data,
   emptyLabel,
@@ -61,38 +95,54 @@ export function CostBarChart({
     );
   }
 
+  // Strip the common prefix so e.g. `claude_code / claude-sonnet-4-5` and
+  // `claude_code / claude-haiku-4-5` don't both truncate to
+  // `claude_code / cla…` at mobile widths (#121). Keep the original on each
+  // row for the SVG <title> so the full label is still discoverable.
+  const displayLabels = stripSharedPrefix(
+    sorted.map((d) => d.label),
+    labelMaxLen
+  );
+  const rows = sorted.map((d, i) => ({
+    ...d,
+    displayLabel: displayLabels[i],
+  }));
+
   const height = barChartHeight(sorted.length);
 
   return (
     <ResponsiveContainer width="100%" height={height}>
       <BarChart
-        data={sorted}
+        data={rows}
         layout="vertical"
         barCategoryGap={BAR_GAP}
         margin={{ left: leftMargin, right: rightMargin, top: 6, bottom: 6 }}
       >
         <YAxis
-          dataKey="label"
+          dataKey="displayLabel"
           type="category"
           tickLine={false}
           axisLine={false}
           width={yAxisWidth}
           interval={0}
-          tick={({ x, y, payload }) => (
-            <g transform={`translate(${x},${y})`}>
-              <text
-                x={0}
-                y={0}
-                dy={4}
-                textAnchor="end"
-                fill="#71717a"
-                fontSize={12}
-              >
-                <title>{payload.value}</title>
-                {truncateLabel(payload.value, labelMaxLen)}
-              </text>
-            </g>
-          )}
+          tick={({ x, y, payload, index }) => {
+            const original = rows[index]?.label ?? payload.value;
+            return (
+              <g transform={`translate(${x},${y})`}>
+                <text
+                  x={0}
+                  y={0}
+                  dy={4}
+                  textAnchor="end"
+                  fill="#71717a"
+                  fontSize={12}
+                >
+                  <title>{original}</title>
+                  {truncateLabel(payload.value, labelMaxLen)}
+                </text>
+              </g>
+            );
+          }}
         />
         <XAxis
           dataKey="cost_cents"

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDuration } from "./format";
+import { formatDuration, repoName } from "./format";
 
 describe("formatDuration (#88)", () => {
   it("uses duration_ms when provided", () => {
@@ -46,5 +46,29 @@ describe("formatDuration (#88)", () => {
     expect(
       formatDuration(60_000, "2026-04-29T10:00:00Z", "2026-04-29T11:00:00Z")
     ).toBe("1m");
+  });
+});
+
+describe("repoName (#121)", () => {
+  it("returns sentinel display strings for empty / untagged ids", () => {
+    expect(repoName(null)).toBe("(unknown)");
+    expect(repoName("Unassigned")).toBe("(no repo)");
+    expect(repoName("(untagged)")).toBe("(no repo)");
+  });
+
+  it("strips the host so `owner/repo` survives chart label truncation", () => {
+    expect(repoName("github.com/siropkin/budi-cloud")).toBe(
+      "siropkin/budi-cloud"
+    );
+    expect(repoName("gitlab.com/team/project")).toBe("team/project");
+  });
+
+  it("keeps short non-URL ids as-is and shortens long opaque ids", () => {
+    expect(repoName("local")).toBe("local");
+    expect(repoName("a-fairly-long-opaque-id-string")).toBe("a-fairly-lon...");
+  });
+
+  it("shortens hashed sha256 ids", () => {
+    expect(repoName("sha256:abcdef0123456789xyz")).toBe("abcdef01...");
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -61,6 +61,12 @@ export function repoName(repoId: string | null): string {
   if (!repoId) return "(unknown)";
   if (repoId === "Unassigned" || repoId === "(untagged)") return "(no repo)";
   if (repoId.startsWith("sha256:")) return repoId.slice(7, 15) + "...";
+  // For URL-like git remotes ("host.tld/owner/repo[/...]") drop the host so
+  // the discriminating "owner/repo" survives the chart's narrow label column;
+  // a length-based slice would otherwise keep "github.com/o..." for every
+  // row and erase what differentiates them (#121).
+  const hostOwnerRepo = repoId.match(/^[^/\s]+\.[a-z]{2,}\/(.+)$/i);
+  if (hostOwnerRepo) return hostOwnerRepo[1];
   if (repoId.length > 16) return repoId.slice(0, 12) + "...";
   return repoId;
 }


### PR DESCRIPTION
## Summary

Closes #121.

On `/dashboard/models` and `/dashboard/repos` at mobile widths, the y-axis labels in the "Cost by …" charts were truncated from the start to 14 chars, so charts whose rows all shared a long prefix (`claude_code / claude-…`, `github.com/o…`) collapsed onto an identical-looking string. The discriminating suffix was hidden behind the SVG `<title>` hover, which mobile can't trigger.

Two changes:

- **`repoName`** now strips the host from URL-like git remotes (`github.com/siropkin/budi-cloud` → `siropkin/budi-cloud`) so the informative `owner/repo` path survives the chart's narrow label column instead of being replaced with a length-based slice that erased the differentiator.
- **`CostBarChart`** detects when label truncation would cause row collisions and drops the longest common prefix from every row before rendering. The original label is still attached to the SVG `<title>` for desktop hover.

The desktop layout is unchanged when truncation alone keeps rows distinct.

## Test plan

- [x] `npx vitest run` (183/183 pass, includes new cases for `repoName` URL handling and `CostBarChart` prefix-stripping at compact widths)
- [x] `npx tsc --noEmit`
- [x] `npx eslint` on the touched files
- [ ] Visual check at ≤390px on `/dashboard/models` and `/dashboard/repos` — each row in any "Cost by …" chart shows a label that visibly differs from its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)