### PR TITLE
feat(models): align Models page depth with Team and Devices pages (#147)

### DIFF
--- a/src/app/dashboard/models/page.test.tsx
+++ b/src/app/dashboard/models/page.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { containsSuspense, extractText } from "@/test-utils/page-tree";
 
 /**
- * Page-level coverage for `/dashboard/models` (#112).
+ * Page-level coverage for `/dashboard/models` (#112, #147).
  */
 
 vi.mock("server-only", () => ({}));
@@ -21,6 +21,7 @@ vi.mock("next/navigation", () => ({
 const dal = {
   getCurrentUser: vi.fn(),
   getCostByModel: vi.fn(),
+  getModelActivityByDay: vi.fn(),
   getEarliestActivity: vi.fn(),
   getOrgMembers: vi.fn(),
 };
@@ -42,6 +43,31 @@ beforeEach(() => {
       provider: "claude_code",
       model: "claude-sonnet-4-5",
       cost_cents: 800_00,
+      input_tokens: 600_000,
+      output_tokens: 200_000,
+    },
+    {
+      provider: "openai",
+      model: "gpt-4o",
+      cost_cents: 200_00,
+      input_tokens: 150_000,
+      output_tokens: 50_000,
+    },
+  ]);
+  dal.getModelActivityByDay.mockReset().mockResolvedValue([
+    {
+      bucket_day: "2026-05-01",
+      active_models: 2,
+      cost_cents: 600_00,
+      input_tokens: 0,
+      output_tokens: 0,
+    },
+    {
+      bucket_day: "2026-05-02",
+      active_models: 1,
+      cost_cents: 400_00,
+      input_tokens: 0,
+      output_tokens: 0,
     },
   ]);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
@@ -54,20 +80,42 @@ async function render(searchParams: Record<string, string> = {}) {
 }
 
 describe("dashboard/models /page", () => {
-  it("smoke: renders the headline + the Cost by Model card with populated DAL data", async () => {
+  it("smoke: renders headline, merged Cost by Model card with companion table, and headline stats (#147)", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("Models");
     expect(text).toContain("Cost by Model");
+    // Companion table promotes provider to its own column so the manager can
+    // tell `gpt-4o` on OpenAI apart from a hypothetical `gpt-4o` on Azure.
+    expect(text).toContain("claude_code");
+    expect(text).toContain("openai");
+    expect(text).toContain("claude-sonnet-4-5");
+    expect(text).toContain("gpt-4o");
+    // Headline tiles. 2 distinct active models, $1,000 total ⇒ $500 avg.
+    expect(text).toContain("Active models");
+    expect(text).toContain("Avg cost per model");
+    expect(text).toContain("$500.00");
   });
 
-  it("empty: renders the chart's empty-state copy when the DAL returns no models", async () => {
+  it("tokens unit relabels the per-model headline and totals", async () => {
+    const node = await render({ units: "tokens" });
+    const text = extractText(node);
+    expect(text).toContain("Avg tokens per model");
+    expect(text).not.toContain("Avg cost per model");
+    // (600k+200k + 150k+50k) / 2 = 500,000 tokens/model ⇒ "500.0K".
+    expect(text).toContain("500.0K");
+  });
+
+  it("empty: chart-empty fallback when the DAL returns no models", async () => {
     dal.getCostByModel.mockResolvedValue([]);
+    dal.getModelActivityByDay.mockResolvedValue([]);
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
-    expect(text).toContain("No model data for this period");
+    expect(text).toContain("No model cost data for this period");
+    // No active models ⇒ both stats render the em-dash sentinel.
+    expect(text).toContain("—");
   });
 
   it("loading: composes a Suspense boundary around the filter cluster", async () => {

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import {
   getCurrentUser,
   getCostByModel,
+  getModelActivityByDay,
   getEarliestActivity,
   getOrgMembers,
 } from "@/lib/dal";
@@ -9,11 +10,14 @@ import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { formatModelName } from "@/lib/format";
+import { fmtCost, fmtNum, formatModelName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { ModelCountChart } from "@/components/charts/model-count-chart";
+import { CostPerModelChart } from "@/components/charts/cost-per-model-chart";
+import { StatCard } from "@/components/stat-card";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function ModelsPage({
@@ -33,10 +37,51 @@ export default async function ModelsPage({
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [models, members] = await Promise.all([
+  const [models, modelActivity, members] = await Promise.all([
     getCostByModel(user, range, scope),
+    getModelActivityByDay(user, range, scope),
     user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
   ]);
+
+  const isTokens = unit === "tokens";
+  const valueWord = isTokens ? "Tokens" : "Cost";
+  const perModelTitle = isTokens ? "Tokens per Model" : "Cost per Model";
+  const fmtValue = (cost_cents: number, tokens: number) =>
+    isTokens ? fmtNum(tokens) : fmtCost(cost_cents);
+
+  // Bar-chart label folds provider into the model name so each bar is
+  // self-describing, but the companion table promotes provider to its own
+  // column so it can be eyeballed and (eventually) sorted on. `gpt-4o` on
+  // OpenAI and `gpt-4o` on Azure are distinct rows here for the same reason
+  // they're distinct lines on the bar chart.
+  const chartRows = models.map((m) => ({
+    label: `${m.provider} / ${formatModelName(m.model)}`,
+    cost_cents: m.cost_cents,
+    tokens: m.input_tokens + m.output_tokens,
+  }));
+
+  // Headline stats for the time-series cards. `getCostByModel` already
+  // filters out `(provider, model)` pairs with zero cost and zero tokens, so
+  // every row here is "active" by the same definition the bar chart uses.
+  // Mirrors the Devices-page filter applied in `activeDevices` (#145).
+  const distinctActiveModels = models.length;
+  const totalCostCents = models.reduce((s, m) => s + m.cost_cents, 0);
+  const totalTokens = models.reduce(
+    (s, m) => s + m.input_tokens + m.output_tokens,
+    0
+  );
+  const perModelNumerator = isTokens ? totalTokens : totalCostCents;
+  const avgPerModel =
+    distinctActiveModels > 0 ? perModelNumerator / distinctActiveModels : null;
+
+  const activeModelsLabel =
+    distinctActiveModels > 0 ? fmtNum(distinctActiveModels) : "—";
+  const avgPerModelLabel =
+    avgPerModel === null
+      ? "—"
+      : isTokens
+        ? fmtNum(Math.round(avgPerModel))
+        : fmtCost(avgPerModel);
 
   return (
     <div className="space-y-6">
@@ -53,18 +98,115 @@ export default async function ModelsPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>{`${unit === "tokens" ? "Tokens" : "Cost"} by Model`}</CardTitle>
+          <CardTitle>{`${valueWord} by Model`}</CardTitle>
         </CardHeader>
         <CardContent>
-          <CostBarChart
-            data={models.map((m) => ({
-              label: `${m.provider} / ${formatModelName(m.model)}`,
-              cost_cents: m.cost_cents,
-              tokens: m.input_tokens + m.output_tokens,
-            }))}
-            emptyLabel="No model data for this period"
-            unit={unit}
-          />
+          {chartRows.length === 0 ? (
+            <CostBarChart
+              data={[]}
+              emptyLabel={`No model ${valueWord.toLowerCase()} data for this period`}
+              unit={unit}
+            />
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2">
+              <CostBarChart
+                data={chartRows}
+                emptyLabel={`No model ${valueWord.toLowerCase()} data for this period`}
+                unit={unit}
+              />
+              <div>
+                <table className="hidden w-full text-sm sm:table">
+                  <thead>
+                    <tr className="border-b border-white/10 text-left text-zinc-400">
+                      <th className="pb-2 font-medium">Provider</th>
+                      <th className="pb-2 font-medium">Model</th>
+                      <th className="pb-2 text-right font-medium">In</th>
+                      <th className="pb-2 text-right font-medium">Out</th>
+                      <th className="pb-2 text-right font-medium">
+                        {valueWord}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {models.map((m, i) => (
+                      <tr
+                        key={`${m.provider}/${m.model}/${i}`}
+                        className="border-b border-white/5"
+                      >
+                        <td className="py-2 text-zinc-200">{m.provider}</td>
+                        <td className="py-2 text-zinc-200">
+                          {formatModelName(m.model)}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-400">
+                          {fmtNum(m.input_tokens)}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-400">
+                          {fmtNum(m.output_tokens)}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {fmtValue(
+                            m.cost_cents,
+                            m.input_tokens + m.output_tokens
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <ul className="divide-y divide-white/5 text-sm sm:hidden">
+                  {models.map((m, i) => (
+                    <li
+                      key={`${m.provider}/${m.model}/${i}`}
+                      className="flex flex-col gap-1 py-2"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="text-zinc-200">
+                          {m.provider} / {formatModelName(m.model)}
+                        </span>
+                        <span className="tabular-nums text-zinc-300">
+                          {fmtValue(
+                            m.cost_cents,
+                            m.input_tokens + m.output_tokens
+                          )}
+                        </span>
+                      </div>
+                      <div className="text-xs tabular-nums text-zinc-500">
+                        in {fmtNum(m.input_tokens)} · out{" "}
+                        {fmtNum(m.output_tokens)}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Model Count</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+            <StatCard title="Active models" value={activeModelsLabel} />
+            <ModelCountChart data={modelActivity} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{perModelTitle}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 sm:grid-cols-[auto,1fr] sm:items-center">
+            <StatCard
+              title={isTokens ? "Avg tokens per model" : "Avg cost per model"}
+              value={avgPerModelLabel}
+            />
+            <CostPerModelChart data={modelActivity} unit={unit} />
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/charts/cost-per-model-chart.tsx
+++ b/src/components/charts/cost-per-model-chart.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtCost, fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+import type { Unit } from "@/lib/units";
+
+interface CostPerModelDatum {
+  bucket_day: string;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+  active_models: number;
+}
+
+export function CostPerModelChart({
+  data,
+  unit = "dollars",
+}: {
+  data: CostPerModelDatum[];
+  unit?: Unit;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No model cost data for this period
+      </div>
+    );
+  }
+
+  const isTokens = unit === "tokens";
+  const fmt = isTokens ? fmtNum : fmtCost;
+  const seriesLabel = isTokens ? "Tokens / model" : "Cost / model";
+
+  // Days with no active models render as gaps rather than NaN/Infinity bars
+  // — same divide-by-zero guard as `CostPerDeviceChart` (#145).
+  const series = data.map((d) => {
+    if (d.active_models <= 0) {
+      return { bucket_day: d.bucket_day, value: null as number | null };
+    }
+    const numerator = isTokens
+      ? d.input_tokens + d.output_tokens
+      : d.cost_cents;
+    return { bucket_day: d.bucket_day, value: numerator / d.active_models };
+  });
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={series}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => fmt(Number(v))}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={72}
+          label={{
+            value: seriesLabel,
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value) => [fmt(Number(value)), seriesLabel]}
+        />
+        <Bar
+          dataKey="value"
+          fill="#f59e0b"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/model-count-chart.tsx
+++ b/src/components/charts/model-count-chart.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+
+interface ModelCountDatum {
+  bucket_day: string;
+  active_models: number;
+}
+
+export function ModelCountChart({ data }: { data: ModelCountDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No model count data for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ left: 16, right: 8, top: 8, bottom: 8 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tickFormatter={fmtNum}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={48}
+          label={{
+            value: "Active models",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value) => [fmtNum(Number(value)), "Active models"]}
+        />
+        <Bar
+          dataKey="active_models"
+          fill="#22c55e"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -427,6 +427,60 @@ interface DeviceActivityRow {
   output_tokens?: number | string;
 }
 
+export interface ModelActivityDay {
+  bucket_day: string;
+  active_models: number;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+/**
+ * Daily series of distinct active models + total cost for the Models page
+ * (#147). Active = the `(provider, model)` pair has any rollup row in the
+ * bucket. Manager sees the full org; member sees own devices only
+ * (ADR-0083 §6). When the manager's `UserFilter` is engaged the series is
+ * narrowed to that teammate's devices so it stays consistent with the
+ * per-model bar chart on the same page.
+ *
+ * Days with no rollup activity simply don't appear in the result; the chart
+ * components decide whether to interpolate or render a gap.
+ */
+export async function getModelActivityByDay(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<ModelActivityDay[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_model_activity_by_day", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as ModelActivityRow[])
+    .map((r) => ({
+      bucket_day: r.bucket_day,
+      active_models: Number(r.active_models),
+      cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}
+
+interface ModelActivityRow {
+  bucket_day: string;
+  active_models: number | string;
+  cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
+}
+
 interface UserLookup {
   id: string;
   display_name: string | null;

--- a/supabase/migrations/011_model_activity_by_day.sql
+++ b/supabase/migrations/011_model_activity_by_day.sql
@@ -1,0 +1,42 @@
+-- Per-day active-model count and cost for the Models page (#147).
+--
+-- Mirrors `dashboard_device_activity_by_day` (#145) but pivots on the
+-- `(provider, model)` pair instead of `device_id` so the Models page can show
+-- "active models per day" and a "cost per model" time series alongside the
+-- existing per-model bar chart. `gpt-4o` on OpenAI and `gpt-4o` on Azure are
+-- distinct lines on the bar chart, so they should also count as distinct lines
+-- in the active-model headcount — we group on the pair, not just the model
+-- string.
+--
+-- The viewer's visibility scope is enforced upstream via `getVisibleDeviceIds`
+-- — `p_device_ids` is the authoritative gate. Aggregating in Postgres keeps
+-- us safe from PostgREST's 1k-row default cap (see #92, #008).
+CREATE OR REPLACE FUNCTION public.dashboard_model_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE
+)
+RETURNS TABLE (
+    bucket_day     DATE,
+    active_models  BIGINT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        COUNT(DISTINCT (provider, model))::BIGINT AS active_models,
+        SUM(cost_cents)                            AS cost_cents,
+        SUM(input_tokens)::BIGINT                  AS input_tokens,
+        SUM(output_tokens)::BIGINT                 AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;


### PR DESCRIPTION
## Summary

Closes #147. Brings the Models page up to parity with the Team (#131, #135) and Devices (#145) pages so the three feel like a matched set.

- **Co-locate bar chart + companion table** in a single card. Provider is its own column instead of being jammed into the bar label, and the table now surfaces the `In / Out` token split that `getCostByModel` already returns.
- **Add `Model Count` card** with per-day distinct-active-models series and a headline `Active models` stat. Distinct count groups on `(provider, model)` so `gpt-4o` on OpenAI and `gpt-4o` on Azure stay separate, matching the bar chart.
- **Add `Cost/Tokens per Model` card** with an `Avg per model` headline stat, mirroring `CostPerPersonChart` / `CostPerDeviceChart`.
- New `dashboard_model_activity_by_day` RPC + `getModelActivityByDay` DAL helper.
- Existing filters (`UserFilter`, `UnitsSelector`, `PeriodSelector`) and ADR-0083 §6 manager-vs-member scoping are unchanged; the new time-series respects `scopedUserId` so the manager UserFilter view stays consistent across all three cards.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — page test updated to mock `getModelActivityByDay`, with new assertions for the merged card, headline stats, and tokens-unit relabel
- [x] `npm run build`
- [ ] Smoke `/dashboard/models` as a manager and as a member; toggle Units between Cost and Tokens; engage UserFilter and confirm all three cards stay scoped together
- [ ] Apply migration `011_model_activity_by_day.sql` in Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)