### PR TITLE
feat(devices): align Devices page depth with Team page (#145)

### DIFF
--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import {
   getCurrentUser,
   getCostByDevice,
+  getDeviceActivityByDay,
   getEarliestActivity,
   getOrgMembers,
 } from "@/lib/dal";
@@ -9,11 +10,14 @@ import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { deviceLabel, fmtCost, fmtNum, fmtRelative } from "@/lib/format";
+import { deviceLabel, fmtCost, fmtNum } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { DeviceCountChart } from "@/components/charts/device-count-chart";
+import { CostPerDeviceChart } from "@/components/charts/cost-per-device-chart";
+import { StatCard } from "@/components/stat-card";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function DevicesPage({
@@ -33,26 +37,58 @@ export default async function DevicesPage({
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [devices, members] = await Promise.all([
+  const [devices, deviceActivity, members] = await Promise.all([
     getCostByDevice(user, range, scope),
+    getDeviceActivityByDay(user, range, scope),
     user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
   ]);
 
   const showOwnerColumn = user.role === "manager";
   const isTokens = unit === "tokens";
   const valueWord = isTokens ? "Tokens" : "Cost";
+  const perDeviceTitle = isTokens ? "Tokens per Device" : "Cost per Device";
   const fmtValue = (cost_cents: number, tokens: number) =>
     isTokens ? fmtNum(tokens) : fmtCost(cost_cents);
 
-  // The chart's "have any data" filter mirrors the previous `cost_cents > 0`
-  // rule, except we also keep rows with zero cost but non-zero tokens so the
-  // tokens lens is never silently empty.
+  // Mirrors the Team-page identifier label so the manager view distinguishes
+  // two laptops both labelled `"laptop"` sitting under different owners.
+  const labelFor = (d: (typeof devices)[number]) =>
+    showOwnerColumn && d.owner_name
+      ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
+      : deviceLabel(d.id, d.label);
+
+  // Headline stats for the time-series cards. Devices that registered but
+  // never pushed a rollup land in `getCostByDevice` with zero cost/tokens; we
+  // exclude them from the period-level "active" reading and the per-device
+  // average so the numbers match the bar chart's `cost > 0 || tokens > 0`
+  // filter (mirrors the Team-page `UNASSIGNED` exclusion at #131).
+  const activeDevices = devices.filter(
+    (d) => d.cost_cents > 0 || d.input_tokens + d.output_tokens > 0
+  );
+  const distinctActiveDevices = activeDevices.length;
+  const totalCostCents = activeDevices.reduce((s, d) => s + d.cost_cents, 0);
+  const totalTokens = activeDevices.reduce(
+    (s, d) => s + d.input_tokens + d.output_tokens,
+    0
+  );
+  const perDeviceNumerator = isTokens ? totalTokens : totalCostCents;
+  const avgPerDevice =
+    distinctActiveDevices > 0
+      ? perDeviceNumerator / distinctActiveDevices
+      : null;
+
+  const activeDevicesLabel =
+    distinctActiveDevices > 0 ? fmtNum(distinctActiveDevices) : "—";
+  const avgPerDeviceLabel =
+    avgPerDevice === null
+      ? "—"
+      : isTokens
+        ? fmtNum(Math.round(avgPerDevice))
+        : fmtCost(avgPerDevice);
+
   const chartRows = devices
     .map((d) => ({
-      label:
-        showOwnerColumn && d.owner_name
-          ? `${deviceLabel(d.id, d.label)} — ${d.owner_name}`
-          : deviceLabel(d.id, d.label),
+      label: labelFor(d),
       cost_cents: d.cost_cents,
       tokens: d.input_tokens + d.output_tokens,
     }))
@@ -76,74 +112,91 @@ export default async function DevicesPage({
           <CardTitle>{`${valueWord} by Device`}</CardTitle>
         </CardHeader>
         <CardContent>
-          <CostBarChart
-            data={chartRows}
-            emptyLabel={`No device ${valueWord.toLowerCase()} data for this period`}
-            unit={unit}
-          />
+          {chartRows.length === 0 ? (
+            <CostBarChart
+              data={[]}
+              emptyLabel={`No device ${valueWord.toLowerCase()} data for this period`}
+              unit={unit}
+            />
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2">
+              <CostBarChart
+                data={chartRows}
+                emptyLabel={`No device ${valueWord.toLowerCase()} data for this period`}
+                unit={unit}
+              />
+              <div>
+                <table className="hidden w-full text-sm sm:table">
+                  <thead>
+                    <tr className="border-b border-white/10 text-left text-zinc-400">
+                      <th className="pb-2 font-medium">Device</th>
+                      <th className="pb-2 text-right font-medium">
+                        {valueWord}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {devices.map((d) => (
+                      <tr key={d.id} className="border-b border-white/5">
+                        <td className="py-2 text-zinc-200">{labelFor(d)}</td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {fmtValue(
+                            d.cost_cents,
+                            d.input_tokens + d.output_tokens
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <ul className="divide-y divide-white/5 text-sm sm:hidden">
+                  {devices.map((d) => (
+                    <li
+                      key={d.id}
+                      className="flex items-center justify-between py-2"
+                    >
+                      <span className="text-zinc-200">{labelFor(d)}</span>
+                      <span className="tabular-nums text-zinc-300">
+                        {fmtValue(
+                          d.cost_cents,
+                          d.input_tokens + d.output_tokens
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
 
-      {devices.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Devices</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <table className="hidden w-full text-sm sm:table">
-              <thead>
-                <tr className="border-b border-white/10 text-left text-zinc-400">
-                  <th className="pb-2 font-medium">Device</th>
-                  {showOwnerColumn && (
-                    <th className="pb-2 font-medium">Owner</th>
-                  )}
-                  <th className="pb-2 font-medium">Last seen</th>
-                  <th className="pb-2 text-right font-medium">{valueWord}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {devices.map((d) => (
-                  <tr key={d.id} className="border-b border-white/5">
-                    <td className="py-2 text-zinc-200">
-                      {deviceLabel(d.id, d.label)}
-                    </td>
-                    {showOwnerColumn && (
-                      <td className="py-2 text-zinc-300">
-                        {d.owner_name ?? "—"}
-                      </td>
-                    )}
-                    <td className="py-2 text-zinc-400">
-                      {fmtRelative(d.last_seen)}
-                    </td>
-                    <td className="py-2 text-right tabular-nums text-zinc-300">
-                      {fmtValue(d.cost_cents, d.input_tokens + d.output_tokens)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <ul className="divide-y divide-white/5 text-sm sm:hidden">
-              {devices.map((d) => (
-                <li key={d.id} className="flex flex-col gap-0.5 py-2">
-                  <div className="flex items-center justify-between">
-                    <span className="text-zinc-200">
-                      {deviceLabel(d.id, d.label)}
-                    </span>
-                    <span className="tabular-nums text-zinc-300">
-                      {fmtValue(d.cost_cents, d.input_tokens + d.output_tokens)}
-                    </span>
-                  </div>
-                  <div className="text-xs text-zinc-500">
-                    {showOwnerColumn && d.owner_name
-                      ? `${d.owner_name} · ${fmtRelative(d.last_seen)}`
-                      : fmtRelative(d.last_seen)}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      )}
+      <Card>
+        <CardHeader>
+          <CardTitle>Device Count</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+            <StatCard title="Active devices" value={activeDevicesLabel} />
+            <DeviceCountChart data={deviceActivity} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{perDeviceTitle}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+            <StatCard
+              title={isTokens ? "Avg tokens per device" : "Avg cost per device"}
+              value={avgPerDeviceLabel}
+            />
+            <CostPerDeviceChart data={deviceActivity} unit={unit} />
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/charts/cost-per-device-chart.tsx
+++ b/src/components/charts/cost-per-device-chart.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtCost, fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+import type { Unit } from "@/lib/units";
+
+interface CostPerDeviceDatum {
+  bucket_day: string;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+  active_devices: number;
+}
+
+export function CostPerDeviceChart({
+  data,
+  unit = "dollars",
+}: {
+  data: CostPerDeviceDatum[];
+  unit?: Unit;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No device cost data for this period
+      </div>
+    );
+  }
+
+  const isTokens = unit === "tokens";
+  const fmt = isTokens ? fmtNum : fmtCost;
+  const seriesLabel = isTokens ? "Tokens / device" : "Cost / device";
+
+  // Days with no active devices render as gaps rather than NaN/Infinity bars
+  // — same divide-by-zero guard as `CostPerPersonChart` (#127).
+  const series = data.map((d) => {
+    if (d.active_devices <= 0) {
+      return { bucket_day: d.bucket_day, value: null as number | null };
+    }
+    const numerator = isTokens
+      ? d.input_tokens + d.output_tokens
+      : d.cost_cents;
+    return { bucket_day: d.bucket_day, value: numerator / d.active_devices };
+  });
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={series}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => fmt(Number(v))}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={72}
+          label={{
+            value: seriesLabel,
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value) => [fmt(Number(value)), seriesLabel]}
+        />
+        <Bar
+          dataKey="value"
+          fill="#f59e0b"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/device-count-chart.tsx
+++ b/src/components/charts/device-count-chart.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+
+interface DeviceCountDatum {
+  bucket_day: string;
+  active_devices: number;
+}
+
+export function DeviceCountChart({ data }: { data: DeviceCountDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No device count data for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ left: 16, right: 8, top: 8, bottom: 8 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tickFormatter={fmtNum}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={48}
+          label={{
+            value: "Active devices",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value) => [fmtNum(Number(value)), "Active devices"]}
+        />
+        <Bar
+          dataKey="active_devices"
+          fill="#22c55e"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -373,6 +373,60 @@ interface TeamActivityRow {
   output_tokens?: number | string;
 }
 
+export interface DeviceActivityDay {
+  bucket_day: string;
+  active_devices: number;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+/**
+ * Daily series of distinct active devices + total cost for the Devices page
+ * (#145). Active = the device wrote any rollup row for that bucket. Manager
+ * sees the full org; member sees own devices only (ADR-0083 §6). When the
+ * manager's `UserFilter` is engaged the series is narrowed to that teammate's
+ * devices so it stays consistent with the per-device bar chart on the same
+ * page.
+ *
+ * Days with no rollup activity simply don't appear in the result; the chart
+ * components decide whether to interpolate or render a gap.
+ */
+export async function getDeviceActivityByDay(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<DeviceActivityDay[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_device_activity_by_day", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as DeviceActivityRow[])
+    .map((r) => ({
+      bucket_day: r.bucket_day,
+      active_devices: Number(r.active_devices),
+      cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}
+
+interface DeviceActivityRow {
+  bucket_day: string;
+  active_devices: number | string;
+  cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
+}
+
 interface UserLookup {
   id: string;
   display_name: string | null;

--- a/supabase/migrations/010_device_activity_by_day.sql
+++ b/supabase/migrations/010_device_activity_by_day.sql
@@ -1,0 +1,37 @@
+-- Per-day active-device count and cost for the Devices page (#145).
+--
+-- Mirrors `dashboard_team_activity_by_day` but pivots on `device_id` instead
+-- of `user_id` so the Devices page can show "active devices per day" and a
+-- "cost per device" time series alongside the existing per-device bar chart.
+-- The viewer's visibility scope is enforced upstream via `getVisibleDeviceIds`
+-- — `p_device_ids` is the authoritative gate. Aggregating in Postgres keeps
+-- us safe from PostgREST's 1k-row default cap (see #92, #008).
+CREATE OR REPLACE FUNCTION public.dashboard_device_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    bucket_day      DATE,
+    active_devices  BIGINT,
+    cost_cents      NUMERIC,
+    input_tokens    BIGINT,
+    output_tokens   BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        COUNT(DISTINCT device_id)::BIGINT AS active_devices,
+        SUM(cost_cents)                   AS cost_cents,
+        SUM(input_tokens)::BIGINT         AS input_tokens,
+        SUM(output_tokens)::BIGINT        AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;


### PR DESCRIPTION
## Summary

Closes #145.

Brings the Devices page up to parity with Team:

- **Co-located bar chart + companion table** in one card (replaces the previous full-width chart + separate table card).
- **Device Count card** — `Active devices` `StatCard` next to a per-day bar chart of distinct active devices.
- **Cost/Tokens per Device card** — `Avg per device` `StatCard` next to a per-device time series; days with no active devices render as gaps.
- New DAL helper `getDeviceActivityByDay` backed by SQL RPC `dashboard_device_activity_by_day` (mirrors `getTeamActivityByDay` / `dashboard_team_activity_by_day`). Honours the manager `UserFilter` scope so the time series matches the bar chart on the same page.

The "Active" reading and the per-device average exclude devices with zero cost and zero tokens (registered but never reported), matching the bar-chart `cost > 0 || tokens > 0` filter and mirroring the Team-page `UNASSIGNED` exclusion.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [ ] Manual: load `/dashboard/devices` as a manager, exercise `UserFilter`, `UnitsSelector`, `PeriodSelector`; confirm chart/table/stat numbers reconcile and per-device time series respects scope.
- [ ] Manual: load `/dashboard/devices` as a member; confirm the page renders without the owner column and stats reflect the self-only scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)