### PR TITLE
fix(team): make headline stats match what their labels say (#135)

### DIFF
--- a/src/app/dashboard/team/page.test.tsx
+++ b/src/app/dashboard/team/page.test.tsx
@@ -34,6 +34,7 @@ const dal = {
   getCostByUser: vi.fn(),
   getEarliestActivity: vi.fn(),
   getTeamActivityByDay: vi.fn(),
+  UNASSIGNED_USER_ID: "__unassigned__",
 };
 vi.mock("@/lib/dal", () => dal);
 
@@ -54,15 +55,15 @@ beforeEach(() => {
       id: "usr_ivan",
       name: "Ivan",
       cost_cents: 2_500_00,
-      input_tokens: 0,
-      output_tokens: 0,
+      input_tokens: 600_000,
+      output_tokens: 200_000,
     },
     {
       id: "usr_jane",
       name: "Jane",
       cost_cents: 1_500_00,
-      input_tokens: 0,
-      output_tokens: 0,
+      input_tokens: 150_000,
+      output_tokens: 50_000,
     },
   ]);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
@@ -90,7 +91,7 @@ async function render(searchParams: Record<string, string> = {}) {
 }
 
 describe("dashboard/team /page", () => {
-  it("smoke: renders Team headline, the merged cost-by-member card, and the headline averages", async () => {
+  it("smoke: renders Team headline, the merged cost-by-member card, and the headline stats", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
@@ -98,9 +99,12 @@ describe("dashboard/team /page", () => {
     expect(text).toContain("Cost by Team Member");
     expect(text).toContain("Ivan");
     expect(text).toContain("Jane");
-    // Headline-average tiles on the time-series cards (#131).
-    expect(text).toContain("Avg active members");
+    // Headline tiles on the time-series cards (#131, #135). The values are
+    // sourced from `getCostByUser` so they match Overview totals: 2 distinct
+    // identifiable members, $4,000 total cost ⇒ $2,000 avg per person.
+    expect(text).toContain("Active members");
     expect(text).toContain("Avg cost per person");
+    expect(text).toContain("$2000.00");
   });
 
   it("smoke: tokens unit relabels the per-person headline to tokens", async () => {
@@ -108,6 +112,35 @@ describe("dashboard/team /page", () => {
     const text = extractText(node);
     expect(text).toContain("Avg tokens per person");
     expect(text).not.toContain("Avg cost per person");
+    // (600k+200k + 150k+50k) / 2 distinct members = 500,000 tokens/person,
+    // which `fmtNum` collapses to "500.0K".
+    expect(text).toContain("500.0K");
+  });
+
+  it("excludes the synthetic Unassigned bucket from the per-person math (#135)", async () => {
+    dal.getCostByUser.mockResolvedValue([
+      {
+        id: "usr_ivan",
+        name: "Ivan",
+        cost_cents: 1_000_00,
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+      {
+        id: "__unassigned__",
+        name: "Unassigned",
+        cost_cents: 5_000_00,
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    ]);
+    const node = await render();
+    const text = extractText(node);
+    // 1 identifiable member, $1,000 from that member ⇒ $1,000 avg per person.
+    // The $5,000 in the Unassigned bucket must NOT inflate the numerator and
+    // must NOT increase the active-members count.
+    expect(text).toContain("$1000.00");
+    expect(text).not.toContain("$3000.00");
   });
 
   it("empty: renders the chart's empty-state copy and the merged-card collapses to chart-only", async () => {
@@ -117,8 +150,8 @@ describe("dashboard/team /page", () => {
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("No team cost data for this period");
-    // No `getTeamActivityByDay` rows ⇒ both averages render the em-dash
-    // sentinel rather than `NaN` (#131 acceptance).
+    // No identifiable members ⇒ both stats render the em-dash sentinel rather
+    // than `NaN` or `0`.
     expect(text).toContain("—");
   });
 

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -5,6 +5,7 @@ import {
   getCostByUser,
   getEarliestActivity,
   getTeamActivityByDay,
+  UNASSIGNED_USER_ID,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
@@ -48,36 +49,33 @@ export default async function TeamPage({
   const fmtValue = (cost_cents: number, tokens: number) =>
     isTokens ? fmtNum(tokens) : fmtCost(cost_cents);
 
-  // Headline averages for the time-series cards (#131). "Avg active members"
-  // is the mean of the daily distinct-member counts over days that have data
-  // (empty days are dropped upstream, so we divide by the row count). Avg
-  // per-person matches the chart's per-day formula: total numerator divided
-  // by total active-member-days, so the headline reads as the period-level
-  // weighted average of the curve below it.
-  const dayCount = teamActivity.length;
-  const totalActiveMemberDays = teamActivity.reduce(
-    (s, d) => s + d.active_members,
+  // Headline stats for the time-series cards (#131, #135). Both reduce to the
+  // period-level "per identifiable person" reading, sourced from `userCosts`
+  // which already aggregates each visible team member across the range and
+  // matches the Overview totals (see `getCostByUser` reconciliation note).
+  // Rollups that don't resolve to a visible owner collapse into the
+  // `Unassigned` bucket, which is not a person and is excluded from both the
+  // count and the per-person numerator.
+  const identifiedMembers = userCosts.filter(
+    (u) => u.id !== UNASSIGNED_USER_ID
+  );
+  const distinctActiveMembers = identifiedMembers.length;
+  const totalCostCents = identifiedMembers.reduce(
+    (s, u) => s + u.cost_cents,
     0
   );
-  const totalCostCents = teamActivity.reduce((s, d) => s + d.cost_cents, 0);
-  const totalTokens = teamActivity.reduce(
-    (s, d) => s + d.input_tokens + d.output_tokens,
+  const totalTokens = identifiedMembers.reduce(
+    (s, u) => s + u.input_tokens + u.output_tokens,
     0
   );
-  const avgActiveMembers =
-    dayCount > 0 ? totalActiveMemberDays / dayCount : null;
   const perPersonNumerator = isTokens ? totalTokens : totalCostCents;
   const avgPerPerson =
-    totalActiveMemberDays > 0
-      ? perPersonNumerator / totalActiveMemberDays
+    distinctActiveMembers > 0
+      ? perPersonNumerator / distinctActiveMembers
       : null;
 
-  const avgActiveMembersLabel =
-    avgActiveMembers === null
-      ? "—"
-      : avgActiveMembers.toLocaleString("en-US", {
-          maximumFractionDigits: 1,
-        });
+  const activeMembersLabel =
+    distinctActiveMembers > 0 ? fmtNum(distinctActiveMembers) : "—";
   const avgPerPersonLabel =
     avgPerPerson === null
       ? "—"
@@ -171,10 +169,7 @@ export default async function TeamPage({
         </CardHeader>
         <CardContent>
           <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
-            <StatCard
-              title="Avg active members"
-              value={avgActiveMembersLabel}
-            />
+            <StatCard title="Active members" value={activeMembersLabel} />
             <TeamCountChart data={teamActivity} />
           </div>
         </CardContent>

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -199,7 +199,7 @@ export async function getEarliestActivity(
 }
 
 /** Synthetic user id used to group rollups whose owner we can't surface. */
-const UNASSIGNED_USER_ID = "__unassigned__";
+export const UNASSIGNED_USER_ID = "__unassigned__";
 
 /**
  * Get cost breakdown by user/device.


### PR DESCRIPTION
Closes #135.

## What was wrong

Both StatCards on `/dashboard/team` were computed from the daily team-activity series, so the values didn't match the natural reading of their labels:

- **\"Avg cost per person\"** was `sum(cost) / sum(daily active_members)` — a per-active-member-day rate weighted toward days with more people active. When daily headcount varies (the common case), this reads meaningfully lower than the intuitive \"total cost ÷ how many people are on the team\".
- **\"Avg active members\"** was the daily mean of distinct-active counts, which doesn't tell you how many distinct people were active over the whole period.

## What changed

Both stats now source from `getCostByUser`, which already aggregates each identifiable member across the range and reconciles to the Overview totals (per the comment block above `getCostByUser` in `dal.ts`).

| Label | Old | New |
|---|---|---|
| `Active members` (was *Avg active members*) | mean of daily distinct counts | distinct identifiable members in period |
| `Avg cost per person` | total cost / active-member-days | total cost / distinct identifiable members |
| `Avg tokens per person` | total tokens / active-member-days | total tokens / distinct identifiable members |

The synthetic `Unassigned` bucket — used by `getCostByUser` to pool rollups whose owner isn't visible to the viewer — is excluded from both numerator and denominator since it's a catch-all, not a person. `UNASSIGNED_USER_ID` is now exported from `dal.ts` so the page doesn't have to repeat the literal.

## Test plan

- [x] `npm test` — 190 tests pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `prettier --check` on the touched files — clean
- [x] Updated `page.test.tsx` smoke test asserts the actual computed values (`$2000.00` per-person, `500.0K` tokens per-person)
- [x] New regression test verifies the `Unassigned` bucket does not inflate the per-person numerator nor the active-member count
- [ ] Spot-check on a deployment with multi-day, varying-headcount data to confirm the headline value now matches manual `total cost ÷ team size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)