### PR TITLE
feat(dashboard): unit toggle to display data in tokens or dollars (#128)

### DIFF
--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -8,8 +8,10 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
-import { deviceLabel, fmtCost, fmtRelative } from "@/lib/format";
+import { parseUnit } from "@/lib/units";
+import { deviceLabel, fmtCost, fmtNum, fmtRelative } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -17,12 +19,13 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function DevicesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string }>;
+  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const unit = parseUnit(params.units);
   const scope = { scopedUserId: params.user || null };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
@@ -36,6 +39,24 @@ export default async function DevicesPage({
   ]);
 
   const showOwnerColumn = user.role === "manager";
+  const isTokens = unit === "tokens";
+  const valueWord = isTokens ? "Tokens" : "Cost";
+  const fmtValue = (cost_cents: number, tokens: number) =>
+    isTokens ? fmtNum(tokens) : fmtCost(cost_cents);
+
+  // The chart's "have any data" filter mirrors the previous `cost_cents > 0`
+  // rule, except we also keep rows with zero cost but non-zero tokens so the
+  // tokens lens is never silently empty.
+  const chartRows = devices
+    .map((d) => ({
+      label:
+        showOwnerColumn && d.owner_name
+          ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
+          : deviceLabel(d.id, d.label),
+      cost_cents: d.cost_cents,
+      tokens: d.input_tokens + d.output_tokens,
+    }))
+    .filter((d) => d.cost_cents > 0 || d.tokens > 0);
 
   return (
     <div className="space-y-6">
@@ -44,6 +65,7 @@ export default async function DevicesPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <UnitsSelector />
             <PeriodSelector />
           </div>
         </Suspense>
@@ -51,20 +73,13 @@ export default async function DevicesPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Cost by Device</CardTitle>
+          <CardTitle>{`${valueWord} by Device`}</CardTitle>
         </CardHeader>
         <CardContent>
           <CostBarChart
-            data={devices
-              .filter((d) => d.cost_cents > 0)
-              .map((d) => ({
-                label:
-                  showOwnerColumn && d.owner_name
-                    ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
-                    : deviceLabel(d.id, d.label),
-                cost_cents: d.cost_cents,
-              }))}
-            emptyLabel="No device cost data for this period"
+            data={chartRows}
+            emptyLabel={`No device ${valueWord.toLowerCase()} data for this period`}
+            unit={unit}
           />
         </CardContent>
       </Card>
@@ -83,7 +98,7 @@ export default async function DevicesPage({
                     <th className="pb-2 font-medium">Owner</th>
                   )}
                   <th className="pb-2 font-medium">Last seen</th>
-                  <th className="pb-2 text-right font-medium">Cost</th>
+                  <th className="pb-2 text-right font-medium">{valueWord}</th>
                 </tr>
               </thead>
               <tbody>
@@ -101,7 +116,7 @@ export default async function DevicesPage({
                       {fmtRelative(d.last_seen)}
                     </td>
                     <td className="py-2 text-right tabular-nums text-zinc-300">
-                      {fmtCost(d.cost_cents)}
+                      {fmtValue(d.cost_cents, d.input_tokens + d.output_tokens)}
                     </td>
                   </tr>
                 ))}
