### PR TITLE
feat(sessions): show main model on list and detail (#140)

### DIFF
--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -60,6 +60,12 @@ export interface IngestSessionSummary {
   total_input_tokens: number;
   total_output_tokens: number;
   total_cost_cents: number;
+  // Per-session "main" model (#140). The model that consumed the largest
+  // share of total (input + output) tokens for the session — see the
+  // 009_session_main_model.sql migration for the full definition. Optional
+  // because older daemons (< 8.3.16) don't emit it, and the daemon
+  // legitimately omits it for sessions with zero scored messages.
+  primary_model?: string | null;
   // Vitals (#99). Optional — older daemons (< 8.3.15) omit these, and budi-core
   // legitimately skips emission for sessions with too few assistant messages.
   vital_context_drag_state?: string | null;
@@ -129,6 +135,7 @@ export function buildSessionRows(
     total_input_tokens: s.total_input_tokens,
     total_output_tokens: s.total_output_tokens,
     total_cost_cents: s.total_cost_cents,
+    main_model: s.primary_model ?? null,
     // Vitals (#99). Each field is normalized independently so a daemon that
     // emits e.g. only the overall state (or only some vitals) still lands the
     // partial signal — the dashboard already renders missing slots as a

--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -57,6 +57,7 @@ const SESSION = {
   total_input_tokens: 2000,
   total_output_tokens: 800,
   total_cost_cents: 250,
+  main_model: "claude-opus-4-7-20260101",
 };
 
 beforeEach(() => {
@@ -125,6 +126,7 @@ describe("dashboard/sessions/[id] /page", () => {
     // Lock down the summary field labels so a refactor that drops one shows up.
     for (const label of [
       "Provider",
+      "Model",
       "Started",
       "Duration",
       "Repo",
@@ -135,17 +137,37 @@ describe("dashboard/sessions/[id] /page", () => {
     ]) {
       expect(text).toContain(label);
     }
+    // The date suffix on the model id is render-only noise (`-20260101`);
+    // formatModelName strips it. Pin both halves so a regression that drops
+    // the formatter or shows the raw id is caught here (#140).
+    expect(text).toContain("claude-opus-4-7");
+    expect(text).not.toContain("claude-opus-4-7-20260101");
   });
 
-  it("orders summary fields so Repo and Branch sit on the same row (#137)", async () => {
+  it("renders a dash for the Model field when the daemon didn't send one (#140)", async () => {
+    // Older daemons (< 8.3.16) never emit `primary_model`, so `main_model`
+    // lands NULL. The detail page must render a placeholder rather than
+    // collapse the field — pair the field's null-handling with the list.
+    dal.getSessionDetail.mockResolvedValue({ ...SESSION, main_model: null });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Model");
+    expect(text).not.toContain("claude-opus-4-7");
+  });
+
+  it("orders summary fields so Provider and Model sit together on the top row (#137, #140)", async () => {
     // The 2-col grid renders fields in document order, left-to-right then
-    // top-to-bottom. The contract: Repo immediately precedes Branch (so they
-    // share a row), and the row pairs are Provider/Started, Repo/Branch,
-    // Duration/Messages, Tokens/Cost.
+    // top-to-bottom. After #140 the top row is Provider/Model — these are the
+    // two "what tool" identifiers and belong adjacent so a manager skimming
+    // the card can read them as a single phrase. Started slides down to row
+    // 2, paired with Repo. The earlier Repo/Branch pairing from #137 gives
+    // way once a 9th field is in the grid; the new pin is the Provider/Model
+    // adjacency.
     const node = await render();
     const text = extractText(node);
     const order = [
       "Provider",
+      "Model",
       "Started",
       "Repo",
       "Branch",

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -2,7 +2,13 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getCurrentUser, getSessionDetail } from "@/lib/dal";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { fmtCost, fmtNum, formatDuration, repoName } from "@/lib/format";
+import {
+  fmtCost,
+  fmtNum,
+  formatDuration,
+  formatModelName,
+  repoName,
+} from "@/lib/format";
 
 /**
  * Session detail page (#99). The id segment is the daemon-emitted
@@ -74,6 +80,12 @@ export default async function SessionDetailPage({
         <CardContent>
           <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
             <Field label="Provider" value={session.provider} />
+            <Field
+              label="Model"
+              value={
+                session.main_model ? formatModelName(session.main_model) : "-"
+              }
+            />
             <Field
               label="Started"
               value={

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -65,6 +65,26 @@ beforeEach(() => {
         total_input_tokens: 2000,
         total_output_tokens: 800,
         total_cost_cents: 250,
+        main_model: "claude-opus-4-7-20260101",
+      },
+      {
+        // Older daemon (#140): no main_model on the wire, column NULL in the
+        // DB. Pin the dash-rendering branch so a regression that crashes on
+        // null shows up here.
+        device_id: "dev_ivan",
+        session_id: "sess_b",
+        provider: "claude_code",
+        started_at: "2026-04-15T09:00:00.000Z",
+        ended_at: "2026-04-15T09:30:00.000Z",
+        duration_ms: 1_800_000,
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        ticket: null,
+        message_count: 4,
+        total_input_tokens: 200,
+        total_output_tokens: 80,
+        total_cost_cents: 30,
+        main_model: null,
       },
     ],
     nextCursor: null,
@@ -90,6 +110,7 @@ describe("dashboard/sessions /page", () => {
     // the unit toggle on the cost column conveys the same signal.
     for (const col of [
       "Provider",
+      "Model",
       "Started",
       "Duration",
       "Repo",
@@ -99,6 +120,12 @@ describe("dashboard/sessions /page", () => {
     ]) {
       expect(text).toContain(col);
     }
+    // New-daemon row renders the model; old-daemon row's NULL can't drop the
+    // row from the page (#140). The full id including the date suffix is
+    // also exposed via the cell's `title` so a hover tooltip surfaces it
+    // when the truncated label hides the suffix — that's why we don't pin
+    // the suffix's absence here.
+    expect(text).toContain("claude-opus-4-7");
   });
 
   it("units toggle: ?units=tokens flips the Cost column header to Tokens (#128)", async () => {

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -15,7 +15,13 @@ import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { fmtCost, fmtNum, formatDuration, repoName } from "@/lib/format";
+import {
+  fmtCost,
+  fmtNum,
+  formatDuration,
+  formatModelName,
+  repoName,
+} from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -130,6 +136,7 @@ export default async function SessionsPage({
                 <thead>
                   <tr className="border-b border-white/10 text-left text-zinc-400">
                     <th className="pr-3 pb-2 font-medium">Provider</th>
+                    <th className="pr-3 pb-2 font-medium">Model</th>
                     <th className="pr-3 pb-2 font-medium">Started</th>
                     <th className="pr-3 pb-2 font-medium">Duration</th>
                     <th className="pr-3 pb-2 font-medium">Repo</th>
@@ -155,6 +162,17 @@ export default async function SessionsPage({
                         <td className="text-zinc-300">
                           <Link href={href} className="block py-2 pr-3">
                             {s.provider}
+                          </Link>
+                        </td>
+                        <td
+                          className="text-zinc-400"
+                          title={s.main_model ?? undefined}
+                        >
+                          <Link
+                            href={href}
+                            className="block max-w-[16ch] truncate py-2 pr-3"
+                          >
+                            {s.main_model ? formatModelName(s.main_model) : "-"}
                           </Link>
                         </td>
                         <td className="text-zinc-400">

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -758,6 +758,10 @@ export interface SessionRow {
   total_input_tokens: number | string;
   total_output_tokens: number | string;
   total_cost_cents: number | string;
+  // Per-session main model (#140). NULL for rows ingested before the daemon
+  // started emitting `primary_model`, and for sessions with zero scored
+  // messages — render as em-dash in those cases.
+  main_model: string | null;
   // The schema also has `vital_*` columns (006_session_vitals.sql) but the
   // daemon has never populated them, so the dashboard stopped reading them in
   // #141. Reintroduce typed fields here once budi-core ships vitals on the

--- a/supabase/migrations/009_session_main_model.sql
+++ b/supabase/migrations/009_session_main_model.sql
@@ -1,0 +1,29 @@
+-- Per-session "main" model (#140).
+--
+-- The dashboard's Sessions list and detail pages show **provider** (e.g.
+-- `claude_code`) but never the model that was actually used. Two sessions
+-- on the same provider that differ only in model (Opus vs Haiku) are
+-- indistinguishable even though their cost/quality profiles diverge wildly.
+-- The daily-rollups surfaces already break out per-model spend because
+-- `daily_rollups.model` exists; sessions are the odd one out.
+--
+-- A real session can span multiple models — Claude Code fans out to a
+-- smaller sub-agent, and providers fall back on context overflow / rate
+-- limits. The daemon picks ONE main model per session: the model that
+-- consumed the largest share of total (input + output) tokens, ties broken
+-- by latest-used. That single string ships in the ingest envelope as
+-- `primary_model` and lands here as `main_model`.
+--
+-- The column is NULLABLE because:
+--   1. Older daemons (< 8.3.16) won't send `primary_model`. The dashboard
+--      renders an em-dash for those rows, mirroring how the vitals columns
+--      from #99 degrade.
+--   2. Sessions with zero scored messages legitimately have no model to
+--      report — the daemon omits the field rather than guessing.
+--
+-- No PK / index change. The column is for display only in v1; sessions
+-- aren't filtered by model. If filtering is wanted later, add the index
+-- alongside that feature.
+
+ALTER TABLE session_summaries
+    ADD COLUMN main_model TEXT;


### PR DESCRIPTION
## Summary

- New migration `009_session_main_model.sql` adds a nullable `main_model` column to `session_summaries`. The cloud half of the two-repo change tracked in #140 — daemon ships `primary_model` (model with the largest token share for the session, ties broken by latest-used) on a future release; the cloud lands rows with `main_model = NULL` from older daemons and renders a dash for them.
- Ingest: `IngestSessionSummary.primary_model` (optional) maps to `main_model` in `buildSessionRows`.
- Sessions list: new **Model** column between Provider and Started (`/dashboard/sessions`). Truncates wide model strings with a tooltip carrying the full id.
- Session detail: new **Model** field paired with **Provider** on the top row of the Summary card (`/dashboard/sessions/[id]`).
- `formatModelName` strips date suffixes (e.g. `claude-opus-4-7-20260101` → `claude-opus-4-7`) for display; the full id is preserved on hover.

Older daemons that don't send `primary_model` continue to land rows with `main_model = NULL`; both surfaces render `-` for those, mirroring the existing null-handling on the page.

Closes #140 (cloud half).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run format:check` clean
- [x] `npm test` — 187/187 passing, including:
  - new "old-daemon NULL `main_model`" branch on the detail page
  - updated row fixture on the list page covering both populated + NULL `main_model`
  - updated #137 ordering test now pinned to Provider/Model adjacency
- [ ] Manual: apply migration on a Supabase preview branch and confirm Model column renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)