### PR TITLE
feat(team): add Team Count and Cost per Person charts (#127)

### DIFF
--- a/src/app/dashboard/team/page.test.tsx
+++ b/src/app/dashboard/team/page.test.tsx
@@ -31,6 +31,7 @@ const dal = {
   getCurrentUser: vi.fn(),
   getCostByUser: vi.fn(),
   getEarliestActivity: vi.fn(),
+  getTeamActivityByDay: vi.fn(),
 };
 vi.mock("@/lib/dal", () => dal);
 
@@ -51,6 +52,10 @@ beforeEach(() => {
     { id: "usr_jane", name: "Jane", cost_cents: 1_500_00 },
   ]);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
+  dal.getTeamActivityByDay.mockReset().mockResolvedValue([
+    { bucket_day: "2026-05-01", active_members: 2, cost_cents: 4_000_00 },
+    { bucket_day: "2026-05-02", active_members: 1, cost_cents: 1_000_00 },
+  ]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,12 +1,19 @@
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
-import { getCurrentUser, getCostByUser, getEarliestActivity } from "@/lib/dal";
+import {
+  getCurrentUser,
+  getCostByUser,
+  getEarliestActivity,
+  getTeamActivityByDay,
+} from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { fmtCost } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { TeamCountChart } from "@/components/charts/team-count-chart";
+import { CostPerPersonChart } from "@/components/charts/cost-per-person-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function TeamPage({
@@ -26,7 +33,10 @@ export default async function TeamPage({
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const userCosts = await getCostByUser(user, range);
+  const [userCosts, teamActivity] = await Promise.all([
+    getCostByUser(user, range),
+    getTeamActivityByDay(user, range),
+  ]);
 
   return (
     <div className="space-y-6">
@@ -49,6 +59,24 @@ export default async function TeamPage({
             }))}
             emptyLabel="No team cost data for this period"
           />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Team Count</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TeamCountChart data={teamActivity} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost per Person</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CostPerPersonChart data={teamActivity} />
         </CardContent>
       </Card>
 

--- a/src/components/charts/cost-per-person-chart.tsx
+++ b/src/components/charts/cost-per-person-chart.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtCost, fmtDate, fmtFullDate } from "@/lib/format";
+
+interface CostPerPersonDatum {
+  bucket_day: string;
+  cost_cents: number;
+  active_members: number;
+}
+
+export function CostPerPersonChart({ data }: { data: CostPerPersonDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No team cost data for this period
+      </div>
+    );
+  }
+
+  // Days with no active members render as gaps rather than NaN/Infinity bars
+  // so the chart visually matches the empty-state semantics elsewhere on the
+  // page (#127 acceptance: "render a gap rather than dividing by zero").
+  const series = data.map((d) => ({
+    bucket_day: d.bucket_day,
+    cost_per_person_cents:
+      d.active_members > 0 ? d.cost_cents / d.active_members : null,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={series}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => fmtCost(Number(v))}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={72}
+          label={{
+            value: "Cost / person",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value) => [fmtCost(Number(value)), "Cost / person"]}
+        />
+        <Bar
+          dataKey="cost_per_person_cents"
+          fill="#f59e0b"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/team-count-chart.tsx
+++ b/src/components/charts/team-count-chart.tsx
@@ -27,10 +27,7 @@ export function TeamCountChart({ data }: { data: TeamCountDatum[] }) {
 
   return (
     <ResponsiveContainer width="100%" height={300}>
-      <BarChart
-        data={data}
-        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
-      >
+      <BarChart data={data} margin={{ left: 16, right: 8, top: 8, bottom: 8 }}>
         <CartesianGrid
           strokeDasharray="3 3"
           stroke="rgba(255,255,255,0.06)"

--- a/src/components/charts/team-count-chart.tsx
+++ b/src/components/charts/team-count-chart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+
+interface TeamCountDatum {
+  bucket_day: string;
+  active_members: number;
+}
+
+export function TeamCountChart({ data }: { data: TeamCountDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No team count data for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={data}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tickFormatter={fmtNum}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={48}
+          label={{
+            value: "Active members",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value) => [fmtNum(Number(value)), "Active members"]}
+        />
+        <Bar
+          dataKey="active_members"
+          fill="#22c55e"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -307,6 +307,52 @@ interface DeviceCostRow {
   cost_cents: number | string;
 }
 
+export interface TeamActivityDay {
+  bucket_day: string;
+  active_members: number;
+  cost_cents: number;
+}
+
+/**
+ * Daily series of distinct active members + total cost for the Team page (#127).
+ * Active = any device the user owns wrote a rollup row for that bucket.
+ * Manager sees the full org; member sees own devices only (ADR-0083 §6) — i.e.
+ * a member's chart will read 0 or 1 every day, which is the same self-only
+ * answer the rest of the page already gives them.
+ *
+ * Days with no rollup activity simply don't appear in the result; the chart
+ * components decide whether to interpolate or render a gap.
+ */
+export async function getTeamActivityByDay(
+  user: BudiUser,
+  range: DateRange
+): Promise<TeamActivityDay[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_team_activity_by_day", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as TeamActivityRow[])
+    .map((r) => ({
+      bucket_day: r.bucket_day,
+      active_members: Number(r.active_members),
+      cost_cents: Number(r.cost_cents),
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}
+
+interface TeamActivityRow {
+  bucket_day: string;
+  active_members: number | string;
+  cost_cents: number | string;
+}
+
 interface UserLookup {
   id: string;
   display_name: string | null;

--- a/supabase/migrations/007_team_activity_by_day.sql
+++ b/supabase/migrations/007_team_activity_by_day.sql
@@ -1,0 +1,40 @@
+-- Per-day active-member count and cost for the Team page (#127).
+--
+-- Active members per day = COUNT DISTINCT users whose devices wrote any
+-- rollup row for that bucket. Cost is the same `SUM(cost_cents)` aggregation
+-- the other dashboard breakdowns use, surfaced alongside the count so the
+-- "cost per person" chart can divide the two without a second round trip.
+--
+-- Joining `daily_rollups` to `devices` happens in Postgres for the same
+-- reason the other `dashboard_*` RPCs aggregate server-side: PostgREST's
+-- 1,000-row default cap turns every JS-side join into a silent truncation
+-- bomb once an org grows past it (see #92, the rationale captured in
+-- `004_dashboard_aggregates.sql`). The viewer's visibility scope is still
+-- enforced by `getVisibleDeviceIds` upstream — `p_device_ids` is the
+-- authoritative gate.
+CREATE OR REPLACE FUNCTION public.dashboard_team_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    bucket_day      DATE,
+    active_members  BIGINT,
+    cost_cents      NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        r.bucket_day,
+        COUNT(DISTINCT d.user_id)::BIGINT AS active_members,
+        SUM(r.cost_cents)                 AS cost_cents
+    FROM daily_rollups r
+    JOIN devices d ON d.id = r.device_id
+    WHERE r.device_id = ANY(p_device_ids)
+      AND r.bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY r.bucket_day
+    ORDER BY r.bucket_day ASC;
+$$;


### PR DESCRIPTION
## Summary

Adds two new daily-series cards to `/dashboard/team`, stacked under the existing **Cost by Team Member** chart, so managers can reason about headcount growth and per-seat economics on the same surface.

- **Team Count** — distinct active members per day (any user with at least one rollup row in that bucket).
- **Cost per Person** — per-day `cost_cents / active_members`, formatted via `fmtCost`. Days with no active members render as gaps rather than dividing by zero.

Both charts respect the existing `PeriodSelector` (1d / 7d / 30d / all) and the viewer-TZ helper the page already uses.

## Implementation notes

- New `dashboard_team_activity_by_day` RPC joins `daily_rollups` to `devices` in Postgres. Same rationale as the other dashboard RPCs (#92): a JS-side join would silently truncate at the PostgREST 1k row cap.
- Single RPC returns both `active_members` and `cost_cents` per day so the two charts share one round trip and stay numerically consistent.
- Page-level test mocks updated for the new DAL fn.

## Test plan
- [x] `npm test` — 19 files / 183 tests pass
- [x] `npm run build` — production build green
- [x] `npm run lint` — clean
- [ ] Apply migration `007_team_activity_by_day.sql` against the Supabase project before deploy
- [ ] Manual: visit `/dashboard/team` as manager — verify three cards render in order; period selector switches all three; mobile (≤390px) has no horizontal scroll
- [ ] Manual: visit `/dashboard/team` as member — confirm redirect to `/dashboard` still fires

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)