### PR TITLE
fix(sessions): pair Started/Duration and Repo/Branch on detail card

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -155,23 +155,27 @@ describe("dashboard/sessions/[id] /page", () => {
     expect(text).not.toContain("claude-opus-4-7");
   });
 
-  it("orders summary fields so Provider and Model sit together on the top row (#137, #140)", async () => {
+  it("groups summary fields so each pair on a row reads as a phrase (#137, #140)", async () => {
     // The 2-col grid renders fields in document order, left-to-right then
-    // top-to-bottom. After #140 the top row is Provider/Model — these are the
-    // two "what tool" identifiers and belong adjacent so a manager skimming
-    // the card can read them as a single phrase. Started slides down to row
-    // 2, paired with Repo. The earlier Repo/Branch pairing from #137 gives
-    // way once a 9th field is in the grid; the new pin is the Provider/Model
-    // adjacency.
+    // top-to-bottom. The pin is the *pair groupings* a viewer reads as a
+    // single phrase, not just monotonic order:
+    //   Row 1: Provider / Model     (what tool)
+    //   Row 2: Started  / Duration  (when, how long)
+    //   Row 3: Repo     / Branch    (where in the codebase)
+    //   Row 4: Messages / Tokens    (volume)
+    //   Row 5: Cost                 (the dollar takeaway)
+    // Earlier rounds (#137, #140) walked through Provider/Started and
+    // Provider/Model adjacency; this is the next iteration once Duration is
+    // promoted next to Started so the temporal pair sits together.
     const node = await render();
     const text = extractText(node);
     const order = [
       "Provider",
       "Model",
       "Started",
+      "Duration",
       "Repo",
       "Branch",
-      "Duration",
       "Messages",
       "Tokens",
       "Cost",

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -94,11 +94,6 @@ export default async function SessionDetailPage({
                   : "-"
               }
             />
-            <Field label="Repo" value={repoName(session.repo_id)} />
-            <Field
-              label="Branch"
-              value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
-            />
             <Field
               label="Duration"
               value={formatDuration(
@@ -106,6 +101,11 @@ export default async function SessionDetailPage({
                 session.started_at,
                 session.ended_at
               )}
+            />
+            <Field label="Repo" value={repoName(session.repo_id)} />
+            <Field
+              label="Branch"
+              value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
             />
             <Field label="Messages" value={fmtNum(session.message_count)} />
             <Field label="Tokens" value={fmtNum(totalTokens)} />


### PR DESCRIPTION
## Summary

Reorder the Summary card on `/dashboard/sessions/[id]` so each row in the 2-col grid reads as a single phrase:

| Row | Left      | Right     | Reads as                  |
|-----|-----------|-----------|---------------------------|
| 1   | Provider  | Model     | what tool                 |
| 2   | Started   | Duration  | when, how long            |
| 3   | Repo      | Branch    | where in the codebase     |
| 4   | Messages  | Tokens    | volume                    |
| 5   | Cost      | —         | the dollar takeaway       |

Started used to land alongside Repo (and Branch sat alone next to Duration) once the grid hit 9 fields in #140 — that broke the Repo/Branch pairing #137 originally established. Promoting Duration up next to Started restores both groupings.

Test pin updated to assert the new document order; the rest of the suite is unaffected.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 187/187 passing
- [ ] Manual: open a session detail page and confirm the row pairings render as expected on both wide and narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)