### PR TITLE
feat(header): source-explicit sync badge + auto-refresh on new data (#133)

### DIFF
--- a/src/app/api/freshness/route.test.ts
+++ b/src/app/api/freshness/route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #133: `GET /api/freshness` — cheap read-only watermark probe used by the
+ * dashboard header to detect a newer daemon upload than what was SSR'd
+ * with the page, then trigger `router.refresh()`.
+ *
+ * Tests treat `getCurrentUser`/`getSyncFreshness` as the bounded API and
+ * mock them directly — the route handler is a thin auth + JSON wrapper.
+ */
+
+const dal = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  getSyncFreshness: vi.fn(),
+}));
+
+vi.mock("@/lib/dal", () => dal);
+
+beforeEach(() => {
+  dal.getCurrentUser.mockReset();
+  dal.getSyncFreshness.mockReset();
+});
+
+describe("GET /api/freshness (#133)", () => {
+  it("returns the freshness snapshot for the current user", async () => {
+    dal.getCurrentUser.mockResolvedValue({ id: "usr_a", org_id: "org_x" });
+    dal.getSyncFreshness.mockResolvedValue({
+      deviceCount: 1,
+      lastSeenAt: "2026-05-05T22:00:00Z",
+      lastRollupAt: "2026-05-05T21:55:00Z",
+      lastSessionAt: "2026-05-05T21:30:00Z",
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(await res.json()).toEqual({
+      deviceCount: 1,
+      lastSeenAt: "2026-05-05T22:00:00Z",
+      lastRollupAt: "2026-05-05T21:55:00Z",
+      lastSessionAt: "2026-05-05T21:30:00Z",
+    });
+  });
+
+  it("401s when the viewer is not authenticated", async () => {
+    dal.getCurrentUser.mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(dal.getSyncFreshness).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/freshness/route.ts
+++ b/src/app/api/freshness/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser, getSyncFreshness } from "@/lib/dal";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/freshness
+ *
+ * Returns the same shape as `getSyncFreshness` so the dashboard header badge
+ * can poll for a newer `lastRollupAt` without re-rendering the entire layout.
+ * The badge compares the polled `lastRollupAt` against the SSR'd
+ * `renderedRollupAt` and triggers `router.refresh()` only when the daemon
+ * has pushed something new (#133).
+ */
+export async function GET() {
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const freshness = await getSyncFreshness(user);
+  // No-store: this endpoint exists precisely to detect new uploads, so any
+  // CDN/Next caching here would defeat the point.
+  return NextResponse.json(freshness, {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -37,6 +37,7 @@ export default async function DashboardLayout({
             lastSeenAt={freshness.lastSeenAt}
             lastRollupAt={freshness.lastRollupAt}
             lastSessionAt={freshness.lastSessionAt}
+            renderedRollupAt={freshness.lastRollupAt}
           />
           <UserMenu displayName={user.display_name} email={user.email} />
         </header>

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -405,7 +405,9 @@ function SyncFreshnessLabel({
   if (state === "refreshing") {
     return (
       <>
-        <span className="hidden sm:inline">Local Budi · new data, refreshing…</span>
+        <span className="hidden sm:inline">
+          Local Budi · new data, refreshing…
+        </span>
         <span className="sm:hidden">Refreshing…</span>
       </>
     );

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { clsx } from "clsx";
 import { ChevronDown } from "lucide-react";
@@ -24,16 +25,31 @@ const STALLED_AFTER_MS = 24 * 60 * 60 * 1000;
  */
 const SESSIONS_LAG_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Cadence for polling `/api/freshness` to spot a newer daemon upload than
+ * what the page was SSR'd with. 60s is comfortably below the daemon's own
+ * 10–15 min sync cadence; the request itself is two cheap COUNT/MAX queries
+ * (see `getSyncFreshness` in `dal.ts`).
+ */
+const FRESHNESS_POLL_INTERVAL_MS = 60_000;
+
 export function SyncFreshness({
   deviceCount,
   lastSeenAt,
   lastRollupAt,
   lastSessionAt,
+  renderedRollupAt,
 }: {
   deviceCount: number;
   lastSeenAt: string | null;
   lastRollupAt: string | null;
   lastSessionAt: string | null;
+  /**
+   * The `lastRollupAt` the page was SSR'd with. Snapshotted on the server
+   * and passed down so the client poll can detect when a newer upload has
+   * landed and trigger `router.refresh()` (#133).
+   */
+  renderedRollupAt?: string | null;
 }) {
   // Not-linked is rendered as a call-to-action so it's obvious what to do
   // next instead of looking like a silent empty dashboard.
@@ -61,6 +77,7 @@ export function SyncFreshness({
       lastSeenAt={lastSeenAt}
       lastRollupAt={lastRollupAt}
       lastSessionAt={lastSessionAt}
+      renderedRollupAt={renderedRollupAt ?? lastRollupAt}
     />
   );
 }
@@ -75,12 +92,15 @@ function LinkedSyncFreshness({
   lastSeenAt,
   lastRollupAt,
   lastSessionAt,
+  renderedRollupAt,
 }: {
   lastSeenAt: string | null;
   lastRollupAt: string | null;
   lastSessionAt: string | null;
+  renderedRollupAt: string | null;
 }) {
   const now = useNow(60_000);
+  const isRefreshing = useFreshnessAutoRefresh(renderedRollupAt);
   const effective = lastRollupAt ?? lastSeenAt;
   const isStalled =
     effective !== null && now - Date.parse(effective) > STALLED_AFTER_MS;
@@ -94,13 +114,19 @@ function LinkedSyncFreshness({
     lastSessionAt !== null &&
     Date.parse(lastRollupAt) - Date.parse(lastSessionAt) >
       SESSIONS_LAG_THRESHOLD_MS;
-  const state: "linked_no_data" | "stalled" | "sessions_stalled" | "ok" =
-    !lastRollupAt
-      ? "linked_no_data"
-      : isStalled
-        ? "stalled"
-        : isSessionsStalled
-          ? "sessions_stalled"
+  const state:
+    | "linked_no_data"
+    | "stalled"
+    | "sessions_stalled"
+    | "refreshing"
+    | "ok" = !lastRollupAt
+    ? "linked_no_data"
+    : isStalled
+      ? "stalled"
+      : isSessionsStalled
+        ? "sessions_stalled"
+        : isRefreshing
+          ? "refreshing"
           : "ok";
 
   // Stalled mirrors the `not_linked` CTA pattern: make it actionable so the
@@ -126,6 +152,8 @@ function LinkedSyncFreshness({
         "inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium",
         state === "ok" &&
           "border-emerald-400/20 bg-emerald-400/5 text-emerald-300",
+        state === "refreshing" &&
+          "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
         state === "linked_no_data" &&
           "border-sky-400/20 bg-sky-400/5 text-sky-300"
       )}
@@ -141,6 +169,7 @@ function LinkedSyncFreshness({
         className={clsx(
           "h-1.5 w-1.5 rounded-full",
           state === "ok" && "bg-emerald-300",
+          state === "refreshing" && "animate-pulse bg-emerald-300",
           state === "linked_no_data" && "animate-pulse bg-sky-300"
         )}
       />
@@ -196,7 +225,7 @@ function StalledBadge({
         className="inline-flex items-center gap-2 rounded-md border border-amber-400/30 bg-amber-400/10 px-2.5 py-1 text-xs font-medium text-amber-300 transition-colors hover:border-amber-400/60 hover:bg-amber-400/20"
       >
         <span className="h-1.5 w-1.5 rounded-full bg-amber-300" />
-        <span className="hidden sm:inline">Stalled — last synced </span>
+        <span className="hidden sm:inline">Local Budi stalled · </span>
         <span>{relative}</span>
         <ChevronDown
           className={clsx("h-3 w-3 transition-transform", open && "rotate-180")}
@@ -358,7 +387,7 @@ function SyncFreshnessLabel({
   effective,
   now,
 }: {
-  state: "linked_no_data" | "ok";
+  state: "linked_no_data" | "ok" | "refreshing";
   effective: string | null;
   now: number;
 }) {
@@ -367,9 +396,17 @@ function SyncFreshnessLabel({
       <>
         {/* Below `sm` the dot already conveys the state; shorten the copy. */}
         <span className="hidden sm:inline">
-          Linked — waiting for first sync…
+          Local Budi · waiting for first upload…
         </span>
         <span className="sm:hidden">Waiting…</span>
+      </>
+    );
+  }
+  if (state === "refreshing") {
+    return (
+      <>
+        <span className="hidden sm:inline">Local Budi · new data, refreshing…</span>
+        <span className="sm:hidden">Refreshing…</span>
       </>
     );
   }
@@ -377,11 +414,11 @@ function SyncFreshnessLabel({
   return (
     <>
       {/*
-        Prefix ("Synced") is redundant with the colored dot at mobile widths.
+        Source prefix is redundant with the colored dot at mobile widths.
         Drop it below `sm` so the whole badge fits next to the hamburger +
         logout icon on a 390px viewport.
       */}
-      <span className="hidden sm:inline">Synced </span>
+      <span className="hidden sm:inline">Local Budi · uploaded </span>
       <span>{formatRelative(Date.parse(effective), now)}</span>
     </>
   );
@@ -394,6 +431,94 @@ function useNow(intervalMs: number): number {
     return () => window.clearInterval(id);
   }, [intervalMs]);
   return now;
+}
+
+/**
+ * Polls `/api/freshness` while the tab is visible and triggers a server
+ * re-render when the daemon has uploaded something newer than what the
+ * page was SSR'd with. Returns `true` for the brief window between
+ * "we noticed new data" and "the new SSR has flowed back" so the badge
+ * can show a transient `refreshing…` state (#133).
+ *
+ * Visibility-aware so backgrounded tabs don't burn one request/min, and
+ * `router.refresh()` is deferred to the next tick to avoid yanking chart
+ * state mid-interaction (e.g. if a period button was just clicked).
+ */
+function useFreshnessAutoRefresh(renderedRollupAt: string | null): boolean {
+  const router = useRouter();
+  // The newest watermark the poller has *seen* on the server. The badge
+  // is "refreshing" while this is strictly newer than the prop the page
+  // was SSR'd with — once a fresh SSR flows back through `renderedRollupAt`,
+  // the comparison naturally goes false (no effect needed to clear it).
+  const [pendingRollupAt, setPendingRollupAt] = useState<string | null>(null);
+  // Mirror the latest SSR'd watermark into a ref so the polling closure
+  // doesn't need to re-subscribe each render.
+  const renderedRef = useRef<string | null>(renderedRollupAt);
+  useEffect(() => {
+    renderedRef.current = renderedRollupAt;
+  }, [renderedRollupAt]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    async function check() {
+      if (typeof document !== "undefined" && document.hidden) return;
+      try {
+        const res = await fetch("/api/freshness", { cache: "no-store" });
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { lastRollupAt: string | null };
+        const seen = renderedRef.current;
+        if (
+          data.lastRollupAt &&
+          (!seen || Date.parse(data.lastRollupAt) > Date.parse(seen))
+        ) {
+          setPendingRollupAt(data.lastRollupAt);
+          // Defer to the next tick so we don't preempt a just-fired
+          // navigation (e.g. a period-selector click).
+          setTimeout(() => {
+            if (!cancelled) router.refresh();
+          }, 0);
+        }
+      } catch {
+        // Network blip — try again next tick.
+      }
+    }
+
+    function start() {
+      if (timer !== null) return;
+      timer = setInterval(check, FRESHNESS_POLL_INTERVAL_MS);
+    }
+    function stop() {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+    function onVisibility() {
+      if (document.hidden) {
+        stop();
+      } else {
+        // Catch up the moment the tab is foregrounded — don't make the user
+        // wait up to a full minute for the next tick.
+        check();
+        start();
+      }
+    }
+
+    if (typeof document !== "undefined" && !document.hidden) start();
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisibility);
+      stop();
+    };
+  }, [router]);
+
+  if (!pendingRollupAt) return false;
+  if (!renderedRollupAt) return true;
+  return Date.parse(pendingRollupAt) > Date.parse(renderedRollupAt);
 }
 
 export function formatRelative(


### PR DESCRIPTION
Closes #133.

## Summary

- Renames the dashboard freshness pill so every state names the source endpoint instead of the ambiguous bare verb \"Synced\":
  - `linked_no_data` → **Local Budi · waiting for first upload…**
  - `ok` → **Local Budi · uploaded 5m ago**
  - `refreshing` *(new, transient)* → **Local Budi · new data, refreshing…**
  - `stalled` → **Local Budi stalled · 26h ago** (popover unchanged)
  - `not_linked` → unchanged CTA
- Adds `GET /api/freshness` returning the same shape as `getSyncFreshness` (cheap; same DAL call, `Cache-Control: no-store`).
- Plumbs the SSR'd `lastRollupAt` into the badge as `renderedRollupAt`.
- Client polls `/api/freshness` every 60s, **paused while `document.hidden`**, and catches up immediately on `visibilitychange` so backgrounded tabs don't burn one request/min.
- When the polled `lastRollupAt > renderedRollupAt`: pill flips to *refreshing…* and `router.refresh()` is fired on the next tick (deferred so it doesn't preempt a just-clicked period button). The transient state is **derived** from `pendingRollupAt > renderedRollupAt`, so the next SSR cycle naturally retires it — no timer race.
- `data-sync-state` test hooks, the stalled / sessions-stalled popovers, and the not-linked CTA are unchanged.

## Files touched

- `src/components/sync-freshness.tsx` — copy + new `useFreshnessAutoRefresh` hook + `refreshing` state.
- `src/app/api/freshness/route.ts` — new (auth via `getCurrentUser`, returns `getSyncFreshness` snapshot).
- `src/app/api/freshness/route.test.ts` — new (200 with snapshot, 401 unauthenticated, no-store header, no DAL call when unauth).
- `src/app/dashboard/layout.tsx` — passes `renderedRollupAt={freshness.lastRollupAt}` into `<SyncFreshness>`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 189 / 189 (was 187; +2 for the new route)
- [x] `npm run build` registers `ƒ /api/freshness`
- [ ] Manual: open `/dashboard`, observe `Local Budi · uploaded Xm ago`; force a daemon upload, observe brief `new data, refreshing…` then a fresh render with the bumped watermark.
- [ ] Manual: backgrounded tab makes no `/api/freshness` requests; foregrounding fires one immediately and resumes the 60s cadence.
- [ ] Manual: stalled / sessions-stalled popovers and `not_linked` CTA unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)