### PR TITLE
fix(sessions): neutral vitals-empty copy and Repo/Branch pairing (#137)

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -140,6 +140,30 @@ describe("dashboard/sessions/[id] /page", () => {
     }
   });
 
+  it("orders summary fields so Repo and Branch sit on the same row (#137)", async () => {
+    // The 2-col grid renders fields in document order, left-to-right then
+    // top-to-bottom. The contract: Repo immediately precedes Branch (so they
+    // share a row), and the row pairs are Provider/Started, Repo/Branch,
+    // Duration/Messages, Tokens/Cost.
+    const node = await render();
+    const text = extractText(node);
+    const order = [
+      "Provider",
+      "Started",
+      "Repo",
+      "Branch",
+      "Duration",
+      "Messages",
+      "Tokens",
+      "Cost",
+    ];
+    const positions = order.map((label) => text.indexOf(label));
+    expect(positions.every((p) => p !== -1)).toBe(true);
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]!);
+    }
+  });
+
   it("empty: 404s when the `device` query param is missing — composite PK can't be resolved", async () => {
     await expect(render("sess_v", {})).rejects.toThrow("__NOT_FOUND__");
     expect(notFoundMock).toHaveBeenCalled();

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -107,6 +107,11 @@ export default async function SessionDetailPage({
                     : "-"
                 }
               />
+              <Field label="Repo" value={repoName(session.repo_id)} />
+              <Field
+                label="Branch"
+                value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
+              />
               <Field
                 label="Duration"
                 value={formatDuration(
@@ -114,11 +119,6 @@ export default async function SessionDetailPage({
                   session.started_at,
                   session.ended_at
                 )}
-              />
-              <Field label="Repo" value={repoName(session.repo_id)} />
-              <Field
-                label="Branch"
-                value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
               />
               <Field label="Messages" value={fmtNum(session.message_count)} />
               <Field label="Tokens" value={fmtNum(totalTokens)} />

--- a/src/components/session-vitals.test.tsx
+++ b/src/components/session-vitals.test.tsx
@@ -58,7 +58,7 @@ describe("SessionVitals", () => {
     expect(beforeFirstLi).toMatch(/amber-500\/15/);
   });
 
-  it("renders the upgrade-daemon notice when every vital is null", () => {
+  it("renders a neutral unavailable notice when every vital is null", () => {
     const html = renderToStaticMarkup(
       <SessionVitals
         contextDrag={{ state: null, metric: null }}
@@ -69,9 +69,11 @@ describe("SessionVitals", () => {
       />
     );
 
-    expect(html).toContain(
-      "Vitals not yet available — upgrade local daemon to ≥ 8.3.15."
-    );
+    expect(html).toContain("Vitals unavailable for this session.");
+    // We can't reliably tell an old daemon from a too-short session here, so
+    // the copy must not finger-wag at viewers about upgrading.
+    expect(html).not.toMatch(/upgrade/i);
+    expect(html).not.toContain("8.3.15");
     // No badges, no row scaffolding.
     expect(html).not.toMatch(/emerald-500\/15/);
     expect(html).not.toMatch(/amber-500\/15/);

--- a/src/components/session-vitals.tsx
+++ b/src/components/session-vitals.tsx
@@ -9,8 +9,9 @@ import type { VitalState } from "@/lib/dal";
  * response content); see ADR-0083 §1 and `006_session_vitals.sql`.
  *
  * When *all* vitals are null, the daemon either hasn't been upgraded or the
- * session was too short to score. We show a single inline notice rather than
- * five empty rows so the surface stays useful for older daemons.
+ * session was too short to score. The cloud can't reliably tell those two
+ * cases apart from the row alone, so we show a single neutral notice rather
+ * than misdirecting current daemons to a version upgrade.
  */
 
 export interface SessionVitalsProps {
@@ -79,7 +80,7 @@ export function SessionVitals(props: SessionVitalsProps) {
   if (allEmpty) {
     return (
       <p className="text-sm text-zinc-400">
-        Vitals not yet available — upgrade local daemon to ≥ 8.3.15.
+        Vitals unavailable for this session.
       </p>
     );
   }


### PR DESCRIPTION
Closes #137.

## Summary
- **Issue 1 — vitals copy.** The all-null branch previously read *"Vitals not yet available — upgrade local daemon to ≥ 8.3.15."* but that same branch also fires for short sessions on a current daemon, so up-to-date users got finger-wagged for nothing (and the hard-coded `8.3.15` would rot anyway). Swapped to a neutral `Vitals unavailable for this session.` notice. The cloud can't reliably tell an old daemon from a too-short session from a single session row, so we don't try to.
- **Issue 2 — Summary grid order.** Reordered the 2-col grid so **Repo** sits next to **Branch** (previously diagonal across two rows). New row pairs: Provider/Started, Repo/Branch, Duration/Messages, Tokens/Cost.
- Updated `session-vitals.test.tsx` to assert the new copy and to forbid any future "upgrade" wording. Added a new `page.test.tsx` case that pins the field order so a refactor that re-shuffles the grid trips the test.

## Test plan
- [x] `npm test` — 191 / 191 passing
- [x] `npm run lint` — clean
- [ ] Eyeball `/dashboard/sessions/[id]` on a short session to confirm the new copy and the Repo/Branch pairing render as expected