@@ -115,7 +130,7 @@ export default async function DevicesPage({
                       {deviceLabel(d.id, d.label)}
                     </span>
                     <span className="tabular-nums text-zinc-300">
-                      {fmtCost(d.cost_cents)}
+                      {fmtValue(d.cost_cents, d.input_tokens + d.output_tokens)}
                     </span>
                   </div>
                   <div className="text-xs text-zinc-500">

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -8,8 +8,10 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { parseUnit } from "@/lib/units";
 import { formatModelName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -17,12 +19,13 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function ModelsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string }>;
+  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const unit = parseUnit(params.units);
   const scope = { scopedUserId: params.user || null };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
@@ -42,6 +45,7 @@ export default async function ModelsPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <UnitsSelector />
             <PeriodSelector />
           </div>
         </Suspense>
@@ -49,15 +53,17 @@ export default async function ModelsPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Cost by Model</CardTitle>
+          <CardTitle>{`${unit === "tokens" ? "Tokens" : "Cost"} by Model`}</CardTitle>
         </CardHeader>
         <CardContent>
           <CostBarChart
             data={models.map((m) => ({
               label: `${m.provider} / ${formatModelName(m.model)}`,
               cost_cents: m.cost_cents,
+              tokens: m.input_tokens + m.output_tokens,
             }))}
             emptyLabel="No model data for this period"
+            unit={unit}
           />
         </CardContent>
       </Card>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -86,17 +86,27 @@ async function render(searchParams: Record<string, string> = {}) {
 }
 
 describe("dashboard /page (Overview)", () => {
-  it("smoke: renders headline, stat cards, and the daily-activity card with populated DAL data", async () => {
+  it("smoke: renders headline, the dollars-default stat cards, and the daily-activity card with populated DAL data", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("Overview");
-    expect(text).toContain("Daily Activity (Tokens)");
-    // The four stat-card titles are part of the page's primary contract.
+    // Default unit is dollars (#128), so the activity card carries the Cost
+    // suffix and the spend card is `Total Cost` — `Total Tokens` only
+    // appears when the toggle is flipped to tokens.
+    expect(text).toContain("Daily Activity (Cost)");
     expect(text).toContain("Total Cost");
-    expect(text).toContain("Total Tokens");
     expect(text).toContain("Messages");
     expect(text).toContain("Sessions");
+    expect(text).not.toContain("Total Tokens");
+  });
+
+  it("units toggle: ?units=tokens swaps Total Cost for Total Tokens and re-titles the activity card (#128)", async () => {
+    const node = await render({ units: "tokens" });
+    const text = extractText(node);
+    expect(text).toContain("Daily Activity (Tokens)");
+    expect(text).toContain("Total Tokens");
+    expect(text).not.toContain("Total Cost");
   });
 
   it("empty: renders headline + zero-value stat cards (not a crash) when the org has no devices yet", async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,9 +10,11 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { parseUnit } from "@/lib/units";
 import { fmtCost, fmtNum } from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
 import { PeriodSelector } from "@/components/period-selector";
+import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { ActivityChart } from "@/components/charts/activity-chart";
 import {
@@ -24,12 +26,13 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function OverviewPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string }>;
+  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const unit = parseUnit(params.units);
   const scopedUserId = params.user || null;
   const scope = { scopedUserId };
   const earliestActivity =
@@ -60,6 +63,7 @@ export default async function OverviewPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <UnitsSelector />
             <PeriodSelector />
           </div>
         </Suspense>
@@ -68,23 +72,26 @@ export default async function OverviewPage({
       {showLinkBanner && <LinkDaemonBanner apiKey={user.api_key} />}
       {showFirstSyncBanner && <FirstSyncInProgressBanner />}
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard title="Total Cost" value={fmtCost(stats.totalCostCents)} />
-        <StatCard
-          title="Total Tokens"
-          value={fmtNum(stats.totalInputTokens + stats.totalOutputTokens)}
-          subtitle={`${fmtNum(stats.totalInputTokens)} in / ${fmtNum(stats.totalOutputTokens)} out`}
-        />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {unit === "tokens" ? (
+          <StatCard
+            title="Total Tokens"
+            value={fmtNum(stats.totalInputTokens + stats.totalOutputTokens)}
+            subtitle={`${fmtNum(stats.totalInputTokens)} in / ${fmtNum(stats.totalOutputTokens)} out`}
+          />
+        ) : (
+          <StatCard title="Total Cost" value={fmtCost(stats.totalCostCents)} />
+        )}
         <StatCard title="Messages" value={fmtNum(stats.totalMessages)} />
         <StatCard title="Sessions" value={fmtNum(stats.totalSessions)} />
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle>Daily Activity (Tokens)</CardTitle>
+          <CardTitle>{`Daily Activity (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
         </CardHeader>
         <CardContent>
-          <ActivityChart data={activity} />
+          <ActivityChart data={activity} unit={unit} />
         </CardContent>
       </Card>
     </div>

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -46,10 +46,7 @@ export default async function ReposPage({
   // (e.g. `"Unassigned"` and `"(untagged)"` both render as `"(no repo)"`),
   // which would otherwise show up as duplicate bars. Merge by label so the
   // chart has one row per bucket the user actually sees.
-  const repoBuckets = new Map<
-    string,
-    { cost_cents: number; tokens: number }
-  >();
+  const repoBuckets = new Map<string, { cost_cents: number; tokens: number }>();
   for (const r of repos) {
     const label = repoName(r.repo_id);
     const tokens = r.input_tokens + r.output_tokens;

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -10,8 +10,10 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { parseUnit } from "@/lib/units";
 import { repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -19,12 +21,13 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function ReposPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string }>;
+  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const unit = parseUnit(params.units);
   const scope = { scopedUserId: params.user || null };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
@@ -43,15 +46,28 @@ export default async function ReposPage({
   // (e.g. `"Unassigned"` and `"(untagged)"` both render as `"(no repo)"`),
   // which would otherwise show up as duplicate bars. Merge by label so the
   // chart has one row per bucket the user actually sees.
-  const repoBuckets = new Map<string, number>();
+  const repoBuckets = new Map<
+    string,
+    { cost_cents: number; tokens: number }
+  >();
   for (const r of repos) {
     const label = repoName(r.repo_id);
-    repoBuckets.set(label, (repoBuckets.get(label) ?? 0) + r.cost_cents);
+    const tokens = r.input_tokens + r.output_tokens;
+    const existing = repoBuckets.get(label);
+    if (existing) {
+      existing.cost_cents += r.cost_cents;
+      existing.tokens += tokens;
+    } else {
+      repoBuckets.set(label, { cost_cents: r.cost_cents, tokens });
+    }
   }
-  const repoChartData = Array.from(repoBuckets, ([label, cost_cents]) => ({
+  const repoChartData = Array.from(repoBuckets, ([label, totals]) => ({
     label,
-    cost_cents,
+    cost_cents: totals.cost_cents,
+    tokens: totals.tokens,
   })).sort((a, b) => b.cost_cents - a.cost_cents);
+
+  const valueWord = unit === "tokens" ? "Tokens" : "Cost";
 
   return (
     <div className="space-y-6">
@@ -60,6 +76,7 @@ export default async function ReposPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <UnitsSelector />
             <PeriodSelector />
           </div>
         </Suspense>
@@ -68,12 +85,13 @@ export default async function ReposPage({
       <div className="grid gap-6 lg:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>Cost by Project</CardTitle>
+            <CardTitle>{`${valueWord} by Project`}</CardTitle>
           </CardHeader>
           <CardContent>
             <CostBarChart
               data={repoChartData}
               emptyLabel="No project data for this period"
+              unit={unit}
             />
             <p className="mt-3 text-xs text-zinc-500">
               <span className="text-zinc-400">(no repo)</span> aggregates spend
@@ -95,15 +113,17 @@ export default async function ReposPage({
 
         <Card>
           <CardHeader>
-            <CardTitle>Cost by Branch</CardTitle>
+            <CardTitle>{`${valueWord} by Branch`}</CardTitle>
           </CardHeader>
           <CardContent>
             <CostBarChart
               data={branches.map((b) => ({
                 label: `${repoName(b.repo_id)} / ${b.git_branch.replace(/^refs\/heads\//, "")}`,
                 cost_cents: b.cost_cents,
+                tokens: b.input_tokens + b.output_tokens,
               }))}
               emptyLabel="No branch data for this period"
+              unit={unit}
             />
           </CardContent>
         </Card>
@@ -111,15 +131,17 @@ export default async function ReposPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Cost by Ticket</CardTitle>
+          <CardTitle>{`${valueWord} by Ticket`}</CardTitle>
         </CardHeader>
         <CardContent>
           <CostBarChart
             data={tickets.map((t) => ({
               label: t.ticket,
               cost_cents: t.cost_cents,
+              tokens: t.input_tokens + t.output_tokens,
             }))}
             emptyLabel="No ticket data for this period"
+            unit={unit}
           />
         </CardContent>
       </Card>

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -84,6 +84,10 @@ describe("dashboard/sessions /page", () => {
     expect(text).toContain("Sessions");
     expect(text).toContain("Recent Sessions");
     // Lock down the column contract so a regression that drops one shows up.
+    // The trailing "Cost" column is unit-aware (#128): under the default
+    // dollars view it reads `Cost`; with `?units=tokens` it flips to
+    // `Tokens`. The standalone Tokens column was retired in #128 because
+    // the unit toggle on the cost column conveys the same signal.
     for (const col of [
       "Provider",
       "Started",
@@ -91,11 +95,19 @@ describe("dashboard/sessions /page", () => {
       "Repo",
       "Branch",
       "Messages",
-      "Tokens",
       "Cost",
     ]) {
       expect(text).toContain(col);
     }
+  });
+
+  it("units toggle: ?units=tokens flips the Cost column header to Tokens (#128)", async () => {
+    const node = await render({ units: "tokens" });
+    const text = extractText(node);
+    // Header now reads `Tokens`; the per-row dollar value is replaced with
+    // the input+output token sum.
+    expect(text).toContain("Tokens");
+    expect(text).not.toContain("$");
   });
 
   it("empty: renders the 'No sessions' empty-state copy and skips pagination chrome", async () => {

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -14,8 +14,10 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { parseUnit } from "@/lib/units";
 import { fmtCost, fmtNum, formatDuration, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
@@ -46,6 +48,7 @@ export default async function SessionsPage({
   searchParams: Promise<{
     days?: string;
     user?: string;
+    units?: string;
     cursor?: string;
     p?: string;
   }>;
@@ -54,6 +57,8 @@ export default async function SessionsPage({
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
+  const unit = parseUnit(params.units);
+  const isTokens = unit === "tokens";
   const scope = { scopedUserId: params.user || null };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
@@ -74,13 +79,14 @@ export default async function SessionsPage({
   const hasOlder = nextCursor !== null;
   const hasNewer = page > 1;
 
-  // Preserve the period and user-filter params across page boundaries (#85
-  // acceptance: "Period selector + user filter both preserved across page
-  // boundaries"). Build link params off the *current* search params so any
-  // future filter we add is automatically carried.
+  // Preserve the period, unit, and user-filter params across page boundaries
+  // (#85 acceptance: "Period selector + user filter both preserved across
+  // page boundaries"). Build link params off the *current* search params so
+  // any future filter we add is automatically carried.
   const baseParams = new URLSearchParams();
   if (params.days) baseParams.set("days", params.days);
   if (params.user) baseParams.set("user", params.user);
+  if (params.units) baseParams.set("units", params.units);
 
   const newerParams = new URLSearchParams(baseParams);
   // "Newer" returns to the first page — drops cursor and `p`. Browser back
@@ -99,6 +105,7 @@ export default async function SessionsPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <UnitsSelector />
             <PeriodSelector />
           </div>
         </Suspense>
@@ -130,8 +137,9 @@ export default async function SessionsPage({
                     <th className="pr-3 pb-2 text-right font-medium">
                       Messages
                     </th>
-                    <th className="pr-3 pb-2 text-right font-medium">Tokens</th>
-                    <th className="pb-2 text-right font-medium">Cost</th>
+                    <th className="pb-2 text-right font-medium">
+                      {isTokens ? "Tokens" : "Cost"}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -178,17 +186,14 @@ export default async function SessionsPage({
                             {fmtNum(s.message_count)}
                           </Link>
                         </td>
-                        <td className="text-right tabular-nums text-zinc-300">
-                          <Link href={href} className="block py-2 pr-3">
-                            {fmtNum(
-                              Number(s.total_input_tokens) +
-                                Number(s.total_output_tokens)
-                            )}
-                          </Link>
-                        </td>
                         <td className="text-right tabular-nums text-zinc-200">
                           <Link href={href} className="block py-2">
-                            {fmtCost(Number(s.total_cost_cents))}
+                            {isTokens
+                              ? fmtNum(
+                                  Number(s.total_input_tokens) +
+                                    Number(s.total_output_tokens)
+                                )
+                              : fmtCost(Number(s.total_cost_cents))}
                           </Link>
                         </td>
                       </tr>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -9,8 +9,10 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
-import { fmtCost } from "@/lib/format";
+import { parseUnit } from "@/lib/units";
+import { fmtCost, fmtNum } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
+import { UnitsSelector } from "@/components/units-selector";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { TeamCountChart } from "@/components/charts/team-count-chart";
 import { CostPerPersonChart } from "@/components/charts/cost-per-person-chart";
@@ -19,7 +21,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function TeamPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ days?: string; units?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
@@ -29,6 +31,7 @@ export default async function TeamPage({
   // member it can only ever show themselves — send them back to Overview (#64).
   if (user.role !== "manager") redirect("/dashboard");
 
+  const unit = parseUnit(params.units);
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
   const tz = await getViewerTimeZone();
@@ -38,26 +41,37 @@ export default async function TeamPage({
     getTeamActivityByDay(user, range),
   ]);
 
+  const isTokens = unit === "tokens";
+  const valueWord = isTokens ? "Tokens" : "Cost";
+  const perPersonTitle = isTokens ? "Tokens per Person" : "Cost per Person";
+  const fmtValue = (cost_cents: number, tokens: number) =>
+    isTokens ? fmtNum(tokens) : fmtCost(cost_cents);
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Team</h1>
         <Suspense>
-          <PeriodSelector />
+          <div className="flex flex-wrap items-center gap-3">
+            <UnitsSelector />
+            <PeriodSelector />
+          </div>
         </Suspense>
       </div>
 
       <Card>
         <CardHeader>
-          <CardTitle>Cost by Team Member</CardTitle>
+          <CardTitle>{`${valueWord} by Team Member`}</CardTitle>
         </CardHeader>
         <CardContent>
           <CostBarChart
             data={userCosts.map((u) => ({
               label: u.name,
               cost_cents: u.cost_cents,
+              tokens: u.input_tokens + u.output_tokens,
             }))}
             emptyLabel="No team cost data for this period"
+            unit={unit}
           />
         </CardContent>
       </Card>
@@ -73,10 +87,10 @@ export default async function TeamPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Cost per Person</CardTitle>
+          <CardTitle>{perPersonTitle}</CardTitle>
         </CardHeader>
         <CardContent>
-          <CostPerPersonChart data={teamActivity} />
+          <CostPerPersonChart data={teamActivity} unit={unit} />
         </CardContent>
       </Card>
 
@@ -91,7 +105,7 @@ export default async function TeamPage({
               <thead>
                 <tr className="border-b border-white/10 text-left text-zinc-400">
                   <th className="pb-2 font-medium">Name</th>
-                  <th className="pb-2 text-right font-medium">Cost</th>
+                  <th className="pb-2 text-right font-medium">{valueWord}</th>
                 </tr>
               </thead>
               <tbody>
@@ -99,7 +113,7 @@ export default async function TeamPage({
                   <tr key={i} className="border-b border-white/5">
                     <td className="py-2 text-zinc-200">{u.name}</td>
                     <td className="py-2 text-right tabular-nums text-zinc-300">
-                      {fmtCost(u.cost_cents)}
+                      {fmtValue(u.cost_cents, u.input_tokens + u.output_tokens)}
                     </td>
                   </tr>
                 ))}
@@ -110,7 +124,7 @@ export default async function TeamPage({
                 <li key={i} className="flex items-center justify-between py-2">
                   <span className="text-zinc-200">{u.name}</span>
                   <span className="tabular-nums text-zinc-300">
-                    {fmtCost(u.cost_cents)}
+                    {fmtValue(u.cost_cents, u.input_tokens + u.output_tokens)}
                   </span>
                 </li>
               ))}

--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -10,7 +10,8 @@ import {
   YAxis,
 } from "recharts";
 import { differenceInDays, format, startOfMonth, startOfWeek } from "date-fns";
-import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+import { fmtCost, fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+import type { Unit } from "@/lib/units";
 
 interface ActivityData {
   bucket_day: string;
@@ -57,7 +58,13 @@ function rebucket(data: ActivityData[]): ActivityData[] {
   );
 }
 
-export function ActivityChart({ data }: { data: ActivityData[] }) {
+export function ActivityChart({
+  data,
+  unit = "tokens",
+}: {
+  data: ActivityData[];
+  unit?: Unit;
+}) {
   if (data.length === 0) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
@@ -67,6 +74,9 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
   }
 
   const bucketed = rebucket(data);
+  const isTokens = unit === "tokens";
+  const fmt = isTokens ? fmtNum : fmtCost;
+  const yAxisLabel = isTokens ? "Tokens" : "Cost";
 
   return (
     <ResponsiveContainer width="100%" height={300}>
@@ -87,13 +97,13 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
           axisLine={false}
         />
         <YAxis
-          tickFormatter={fmtNum}
+          tickFormatter={(v) => fmt(Number(v))}
           tick={{ fill: "#71717a", fontSize: 12 }}
           tickLine={false}
           axisLine={false}
           width={72}
           label={{
-            value: "Tokens",
+            value: yAxisLabel,
             angle: -90,
             position: "insideLeft",
             offset: 0,
@@ -110,25 +120,44 @@ export function ActivityChart({ data }: { data: ActivityData[] }) {
             fontSize: "13px",
           }}
           labelFormatter={(label) => fmtFullDate(String(label))}
-          formatter={(value, name) => [
-            fmtNum(Number(value)),
-            String(name) === "input_tokens" ? "Input" : "Output",
-          ]}
+          formatter={(value, name) => {
+            const key = String(name);
+            const seriesLabel = isTokens
+              ? key === "input_tokens"
+                ? "Input"
+                : "Output"
+              : "Cost";
+            return [fmt(Number(value)), seriesLabel];
+          }}
         />
-        <Bar
-          dataKey="input_tokens"
-          stackId="tokens"
-          fill="#3b82f6"
-          maxBarSize={28}
-          radius={[0, 0, 0, 0]}
-        />
-        <Bar
-          dataKey="output_tokens"
-          stackId="tokens"
-          fill="#8b5cf6"
-          maxBarSize={28}
-          radius={[4, 4, 0, 0]}
-        />
+        {isTokens ? (
+          <>
+            <Bar
+              dataKey="input_tokens"
+              stackId="value"
+              fill="#3b82f6"
+              maxBarSize={28}
+              radius={[0, 0, 0, 0]}
+              isAnimationActive={false}
+            />
+            <Bar
+              dataKey="output_tokens"
+              stackId="value"
+              fill="#8b5cf6"
+              maxBarSize={28}
+              radius={[4, 4, 0, 0]}
+              isAnimationActive={false}
+            />
+          </>
+        ) : (
+          <Bar
+            dataKey="cost_cents"
+            fill="#3b82f6"
+            maxBarSize={28}
+            radius={[4, 4, 0, 0]}
+            isAnimationActive={false}
+          />
+        )}
       </BarChart>
     </ResponsiveContainer>
   );

--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ReactElement } from "react";
 import { Bar, BarChart, LabelList } from "recharts";
-import { fmtCost } from "@/lib/format";
+import { fmtCost, fmtNum } from "@/lib/format";
 
 // CostBarChart now calls `useMediaQuery` to shrink the y-axis column on
 // narrow viewports. The hook is stubbed by a controllable function so each
@@ -45,12 +45,12 @@ describe("CostBarChart", () => {
     // Without minPointSize the non-leading bars shrink to <1px; without
     // isAnimationActive={false} LabelList silently stays empty on first paint.
     const mixedScale = [
-      { label: "claude_code / claude-opus-4-7", cost_cents: 3000 },
-      { label: "claude-opus-4-6", cost_cents: 81 },
-      { label: "codex / (untagged)", cost_cents: 47 },
-      { label: "tiny-1", cost_cents: 12 },
-      { label: "tiny-2", cost_cents: 9 },
-      { label: "tiny-3", cost_cents: 7 },
+      { label: "claude_code / claude-opus-4-7", cost_cents: 3000, tokens: 0 },
+      { label: "claude-opus-4-6", cost_cents: 81, tokens: 0 },
+      { label: "codex / (untagged)", cost_cents: 47, tokens: 0 },
+      { label: "tiny-1", cost_cents: 12, tokens: 0 },
+      { label: "tiny-2", cost_cents: 9, tokens: 0 },
+      { label: "tiny-3", cost_cents: 7, tokens: 0 },
     ];
     const tree = CostBarChart({
       data: mixedScale,
@@ -71,31 +71,65 @@ describe("CostBarChart", () => {
     const labelList = nodes.find((n) => n.type === LabelList);
     expect(
       labelList,
-      "LabelList should be inside Bar so each row gets a $X.XX suffix"
+      "LabelList should be inside Bar so each row gets a value suffix"
     ).toBeDefined();
     const labelListProps = labelList!.props as {
       dataKey: string;
       position: string;
       formatter: (v: unknown) => string | number;
     };
-    expect(labelListProps.dataKey).toBe("cost_cents");
+    // Both axes are now keyed off the unit-projected `value` field so the
+    // toggle doesn't have to re-key the bar element on switch (#128).
+    expect(labelListProps.dataKey).toBe("value");
     expect(labelListProps.position).toBe("right");
 
-    // Formatter must round-trip a cents amount into the fmtCost form so the
-    // regression where `$X.XX` goes missing can't sneak back in.
+    // Default unit is dollars, so the formatter must round-trip cents into
+    // the fmtCost form and the missing-suffix regression from #41 stays put.
     const formatter = labelListProps.formatter;
     expect(formatter).toBeTypeOf("function");
     expect(formatter(3000)).toBe(fmtCost(3000));
     expect(formatter(81)).toBe(fmtCost(81));
   });
 
+  it("renders token totals when unit='tokens' (#128)", () => {
+    const data = [
+      { label: "alpha", cost_cents: 1000, tokens: 5_000_000 },
+      { label: "beta", cost_cents: 200, tokens: 3_500_000 },
+    ];
+    const tree = CostBarChart({ data, emptyLabel: "unused", unit: "tokens" });
+    const nodes = Array.from(walk(tree));
+
+    const labelList = nodes.find((n) => n.type === LabelList);
+    expect(labelList).toBeDefined();
+    const formatter = (
+      labelList!.props as { formatter: (v: unknown) => string | number }
+    ).formatter;
+    // Token mode formats with fmtNum (no $).
+    expect(formatter(5_000_000)).toBe(fmtNum(5_000_000));
+    expect(formatter(3_500_000)).toBe(fmtNum(3_500_000));
+
+    // Sort order follows the projected token value, not cost — alpha leads
+    // because 5M > 3.5M, even though both have positive cost.
+    const barChart = nodes.find((n) => n.type === BarChart);
+    const rows = (barChart!.props as { data: { value: number }[] }).data;
+    expect(rows.map((r) => r.value)).toEqual([5_000_000, 3_500_000]);
+  });
+
   it("strips the shared label prefix on compact widths so rows are visibly distinct (#121)", () => {
     isCompact = true;
     try {
       const collidingPrefix = [
-        { label: "claude_code / claude-sonnet-4-5", cost_cents: 5000 },
-        { label: "claude_code / claude-haiku-4-5", cost_cents: 3000 },
-        { label: "claude_code / claude-opus-4-7", cost_cents: 1000 },
+        {
+          label: "claude_code / claude-sonnet-4-5",
+          cost_cents: 5000,
+          tokens: 0,
+        },
+        {
+          label: "claude_code / claude-haiku-4-5",
+          cost_cents: 3000,
+          tokens: 0,
+        },
+        { label: "claude_code / claude-opus-4-7", cost_cents: 1000, tokens: 0 },
       ];
       const tree = CostBarChart({
         data: collidingPrefix,
@@ -122,8 +156,8 @@ describe("CostBarChart", () => {
     isCompact = true;
     try {
       const distinctEnough = [
-        { label: "alpha", cost_cents: 100 },
-        { label: "beta", cost_cents: 50 },
+        { label: "alpha", cost_cents: 100, tokens: 0 },
+        { label: "beta", cost_cents: 50, tokens: 0 },
       ];
       const tree = CostBarChart({
         data: distinctEnough,

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -9,12 +9,14 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { fmtCost } from "@/lib/format";
+import { fmtCost, fmtNum } from "@/lib/format";
+import type { Unit } from "@/lib/units";
 import { useMediaQuery } from "@/lib/use-media-query";
 
 interface CostBarDatum {
   label: string;
   cost_cents: number;
+  tokens: number;
 }
 
 const MAX_ITEMS = 10;
@@ -27,7 +29,7 @@ function barChartHeight(rows: number): number {
 
 function truncateLabel(value: string, maxLen = 28): string {
   if (value.length <= maxLen) return value;
-  return value.slice(0, maxLen - 1) + "\u2026";
+  return value.slice(0, maxLen - 1) + "…";
 }
 
 /**
@@ -49,8 +51,8 @@ function commonPrefix(values: string[]): string {
 
 /**
  * Drop the longest common prefix from every label when truncation would
- * otherwise collapse rows onto each other \u2014 e.g. four rows of
- * `claude_code / claude-\u2026` lose the differentiating model id at mobile
+ * otherwise collapse rows onto each other — e.g. four rows of
+ * `claude_code / claude-…` lose the differentiating model id at mobile
  * widths. Only kicks in when the truncated forms actually collide and the
  * stripped forms are non-empty (#121).
  */
@@ -67,9 +69,11 @@ function stripSharedPrefix(labels: string[], maxLen: number): string[] {
 export function CostBarChart({
   data,
   emptyLabel,
+  unit = "dollars",
 }: {
   data: CostBarDatum[];
   emptyLabel: string;
+  unit?: Unit;
 }) {
   // At 390px the 180px label column plus 56px right padding claims ~60% of
   // the chart, leaving bars with no room. Shrink both below `sm` and leave
@@ -83,8 +87,17 @@ export function CostBarChart({
   // clipped (#120). 14 chars fits comfortably.
   const labelMaxLen = isCompact ? 14 : 28;
 
+  // The bar dataKey is the same name across both modes so recharts doesn't
+  // re-key the bar element on toggle; the projected `value` is what flips.
+  const fmt = unit === "tokens" ? fmtNum : fmtCost;
+  const valueLabel = unit === "tokens" ? "Tokens" : "Cost";
+
   const sorted = [...data]
-    .sort((a, b) => b.cost_cents - a.cost_cents)
+    .map((d) => ({
+      ...d,
+      value: unit === "tokens" ? d.tokens : d.cost_cents,
+    }))
+    .sort((a, b) => b.value - a.value)
     .slice(0, MAX_ITEMS);
 
   if (sorted.length === 0) {
@@ -145,9 +158,9 @@ export function CostBarChart({
           }}
         />
         <XAxis
-          dataKey="cost_cents"
+          dataKey="value"
           type="number"
-          tickFormatter={(v) => fmtCost(v)}
+          tickFormatter={(v) => fmt(Number(v))}
           axisLine={false}
           tickLine={false}
           tick={{ fill: "#71717a", fontSize: 12 }}
@@ -160,31 +173,31 @@ export function CostBarChart({
             borderRadius: "8px",
             fontSize: "13px",
           }}
-          formatter={(value) => [fmtCost(Number(value)), "Cost"]}
+          formatter={(value) => [fmt(Number(value)), valueLabel]}
         />
         <Bar
-          dataKey="cost_cents"
+          dataKey="value"
           fill="#3b82f6"
           barSize={BAR_SIZE}
           radius={[5, 5, 5, 5]}
-          // Sub-dollar rows otherwise render at <1px next to a double-digit
-          // leader. Floor the rendered width so every >0 row is still a
-          // recognizable sliver; the cost label to the right is the
-          // authoritative magnitude signal (#41).
+          // Sub-dollar (or sub-K-token) rows otherwise render at <1px next
+          // to a double-digit leader. Floor the rendered width so every >0
+          // row is still a recognizable sliver; the right-side label is
+          // the authoritative magnitude signal (#41).
           minPointSize={4}
           // recharts v3 gates LabelList on animation completion; if the Bar
           // ever fails to emit `onAnimationEnd` (e.g. under strict mode or
           // when re-rendered mid-animation) `<LabelList>` stays empty and the
-          // `$X.XX` suffix is silently missing. Skip the animation so labels
+          // suffix label is silently missing. Skip the animation so labels
           // render on first paint.
           isAnimationActive={false}
         >
           <LabelList
-            dataKey="cost_cents"
+            dataKey="value"
             position="right"
             fill="#71717a"
             fontSize={12}
-            formatter={(v) => fmtCost(Number(v))}
+            formatter={(v) => fmt(Number(v))}
           />
         </Bar>
       </BarChart>

--- a/src/components/charts/cost-per-person-chart.tsx
+++ b/src/components/charts/cost-per-person-chart.tsx
@@ -9,15 +9,24 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { fmtCost, fmtDate, fmtFullDate } from "@/lib/format";
+import { fmtCost, fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+import type { Unit } from "@/lib/units";
 
 interface CostPerPersonDatum {
   bucket_day: string;
   cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
   active_members: number;
 }
 
-export function CostPerPersonChart({ data }: { data: CostPerPersonDatum[] }) {
+export function CostPerPersonChart({
+  data,
+  unit = "dollars",
+}: {
+  data: CostPerPersonDatum[];
+  unit?: Unit;
+}) {
   if (data.length === 0) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
@@ -26,14 +35,22 @@ export function CostPerPersonChart({ data }: { data: CostPerPersonDatum[] }) {
     );
   }
 
+  const isTokens = unit === "tokens";
+  const fmt = isTokens ? fmtNum : fmtCost;
+  const seriesLabel = isTokens ? "Tokens / person" : "Cost / person";
+
   // Days with no active members render as gaps rather than NaN/Infinity bars
   // so the chart visually matches the empty-state semantics elsewhere on the
   // page (#127 acceptance: "render a gap rather than dividing by zero").
-  const series = data.map((d) => ({
-    bucket_day: d.bucket_day,
-    cost_per_person_cents:
-      d.active_members > 0 ? d.cost_cents / d.active_members : null,
-  }));
+  const series = data.map((d) => {
+    if (d.active_members <= 0) {
+      return { bucket_day: d.bucket_day, value: null as number | null };
+    }
+    const numerator = isTokens
+      ? d.input_tokens + d.output_tokens
+      : d.cost_cents;
+    return { bucket_day: d.bucket_day, value: numerator / d.active_members };
+  });
 
   return (
     <ResponsiveContainer width="100%" height={300}>
@@ -54,13 +71,13 @@ export function CostPerPersonChart({ data }: { data: CostPerPersonDatum[] }) {
           axisLine={false}
         />
         <YAxis
-          tickFormatter={(v) => fmtCost(Number(v))}
+          tickFormatter={(v) => fmt(Number(v))}
           tick={{ fill: "#71717a", fontSize: 12 }}
           tickLine={false}
           axisLine={false}
           width={72}
           label={{
-            value: "Cost / person",
+            value: seriesLabel,
             angle: -90,
             position: "insideLeft",
             offset: 0,
@@ -77,10 +94,10 @@ export function CostPerPersonChart({ data }: { data: CostPerPersonDatum[] }) {
             fontSize: "13px",
           }}
           labelFormatter={(label) => fmtFullDate(String(label))}
-          formatter={(value) => [fmtCost(Number(value)), "Cost / person"]}
+          formatter={(value) => [fmt(Number(value)), seriesLabel]}
         />
         <Bar
-          dataKey="cost_per_person_cents"
+          dataKey="value"
           fill="#f59e0b"
           maxBarSize={28}
           radius={[4, 4, 0, 0]}

--- a/src/components/units-selector.tsx
+++ b/src/components/units-selector.tsx
@@ -3,12 +3,7 @@
 import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { clsx } from "clsx";
-import {
-  DEFAULT_UNIT,
-  UNITS,
-  UNITS_STORAGE_KEY,
-  parseUnit,
-} from "@/lib/units";
+import { DEFAULT_UNIT, UNITS, UNITS_STORAGE_KEY, parseUnit } from "@/lib/units";
 
 /**
  * Display-unit toggle for the dashboard (#128). Mirrors the URL-driven shape

--- a/src/components/units-selector.tsx
+++ b/src/components/units-selector.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { clsx } from "clsx";
+import {
+  DEFAULT_UNIT,
+  UNITS,
+  UNITS_STORAGE_KEY,
+  parseUnit,
+} from "@/lib/units";
+
+/**
+ * Display-unit toggle for the dashboard (#128). Mirrors the URL-driven shape
+ * of `PeriodSelector` (`?units=tokens|dollars`) so the choice round-trips
+ * through links, bookmarks, and the back/forward stack.
+ *
+ * On mount, if the URL has no `?units=` param, we hydrate the URL from the
+ * last value in `localStorage` (using `router.replace` so the navigation
+ * stack doesn't grow). That makes the choice survive reloads even when the
+ * user lands on a bare `/dashboard/...` link, while still keeping
+ * server-rendered output a pure function of the URL.
+ */
+export function UnitsSelector() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlValue = searchParams.get("units");
+  const current = parseUnit(urlValue);
+
+  useEffect(() => {
+    if (urlValue) return;
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(UNITS_STORAGE_KEY);
+    const persisted = parseUnit(stored);
+    if (persisted === DEFAULT_UNIT) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("units", persisted);
+    router.replace(`?${params.toString()}`);
+    // We deliberately depend on `urlValue` so this only fires while the URL
+    // is missing the param — once it's set (either by us or by a click) the
+    // effect short-circuits on the very first line.
+  }, [urlValue, router, searchParams]);
+
+  function selectUnit(value: string) {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(UNITS_STORAGE_KEY, value);
+    }
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("units", value);
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Display units"
+      className="flex gap-1 rounded-lg border border-white/10 bg-white/[0.02] p-1"
+    >
+      {UNITS.map((u) => (
+        <button
+          key={u.value}
+          role="radio"
+          aria-checked={current === u.value}
+          onClick={() => selectUnit(u.value)}
+          className={clsx(
+            "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            current === u.value
+              ? "bg-white/10 text-white"
+              : "text-zinc-400 hover:text-zinc-200"
+          )}
+        >
+          {u.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -743,7 +743,13 @@ describe("Overview ↔ Team reconciliation (#15)", () => {
     );
     expect(janeOverview.totalCostCents).toBe(1500_00);
     expect(janeByUser).toEqual([
-      { id: "usr_jane", name: "Jane", cost_cents: 1500_00 },
+      {
+        id: "usr_jane",
+        name: "Jane",
+        cost_cents: 1500_00,
+        input_tokens: 0,
+        output_tokens: 0,
+      },
     ]);
   });
 });
@@ -1174,6 +1180,8 @@ describe("getCostByDevice", () => {
         owner_name: null,
         last_seen: null,
         cost_cents: 1500_00,
+        input_tokens: 0,
+        output_tokens: 0,
       },
     ]);
   });

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -270,16 +270,26 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
     userMeta.set(u.id, u.display_name || u.email || u.id.slice(0, 8));
   }
 
-  type Bucket = { id: string; name: string; cost_cents: number };
+  type Bucket = {
+    id: string;
+    name: string;
+    cost_cents: number;
+    input_tokens: number;
+    output_tokens: number;
+  };
   const byUser = new Map<string, Bucket>();
   for (const r of deviceCostRows) {
     const ownerId = deviceToUser.get(r.device_id);
     const bucketId =
       ownerId && visibleOwnerIds.has(ownerId) ? ownerId : UNASSIGNED_USER_ID;
     const cost = Number(r.cost_cents);
+    const inTok = Number(r.input_tokens ?? 0);
+    const outTok = Number(r.output_tokens ?? 0);
     const existing = byUser.get(bucketId);
     if (existing) {
       existing.cost_cents += cost;
+      existing.input_tokens += inTok;
+      existing.output_tokens += outTok;
     } else {
       byUser.set(bucketId, {
         id: bucketId,
@@ -288,12 +298,14 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
             ? "Unassigned"
             : (userMeta.get(bucketId) ?? bucketId.slice(0, 8)),
         cost_cents: cost,
+        input_tokens: inTok,
+        output_tokens: outTok,
       });
     }
   }
 
   return Array.from(byUser.values())
-    .filter((u) => u.cost_cents > 0)
+    .filter((u) => u.cost_cents > 0 || u.input_tokens + u.output_tokens > 0)
     .sort((a, b) => {
       // Keep "Unassigned" at the end regardless of its magnitude.
       if (a.id === UNASSIGNED_USER_ID) return 1;
@@ -305,12 +317,16 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
 interface DeviceCostRow {
   device_id: string;
   cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
 }
 
 export interface TeamActivityDay {
   bucket_day: string;
   active_members: number;
   cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
 }
 
 /**
@@ -343,6 +359,8 @@ export async function getTeamActivityByDay(
       bucket_day: r.bucket_day,
       active_members: Number(r.active_members),
       cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
     }))
     .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
 }
@@ -351,6 +369,8 @@ interface TeamActivityRow {
   bucket_day: string;
   active_members: number | string;
   cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
 }
 
 interface UserLookup {
@@ -366,6 +386,8 @@ export interface DeviceCost {
   owner_name: string | null;
   last_seen: string | null;
   cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
 }
 
 /**
@@ -441,10 +463,17 @@ export async function getCostByDevice(
   }
 
   // The RPC already aggregates by device_id, so each row is a (device, sum)
-  // pair — no further reduction needed.
-  const costByDevice = new Map<string, number>();
+  // tuple — no further reduction needed.
+  const totalsByDevice = new Map<
+    string,
+    { cost_cents: number; input_tokens: number; output_tokens: number }
+  >();
   for (const r of rollups) {
-    costByDevice.set(r.device_id, Number(r.cost_cents));
+    totalsByDevice.set(r.device_id, {
+      cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
+    });
   }
 
   // Surface every visible device — including zero-cost ones — so a brand-new
@@ -453,6 +482,7 @@ export async function getCostByDevice(
   // gap covered by FirstSyncInProgressBanner on Overview.
   const result: DeviceCost[] = [];
   for (const [id, meta] of deviceMeta) {
+    const totals = totalsByDevice.get(id);
     result.push({
       id,
       label: meta.label,
@@ -461,7 +491,9 @@ export async function getCostByDevice(
           ? (ownerLookup.get(meta.user_id) ?? null)
           : null,
       last_seen: meta.last_seen,
-      cost_cents: costByDevice.get(id) ?? 0,
+      cost_cents: totals?.cost_cents ?? 0,
+      input_tokens: totals?.input_tokens ?? 0,
+      output_tokens: totals?.output_tokens ?? 0,
     });
   }
 
@@ -494,8 +526,10 @@ export async function getCostByModel(
       provider: r.provider,
       model: r.model,
       cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
     }))
-    .filter((m) => m.cost_cents > 0)
+    .filter((m) => m.cost_cents > 0 || m.input_tokens + m.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
 
@@ -503,6 +537,8 @@ interface ModelCostRow {
   provider: string;
   model: string;
   cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
 }
 
 /**
@@ -530,14 +566,18 @@ export async function getCostByRepo(
     .map((r) => ({
       repo_id: r.repo_id,
       cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
     }))
-    .filter((r) => r.cost_cents > 0)
+    .filter((r) => r.cost_cents > 0 || r.input_tokens + r.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
 
 interface RepoCostRow {
   repo_id: string;
   cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
 }
 
 /**
@@ -566,8 +606,10 @@ export async function getCostByBranch(
       repo_id: r.repo_id,
       git_branch: r.git_branch,
       cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
     }))
-    .filter((b) => b.cost_cents > 0)
+    .filter((b) => b.cost_cents > 0 || b.input_tokens + b.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
 
@@ -575,6 +617,8 @@ interface BranchCostRow {
   repo_id: string;
   git_branch: string;
   cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
 }
 
 /**
@@ -602,14 +646,18 @@ export async function getCostByTicket(
     .map((r) => ({
       ticket: r.ticket,
       cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
     }))
-    .filter((t) => t.cost_cents > 0)
+    .filter((t) => t.cost_cents > 0 || t.input_tokens + t.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
 
 interface TicketCostRow {
   ticket: string;
   cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
 }
 
 /**

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,0 +1,34 @@
+/**
+ * Display-unit toggle shared across the dashboard (#128).
+ *
+ * The dashboard mixes two natural lenses on the same data:
+ *   - dollars  — what finance/managers care about
+ *   - tokens   — what engineers care about
+ *
+ * Both are derivable from the rollup rows (`cost_cents` and
+ * `input_tokens + output_tokens`), so the toggle is purely a render-time
+ * choice, not a query-shape change. Keeping the values, default, and parser
+ * in one module means every page agrees on the wire format of `?units=`
+ * and on what falls back when the param is missing or malformed.
+ */
+export const UNITS = [
+  { label: "$", value: "dollars" },
+  { label: "Tokens", value: "tokens" },
+] as const;
+
+export type Unit = (typeof UNITS)[number]["value"];
+
+/** Default lens when the URL has no `?units=` param. */
+export const DEFAULT_UNIT: Unit = "dollars";
+
+/** localStorage key used by `UnitsSelector` to persist the last choice. */
+export const UNITS_STORAGE_KEY = "budi.dashboard.units";
+
+/**
+ * Coerce a raw `?units=` value (or any string-ish) into a known unit. Falls
+ * back to `DEFAULT_UNIT` for missing/unknown values so an unsupported value
+ * pasted into a URL never crashes the page or silently shows mixed units.
+ */
+export function parseUnit(raw: string | null | undefined): Unit {
+  return raw === "tokens" ? "tokens" : "dollars";
+}

--- a/supabase/migrations/008_breakdown_tokens.sql
+++ b/supabase/migrations/008_breakdown_tokens.sql
@@ -3,6 +3,18 @@
 -- second round trip. Cost was the only metric the breakdown RPCs emitted —
 -- adding tokens here keeps the per-row aggregation in Postgres so the
 -- 100k-row cap that #92 fixed cannot resurface as a JS-side sum.
+--
+-- Postgres won't let `CREATE OR REPLACE FUNCTION` change a function's
+-- RETURNS TABLE shape (it's the same row-type rule that blocks dropping a
+-- column from a view). Drop each function first; the next CREATE
+-- re-establishes it with the wider tuple.
+
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_device(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_model(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_repo(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_branch(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_ticket(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_team_activity_by_day(TEXT[], DATE, DATE);
 
 -- ============================================================
 -- Per-device breakdown (Devices, Team-by-user via JS join).

--- a/supabase/migrations/008_breakdown_tokens.sql
+++ b/supabase/migrations/008_breakdown_tokens.sql
@@ -1,0 +1,194 @@
+-- Surface input_tokens / output_tokens on every breakdown RPC so the dashboard
+-- unit toggle (#128) can render the same chart in dollars or tokens without a
+-- second round trip. Cost was the only metric the breakdown RPCs emitted —
+-- adding tokens here keeps the per-row aggregation in Postgres so the
+-- 100k-row cap that #92 fixed cannot resurface as a JS-side sum.
+
+-- ============================================================
+-- Per-device breakdown (Devices, Team-by-user via JS join).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_device(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    device_id      TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        device_id,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY device_id;
+$$;
+
+-- ============================================================
+-- Per-(provider, model) breakdown.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_model(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    provider       TEXT,
+    model          TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        provider,
+        model,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY provider, model;
+$$;
+
+-- ============================================================
+-- Per-repo breakdown.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_repo(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    repo_id        TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        repo_id,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY repo_id;
+$$;
+
+-- ============================================================
+-- Per-(repo, branch) breakdown.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_branch(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    repo_id        TEXT,
+    git_branch     TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        repo_id,
+        git_branch,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY repo_id, git_branch;
+$$;
+
+-- ============================================================
+-- Per-ticket breakdown (rows with ticket IS NULL still excluded).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_ticket(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    ticket         TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        ticket,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND ticket IS NOT NULL
+    GROUP BY ticket;
+$$;
+
+-- ============================================================
+-- Team activity per day — adds tokens alongside the existing cost.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_team_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    bucket_day      DATE,
+    active_members  BIGINT,
+    cost_cents      NUMERIC,
+    input_tokens    BIGINT,
+    output_tokens   BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        r.bucket_day,
+        COUNT(DISTINCT d.user_id)::BIGINT AS active_members,
+        SUM(r.cost_cents)                 AS cost_cents,
+        SUM(r.input_tokens)::BIGINT       AS input_tokens,
+        SUM(r.output_tokens)::BIGINT      AS output_tokens
+    FROM daily_rollups r
+    JOIN devices d ON d.id = r.device_id
+    WHERE r.device_id = ANY(p_device_ids)
+      AND r.bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY r.bucket_day
+    ORDER BY r.bucket_day ASC;
+$$;


### PR DESCRIPTION
## Summary

Closes #128.

Adds a global **\$ / Tokens** toggle next to the period selector on every dashboard subpage. The dashboard previously mixed units (cost charts/tables in dollars, Daily Activity in tokens); this lets the user pick one lens and have every chart, axis, tooltip, table column, and stat card render in it.

- URL-driven via `?units=tokens|dollars` (mirrors `?days=`); default is **dollars** so existing bookmarks behave the same.
- Persisted in `localStorage` (`budi.dashboard.units`) and re-applied via `router.replace` when the URL has no param, so reloads of bare `/dashboard/...` links keep the choice.
- Carried across pagination (sessions cursor links) and reachable from every subpage's filter cluster.

## Changes

- New: `src/lib/units.ts`, `src/components/units-selector.tsx`.
- `CostBarChart`, `ActivityChart`, `CostPerPersonChart` accept a `unit` prop and switch tickFormatter / y-axis label / tooltip / `LabelList` formatter accordingly. Bar `dataKey` projects to a unified `value` field so the toggle doesn't have to re-key the bar element on switch.
- Every `/dashboard/*` page parses `units`, plumbs it into chart titles + table column headers, and renders the value via `fmtCost` or `fmtNum` as appropriate. Sessions table drops the now-redundant standalone Tokens column and lets the (renamed) Cost column flip to Tokens under the toggle.
- Migration `008_breakdown_tokens.sql` extends every `dashboard_cost_by_*` RPC and `dashboard_team_activity_by_day` to also return `input_tokens` / `output_tokens`, so the tokens lens reuses the same Postgres-side aggregation path (no 100k-row PostgREST cap, per #92).
- DAL: `getCostByUser` / `getCostByDevice` / `getCostByModel` / `getCostByRepo` / `getCostByBranch` / `getCostByTicket` / `getTeamActivityByDay` now surface tokens alongside cost.

## Test plan

- [x] `npm test` — 19 files, 186 tests pass (incl. new `?units=tokens` cases on `/dashboard`, `/sessions`, and `CostBarChart`).
- [x] `npm run lint` — clean.
- [x] `npm run build` — Next.js 16 production build succeeds.
- [ ] Smoke in the browser:
  - [ ] Toggle on Overview / Models / Repos / Sessions / Devices / Team flips axes, tooltips, table columns, and the spend stat card.
  - [ ] `?units=tokens` survives navigation between `/dashboard/*` pages.
  - [ ] Reload of a bare `/dashboard/models` URL re-applies the last-chosen unit from `localStorage`.
  - [ ] No layout regression at 390px or on desktop.
- [ ] Apply migration `008_breakdown_tokens.sql` against a populated Postgres so the new columns flow through into the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)