### PR TITLE
feat(sessions): surface team member name for manager viewers (#138)

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -43,6 +43,15 @@ const MANAGER = {
   email: "ivan@example.com",
 };
 
+const MEMBER = {
+  id: "usr_jane",
+  org_id: "org_team",
+  role: "member",
+  api_key: "budi_j",
+  display_name: "Jane",
+  email: "jane@example.com",
+};
+
 const SESSION = {
   device_id: "dev_ivan",
   session_id: "sess_v",
@@ -58,6 +67,7 @@ const SESSION = {
   total_output_tokens: 800,
   total_cost_cents: 250,
   main_model: "claude-opus-4-7-20260101",
+  owner_name: "Jane Smith",
 };
 
 beforeEach(() => {
@@ -125,6 +135,7 @@ describe("dashboard/sessions/[id] /page", () => {
     expect(text).not.toContain("Vitals unavailable");
     // Lock down the summary field labels so a refactor that drops one shows up.
     for (const label of [
+      "Member",
       "Provider",
       "Model",
       "Started",
@@ -137,11 +148,27 @@ describe("dashboard/sessions/[id] /page", () => {
     ]) {
       expect(text).toContain(label);
     }
+    // Manager-attribution (#138): the resolved owner label renders next to
+    // the Provider field so a manager can tell whose session this is without
+    // pivoting back to the device list.
+    expect(text).toContain("Jane Smith");
     // The date suffix on the model id is render-only noise (`-20260101`);
     // formatModelName strips it. Pin both halves so a regression that drops
     // the formatter or shows the raw id is caught here (#140).
     expect(text).toContain("claude-opus-4-7");
     expect(text).not.toContain("claude-opus-4-7-20260101");
+  });
+
+  it("hides the Member field for non-manager (member) viewers (#138)", async () => {
+    // Members only see their own sessions, so attribution would be a constant
+    // restating their own name. Suppress it to keep the card focused.
+    dal.getCurrentUser.mockResolvedValue(MEMBER);
+    const node = await render();
+    const text = extractText(node);
+    expect(text).not.toContain("Member");
+    // The rest of the summary surface still renders.
+    expect(text).toContain("Provider");
+    expect(text).toContain("Summary");
   });
 
   it("renders a dash for the Model field when the daemon didn't send one (#140)", async () => {
@@ -170,6 +197,7 @@ describe("dashboard/sessions/[id] /page", () => {
     const node = await render();
     const text = extractText(node);
     const order = [
+      "Member",
       "Provider",
       "Model",
       "Started",

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -56,6 +56,7 @@ export default async function SessionDetailPage({
   const session = await getSessionDetail(user, deviceId, sessionId);
   if (!session) notFound();
 
+  const isManager = user.role === "manager";
   const totalTokens =
     Number(session.total_input_tokens) + Number(session.total_output_tokens);
 
@@ -79,6 +80,9 @@ export default async function SessionDetailPage({
         </CardHeader>
         <CardContent>
           <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+            {isManager && (
+              <Field label="Member" value={session.owner_name ?? "-"} />
+            )}
             <Field label="Provider" value={session.provider} />
             <Field
               label="Model"

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -45,6 +45,15 @@ const MANAGER = {
   email: "ivan@example.com",
 };
 
+const MEMBER = {
+  id: "usr_jane",
+  org_id: "org_team",
+  role: "member",
+  api_key: "budi_j",
+  display_name: "Jane",
+  email: "jane@example.com",
+};
+
 beforeEach(() => {
   dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
@@ -66,12 +75,13 @@ beforeEach(() => {
         total_output_tokens: 800,
         total_cost_cents: 250,
         main_model: "claude-opus-4-7-20260101",
+        owner_name: "Ivan",
       },
       {
         // Older daemon (#140): no main_model on the wire, column NULL in the
         // DB. Pin the dash-rendering branch so a regression that crashes on
         // null shows up here.
-        device_id: "dev_ivan",
+        device_id: "dev_jane",
         session_id: "sess_b",
         provider: "claude_code",
         started_at: "2026-04-15T09:00:00.000Z",
@@ -85,6 +95,7 @@ beforeEach(() => {
         total_output_tokens: 80,
         total_cost_cents: 30,
         main_model: null,
+        owner_name: "Jane",
       },
     ],
     nextCursor: null,
@@ -109,6 +120,7 @@ describe("dashboard/sessions /page", () => {
     // `Tokens`. The standalone Tokens column was retired in #128 because
     // the unit toggle on the cost column conveys the same signal.
     for (const col of [
+      "Member",
       "Provider",
       "Model",
       "Started",
@@ -126,6 +138,21 @@ describe("dashboard/sessions /page", () => {
     // when the truncated label hides the suffix — that's why we don't pin
     // the suffix's absence here.
     expect(text).toContain("claude-opus-4-7");
+    // Manager attribution (#138): each row reads as "<member> ran <provider>".
+    expect(text).toContain("Ivan");
+    expect(text).toContain("Jane");
+  });
+
+  it("hides the Member column for non-manager (member) viewers (#138)", async () => {
+    // Members only ever see their own rows, so the column would just repeat
+    // their own name on every line. Suppress it to keep the table tight.
+    dal.getCurrentUser.mockResolvedValue(MEMBER);
+    const node = await render();
+    const text = extractText(node);
+    expect(text).not.toContain("Member");
+    // Other column headers must still render — the suppression is scoped.
+    expect(text).toContain("Provider");
+    expect(text).toContain("Started");
   });
 
   it("units toggle: ?units=tokens flips the Cost column header to Tokens (#128)", async () => {

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -65,6 +65,7 @@ export default async function SessionsPage({
 
   const unit = parseUnit(params.units);
   const isTokens = unit === "tokens";
+  const isManager = user.role === "manager";
   const scope = { scopedUserId: params.user || null };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
@@ -77,7 +78,7 @@ export default async function SessionsPage({
 
   const [{ rows: sessions, nextCursor }, members] = await Promise.all([
     getSessions(user, range, scope, { cursor }),
-    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+    isManager ? getOrgMembers(user.org_id) : Promise.resolve([]),
   ]);
 
   const startIndex = (page - 1) * SESSIONS_PAGE_SIZE + 1;
@@ -135,6 +136,9 @@ export default async function SessionsPage({
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-white/10 text-left text-zinc-400">
+                    {isManager && (
+                      <th className="pr-3 pb-2 font-medium">Member</th>
+                    )}
                     <th className="pr-3 pb-2 font-medium">Provider</th>
                     <th className="pr-3 pb-2 font-medium">Model</th>
                     <th className="pr-3 pb-2 font-medium">Started</th>
@@ -159,6 +163,19 @@ export default async function SessionsPage({
                         key={`${s.device_id}-${s.session_id}`}
                         className="border-b border-white/5 transition-colors hover:bg-white/5"
                       >
+                        {isManager && (
+                          <td
+                            className="text-zinc-300"
+                            title={s.owner_name ?? undefined}
+                          >
+                            <Link
+                              href={href}
+                              className="block max-w-[20ch] truncate py-2 pr-3"
+                            >
+                              {s.owner_name ?? "-"}
+                            </Link>
+                          </td>
+                        )}
                         <td className="text-zinc-300">
                           <Link href={href} className="block py-2 pr-3">
                             {s.provider}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -734,7 +734,8 @@ export async function getSessions(
   const { data } = await query;
   const fetched = (data ?? []) as SessionRow[];
   const hasMore = fetched.length > pageSize;
-  const rows = hasMore ? fetched.slice(0, pageSize) : fetched;
+  const trimmed = hasMore ? fetched.slice(0, pageSize) : fetched;
+  const rows = await attachOwners(admin, user, trimmed);
   const tail = rows[rows.length - 1];
   const nextCursor =
     hasMore && tail
@@ -742,6 +743,58 @@ export async function getSessions(
       : null;
 
   return { rows, nextCursor };
+}
+
+/**
+ * Resolve owner display labels for a batch of session rows. Manager-only:
+ * member viewers already know every row is theirs (#138), so we leave
+ * `owner_name` null and skip the device→user→identity joins entirely.
+ *
+ * Falls back through `display_name → email → id-prefix` so a freshly-invited
+ * teammate without a profile name still renders something a manager can match
+ * to a person in the team list. Mirrors the lookup already proven out in
+ * `getCostByDevice` so the two surfaces label the same teammate identically.
+ */
+async function attachOwners(
+  admin: ReturnType<typeof createAdminClient>,
+  user: BudiUser,
+  rows: SessionRow[]
+): Promise<SessionRow[]> {
+  if (user.role !== "manager" || rows.length === 0) return rows;
+
+  const deviceIds = Array.from(new Set(rows.map((r) => r.device_id)));
+  const { data: devices } = await admin
+    .from("devices")
+    .select("id, user_id")
+    .in("id", deviceIds);
+  const deviceToUser = new Map<string, string>();
+  for (const d of devices ?? []) {
+    deviceToUser.set(d.id as string, d.user_id as string);
+  }
+
+  const ownerIds = Array.from(new Set(deviceToUser.values()));
+  if (ownerIds.length === 0) return rows;
+
+  const { data: owners } = await admin
+    .from("users")
+    .select("id, display_name, email")
+    .in("id", ownerIds);
+  const ownerLookup = new Map<string, string>(
+    (owners ?? []).map((u) => [
+      u.id as string,
+      (u.display_name as string | null) ||
+        (u.email as string | null) ||
+        (u.id as string).slice(0, 8),
+    ])
+  );
+
+  return rows.map((r) => {
+    const ownerId = deviceToUser.get(r.device_id);
+    return {
+      ...r,
+      owner_name: ownerId ? (ownerLookup.get(ownerId) ?? null) : null,
+    };
+  });
 }
 
 export interface SessionRow {
@@ -762,6 +815,12 @@ export interface SessionRow {
   // started emitting `primary_model`, and for sessions with zero scored
   // messages — render as em-dash in those cases.
   main_model: string | null;
+  // Resolved owner label for the device this session ran on (#138). Only
+  // populated for manager viewers; null for member viewers (every row is
+  // theirs) and for sessions whose device→user mapping cannot be resolved.
+  // Not a column on `session_summaries` — joined in by the DAL via
+  // `attachOwners`.
+  owner_name?: string | null;
   // The schema also has `vital_*` columns (006_session_vitals.sql) but the
   // daemon has never populated them, so the dashboard stopped reading them in
   // #141. Reintroduce typed fields here once budi-core ships vitals on the
@@ -793,7 +852,10 @@ export async function getSessionDetail(
     .eq("session_id", sessionId)
     .maybeSingle();
 
-  return (data as SessionRow | null) ?? null;
+  const row = (data as SessionRow | null) ?? null;
+  if (!row) return null;
+  const [enriched] = await attachOwners(admin, user, [row]);
+  return enriched ?? row;
 }
 
 /**


### PR DESCRIPTION
Closes #138.

## Summary
- DAL: `getSessions` and `getSessionDetail` resolve a per-row `owner_name` (display_name → email → id-prefix), reusing the same lookup as `getCostByDevice`. The join is manager-only — member viewers skip it since every row is already theirs.
- Sessions list: render a **Member** column for managers (truncated, with the full label exposed via `title` for hover) at the start of each row. Hidden for members.
- Session detail: render a **Member** field on the Summary card next to **Provider** for managers. Hidden for members.

## Test plan
- [x] `npm test` — 189 passed
  - New cases pin Member visibility on both pages for managers and its absence for member viewers.
- [x] `npm run typecheck`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)