### PR TITLE
feat(team): co-locate cost-by-member views and add headline averages (#131)

### DIFF
--- a/src/app/dashboard/team/page.test.tsx
+++ b/src/app/dashboard/team/page.test.tsx
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { containsSuspense, extractText } from "@/test-utils/page-tree";
 
 /**
- * Page-level coverage for `/dashboard/team` (#112).
+ * Page-level coverage for `/dashboard/team` (#112, #131).
  *
  * Defense-in-depth ladder is the moving part to lock down here:
- *   1. Smoke — manager view renders Team headline, chart card, and member table.
+ *   1. Smoke — manager view renders Team headline, the merged cost-by-member
+ *      card (chart + table together), and headline averages on each
+ *      time-series card.
  *   2. Empty — empty `getCostByUser` still renders the chart-empty fallback.
  *   3. Loading — `<Suspense>` wraps the period selector.
  *   4. Error — DAL faults propagate so the framework error boundary fires.
@@ -48,13 +50,37 @@ beforeEach(() => {
   redirectMock.mockClear();
   dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
   dal.getCostByUser.mockReset().mockResolvedValue([
-    { id: "usr_ivan", name: "Ivan", cost_cents: 2_500_00 },
-    { id: "usr_jane", name: "Jane", cost_cents: 1_500_00 },
+    {
+      id: "usr_ivan",
+      name: "Ivan",
+      cost_cents: 2_500_00,
+      input_tokens: 0,
+      output_tokens: 0,
+    },
+    {
+      id: "usr_jane",
+      name: "Jane",
+      cost_cents: 1_500_00,
+      input_tokens: 0,
+      output_tokens: 0,
+    },
   ]);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
   dal.getTeamActivityByDay.mockReset().mockResolvedValue([
-    { bucket_day: "2026-05-01", active_members: 2, cost_cents: 4_000_00 },
-    { bucket_day: "2026-05-02", active_members: 1, cost_cents: 1_000_00 },
+    {
+      bucket_day: "2026-05-01",
+      active_members: 2,
+      cost_cents: 4_000_00,
+      input_tokens: 0,
+      output_tokens: 0,
+    },
+    {
+      bucket_day: "2026-05-02",
+      active_members: 1,
+      cost_cents: 1_000_00,
+      input_tokens: 0,
+      output_tokens: 0,
+    },
   ]);
 });
 
@@ -64,25 +90,36 @@ async function render(searchParams: Record<string, string> = {}) {
 }
 
 describe("dashboard/team /page", () => {
-  it("smoke: renders Team headline, the cost chart, and the member table", async () => {
+  it("smoke: renders Team headline, the merged cost-by-member card, and the headline averages", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("Team");
     expect(text).toContain("Cost by Team Member");
-    expect(text).toContain("Team Members");
     expect(text).toContain("Ivan");
     expect(text).toContain("Jane");
+    // Headline-average tiles on the time-series cards (#131).
+    expect(text).toContain("Avg active members");
+    expect(text).toContain("Avg cost per person");
   });
 
-  it("empty: renders the chart's empty-state copy and skips the member table", async () => {
+  it("smoke: tokens unit relabels the per-person headline to tokens", async () => {
+    const node = await render({ units: "tokens" });
+    const text = extractText(node);
+    expect(text).toContain("Avg tokens per person");
+    expect(text).not.toContain("Avg cost per person");
+  });
+
+  it("empty: renders the chart's empty-state copy and the merged-card collapses to chart-only", async () => {
     dal.getCostByUser.mockResolvedValue([]);
+    dal.getTeamActivityByDay.mockResolvedValue([]);
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("No team cost data for this period");
-    // Members table is gated on `userCosts.length > 0` — must not render here.
-    expect(text).not.toContain("Team Members");
+    // No `getTeamActivityByDay` rows ⇒ both averages render the em-dash
+    // sentinel rather than `NaN` (#131 acceptance).
+    expect(text).toContain("—");
   });
 
   it("loading: composes a Suspense boundary around the filter cluster", async () => {

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -16,6 +16,7 @@ import { UnitsSelector } from "@/components/units-selector";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { TeamCountChart } from "@/components/charts/team-count-chart";
 import { CostPerPersonChart } from "@/components/charts/cost-per-person-chart";
+import { StatCard } from "@/components/stat-card";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function TeamPage({
@@ -47,6 +48,43 @@ export default async function TeamPage({
   const fmtValue = (cost_cents: number, tokens: number) =>
     isTokens ? fmtNum(tokens) : fmtCost(cost_cents);
 
+  // Headline averages for the time-series cards (#131). "Avg active members"
+  // is the mean of the daily distinct-member counts over days that have data
+  // (empty days are dropped upstream, so we divide by the row count). Avg
+  // per-person matches the chart's per-day formula: total numerator divided
+  // by total active-member-days, so the headline reads as the period-level
+  // weighted average of the curve below it.
+  const dayCount = teamActivity.length;
+  const totalActiveMemberDays = teamActivity.reduce(
+    (s, d) => s + d.active_members,
+    0
+  );
+  const totalCostCents = teamActivity.reduce((s, d) => s + d.cost_cents, 0);
+  const totalTokens = teamActivity.reduce(
+    (s, d) => s + d.input_tokens + d.output_tokens,
+    0
+  );
+  const avgActiveMembers =
+    dayCount > 0 ? totalActiveMemberDays / dayCount : null;
+  const perPersonNumerator = isTokens ? totalTokens : totalCostCents;
+  const avgPerPerson =
+    totalActiveMemberDays > 0
+      ? perPersonNumerator / totalActiveMemberDays
+      : null;
+
+  const avgActiveMembersLabel =
+    avgActiveMembers === null
+      ? "—"
+      : avgActiveMembers.toLocaleString("en-US", {
+          maximumFractionDigits: 1,
+        });
+  const avgPerPersonLabel =
+    avgPerPerson === null
+      ? "—"
+      : isTokens
+        ? fmtNum(Math.round(avgPerPerson))
+        : fmtCost(avgPerPerson);
+
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -64,15 +102,66 @@ export default async function TeamPage({
           <CardTitle>{`${valueWord} by Team Member`}</CardTitle>
         </CardHeader>
         <CardContent>
-          <CostBarChart
-            data={userCosts.map((u) => ({
-              label: u.name,
-              cost_cents: u.cost_cents,
-              tokens: u.input_tokens + u.output_tokens,
-            }))}
-            emptyLabel="No team cost data for this period"
-            unit={unit}
-          />
+          {userCosts.length === 0 ? (
+            <CostBarChart
+              data={[]}
+              emptyLabel="No team cost data for this period"
+              unit={unit}
+            />
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2">
+              <CostBarChart
+                data={userCosts.map((u) => ({
+                  label: u.name,
+                  cost_cents: u.cost_cents,
+                  tokens: u.input_tokens + u.output_tokens,
+                }))}
+                emptyLabel="No team cost data for this period"
+                unit={unit}
+              />
+              <div>
+                <table className="hidden w-full text-sm sm:table">
+                  <thead>
+                    <tr className="border-b border-white/10 text-left text-zinc-400">
+                      <th className="pb-2 font-medium">Name</th>
+                      <th className="pb-2 text-right font-medium">
+                        {valueWord}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {userCosts.map((u, i) => (
+                      <tr key={i} className="border-b border-white/5">
+                        <td className="py-2 text-zinc-200">{u.name}</td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {fmtValue(
+                            u.cost_cents,
+                            u.input_tokens + u.output_tokens
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <ul className="divide-y divide-white/5 text-sm sm:hidden">
+                  {userCosts.map((u, i) => (
+                    <li
+                      key={i}
+                      className="flex items-center justify-between py-2"
+                    >
+                      <span className="text-zinc-200">{u.name}</span>
+                      <span className="tabular-nums text-zinc-300">
+                        {fmtValue(
+                          u.cost_cents,
+                          u.input_tokens + u.output_tokens
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -81,7 +170,13 @@ export default async function TeamPage({
           <CardTitle>Team Count</CardTitle>
         </CardHeader>
         <CardContent>
-          <TeamCountChart data={teamActivity} />
+          <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+            <StatCard
+              title="Avg active members"
+              value={avgActiveMembersLabel}
+            />
+            <TeamCountChart data={teamActivity} />
+          </div>
         </CardContent>
       </Card>
 
@@ -90,48 +185,15 @@ export default async function TeamPage({
           <CardTitle>{perPersonTitle}</CardTitle>
         </CardHeader>
         <CardContent>
-          <CostPerPersonChart data={teamActivity} unit={unit} />
+          <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+            <StatCard
+              title={isTokens ? "Avg tokens per person" : "Avg cost per person"}
+              value={avgPerPersonLabel}
+            />
+            <CostPerPersonChart data={teamActivity} unit={unit} />
+          </div>
         </CardContent>
       </Card>
-
-      {userCosts.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Team Members</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {/* Table on sm+; stacked rows below. */}
-            <table className="hidden w-full text-sm sm:table">
-              <thead>
-                <tr className="border-b border-white/10 text-left text-zinc-400">
-                  <th className="pb-2 font-medium">Name</th>
-                  <th className="pb-2 text-right font-medium">{valueWord}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {userCosts.map((u, i) => (
-                  <tr key={i} className="border-b border-white/5">
-                    <td className="py-2 text-zinc-200">{u.name}</td>
-                    <td className="py-2 text-right tabular-nums text-zinc-300">
-                      {fmtValue(u.cost_cents, u.input_tokens + u.output_tokens)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <ul className="divide-y divide-white/5 text-sm sm:hidden">
-              {userCosts.map((u, i) => (
-                <li key={i} className="flex items-center justify-between py-2">
-                  <span className="text-zinc-200">{u.name}</span>
-                  <span className="tabular-nums text-zinc-300">
-                    {fmtValue(u.cost_cents, u.input_tokens + u.output_tokens)}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #131. Restructures `/dashboard/team` from four cards to three:

- **Cost by Team Member** — bar chart and member table merged into one card. `sm+` puts chart left, table right (`grid sm:grid-cols-2`); mobile stacks chart over the existing list rendering. Standalone "Team Members" card removed.
- **Team Count** — adds a "Avg active members" `StatCard` tile next to the chart. Mean of daily distinct active members over days with data.
- **Cost per Person** — adds a "Avg cost per person" / "Avg tokens per person" tile next to the chart. Computed as `period total / total active-member-days` so the headline is the weighted average of the per-day series the chart already renders.

Empty/zero windows render `—` rather than `NaN`. `?days=` and `?units=` are honored. Manager-only redirect and `<Suspense>`-wrapped selector cluster are preserved.

## Test plan

- [x] `npx vitest run src/app/dashboard/team/page.test.tsx` — added smoke coverage for headline averages and tokens unit relabeling, refreshed empty-state assertions.
- [x] `npx vitest run` — full suite, 19 files / 187 tests pass.
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/app/dashboard/team/`
- [x] `npx next build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)