### PR TITLE
feat(overview): period-over-period deltas + previous-period overlay (#150)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,11 +7,11 @@ import {
   getOrgMembers,
   getSyncFreshness,
 } from "@/lib/dal";
-import { dateRangeFromDays } from "@/lib/date-range";
+import { dateRangeFromDays, previousDateRange } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { fmtCost, fmtNum } from "@/lib/format";
+import { fmtCost, fmtDelta, fmtNum } from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
@@ -41,12 +41,40 @@ export default async function OverviewPage({
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [stats, activity, freshness, members] = await Promise.all([
-    getOverviewStats(user, range, scope),
-    getDailyActivity(user, range, scope),
-    getSyncFreshness(user),
-    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
-  ]);
+  // Same-length window immediately preceding `range` for period-over-period
+  // deltas (#150). `null` for the lifetime preset where "the period before
+  // earliest-activity" is empty by definition.
+  const previousRange =
+    params.days === ALL_PERIOD_VALUE ? null : previousDateRange(range, tz);
+  const [stats, activity, freshness, members, previousStats, previousActivity] =
+    await Promise.all([
+      getOverviewStats(user, range, scope),
+      getDailyActivity(user, range, scope),
+      getSyncFreshness(user),
+      user.role === "manager"
+        ? getOrgMembers(user.org_id)
+        : Promise.resolve([]),
+      previousRange
+        ? getOverviewStats(user, previousRange, scope)
+        : Promise.resolve(null),
+      previousRange
+        ? getDailyActivity(user, previousRange, scope)
+        : Promise.resolve([]),
+    ]);
+
+  // Caption for the headline-card delta (e.g. "vs previous 7d"). For numeric
+  // ?days= we show the length verbatim; for any other window we say "previous
+  // period" so the label stays accurate without inventing a number.
+  const periodLengthDays = Number(params.days);
+  const deltaCaption =
+    Number.isFinite(periodLengthDays) && periodLengthDays >= 1
+      ? `vs previous ${Math.floor(periodLengthDays)}d`
+      : "vs previous period";
+
+  const totalTokens = stats.totalInputTokens + stats.totalOutputTokens;
+  const previousTotalTokens = previousStats
+    ? previousStats.totalInputTokens + previousStats.totalOutputTokens
+    : 0;
 
   // Decide which empty-state banner (if any) is most informative. The
   // freshness snapshot lets us tell "no devices yet" apart from "devices
@@ -76,14 +104,47 @@ export default async function OverviewPage({
         {unit === "tokens" ? (
           <StatCard
             title="Total Tokens"
-            value={fmtNum(stats.totalInputTokens + stats.totalOutputTokens)}
+            value={fmtNum(totalTokens)}
             subtitle={`${fmtNum(stats.totalInputTokens)} in / ${fmtNum(stats.totalOutputTokens)} out`}
+            delta={
+              previousStats
+                ? fmtDelta(totalTokens, previousTotalTokens)
+                : undefined
+            }
+            deltaCaption={previousStats ? deltaCaption : undefined}
           />
         ) : (
-          <StatCard title="Total Cost" value={fmtCost(stats.totalCostCents)} />
+          <StatCard
+            title="Total Cost"
+            value={fmtCost(stats.totalCostCents)}
+            delta={
+              previousStats
+                ? fmtDelta(stats.totalCostCents, previousStats.totalCostCents)
+                : undefined
+            }
+            deltaCaption={previousStats ? deltaCaption : undefined}
+          />
         )}
-        <StatCard title="Messages" value={fmtNum(stats.totalMessages)} />
-        <StatCard title="Sessions" value={fmtNum(stats.totalSessions)} />
+        <StatCard
+          title="Messages"
+          value={fmtNum(stats.totalMessages)}
+          delta={
+            previousStats
+              ? fmtDelta(stats.totalMessages, previousStats.totalMessages)
+              : undefined
+          }
+          deltaCaption={previousStats ? deltaCaption : undefined}
+        />
+        <StatCard
+          title="Sessions"
+          value={fmtNum(stats.totalSessions)}
+          delta={
+            previousStats
+              ? fmtDelta(stats.totalSessions, previousStats.totalSessions)
+              : undefined
+          }
+          deltaCaption={previousStats ? deltaCaption : undefined}
+        />
       </div>
 
       <Card>
@@ -91,7 +152,11 @@ export default async function OverviewPage({
           <CardTitle>{`Daily Activity (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
         </CardHeader>
         <CardContent>
-          <ActivityChart data={activity} unit={unit} />
+          <ActivityChart
+            data={activity}
+            previousData={previousActivity}
+            unit={unit}
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import {
   Bar,
-  BarChart,
   CartesianGrid,
+  ComposedChart,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -58,13 +60,56 @@ function rebucket(data: ActivityData[]): ActivityData[] {
   );
 }
 
+interface ChartRow extends ActivityData {
+  /** Previous-period token total at the same offset, when overlay is on. */
+  previous_tokens?: number;
+  /** Previous-period cost at the same offset, when overlay is on. */
+  previous_cost_cents?: number;
+  /** Bucket day from the previous-period series, for the tooltip label. */
+  previous_bucket_day?: string;
+}
+
+/**
+ * Align previous-period rows to current-period rows by index. The two windows
+ * are constructed to be the same length, so position N in `previous` maps to
+ * position N in `current` — the overlay reads as "what we did last week, on
+ * the same day-of-week". Length mismatches (e.g. brand-new orgs whose first
+ * sync started mid-window) just truncate to whichever is shorter.
+ */
+function withPreviousOverlay(
+  current: ActivityData[],
+  previous: ActivityData[],
+  unit: Unit
+): ChartRow[] {
+  return current.map((row, i) => {
+    const prev = previous[i];
+    if (!prev) return row;
+    return {
+      ...row,
+      previous_tokens:
+        unit === "tokens" ? prev.input_tokens + prev.output_tokens : undefined,
+      previous_cost_cents: unit === "tokens" ? undefined : prev.cost_cents,
+      previous_bucket_day: prev.bucket_day,
+    };
+  });
+}
+
 export function ActivityChart({
   data,
+  previousData = [],
   unit = "tokens",
 }: {
   data: ActivityData[];
+  /**
+   * Optional same-length series from the period immediately preceding `data`,
+   * rendered as a ghosted line overlay when the viewer toggles it on (#150).
+   * Off by default so the default page render stays uncluttered.
+   */
+  previousData?: ActivityData[];
   unit?: Unit;
 }) {
+  const [showPrevious, setShowPrevious] = useState(false);
+
   if (data.length === 0) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
@@ -74,91 +119,138 @@ export function ActivityChart({
   }
 
   const bucketed = rebucket(data);
+  const bucketedPrevious = rebucket(previousData);
   const isTokens = unit === "tokens";
   const fmt = isTokens ? fmtNum : fmtCost;
   const yAxisLabel = isTokens ? "Tokens" : "Cost";
+  const hasPrevious = bucketedPrevious.length > 0;
+  const rows: ChartRow[] = hasPrevious
+    ? withPreviousOverlay(bucketed, bucketedPrevious, unit)
+    : bucketed;
 
   return (
-    <ResponsiveContainer width="100%" height={300}>
-      <BarChart
-        data={bucketed}
-        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
-      >
-        <CartesianGrid
-          strokeDasharray="3 3"
-          stroke="rgba(255,255,255,0.06)"
-          vertical={false}
-        />
-        <XAxis
-          dataKey="bucket_day"
-          tickFormatter={fmtDate}
-          tick={{ fill: "#71717a", fontSize: 12 }}
-          tickLine={false}
-          axisLine={false}
-        />
-        <YAxis
-          tickFormatter={(v) => fmt(Number(v))}
-          tick={{ fill: "#71717a", fontSize: 12 }}
-          tickLine={false}
-          axisLine={false}
-          width={72}
-          label={{
-            value: yAxisLabel,
-            angle: -90,
-            position: "insideLeft",
-            offset: 0,
-            dx: -8,
-            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
-          }}
-        />
-        <Tooltip
-          cursor={{ fill: "rgba(255,255,255,0.05)" }}
-          contentStyle={{
-            background: "#18181b",
-            border: "1px solid rgba(255,255,255,0.1)",
-            borderRadius: "8px",
-            fontSize: "13px",
-          }}
-          labelFormatter={(label) => fmtFullDate(String(label))}
-          formatter={(value, name) => {
-            const key = String(name);
-            const seriesLabel = isTokens
-              ? key === "input_tokens"
-                ? "Input"
-                : "Output"
-              : "Cost";
-            return [fmt(Number(value)), seriesLabel];
-          }}
-        />
-        {isTokens ? (
-          <>
-            <Bar
-              dataKey="input_tokens"
-              stackId="value"
-              fill="#3b82f6"
-              maxBarSize={28}
-              radius={[0, 0, 0, 0]}
-              isAnimationActive={false}
+    <div>
+      {hasPrevious && (
+        <div className="mb-2 flex justify-end">
+          <label className="flex items-center gap-2 text-xs text-zinc-400">
+            <input
+              type="checkbox"
+              className="h-3 w-3 cursor-pointer accent-zinc-500"
+              checked={showPrevious}
+              onChange={(e) => setShowPrevious(e.target.checked)}
             />
-            <Bar
-              dataKey="output_tokens"
-              stackId="value"
-              fill="#8b5cf6"
-              maxBarSize={28}
-              radius={[4, 4, 0, 0]}
-              isAnimationActive={false}
-            />
-          </>
-        ) : (
-          <Bar
-            dataKey="cost_cents"
-            fill="#3b82f6"
-            maxBarSize={28}
-            radius={[4, 4, 0, 0]}
-            isAnimationActive={false}
+            Compare to previous period
+          </label>
+        </div>
+      )}
+      <ResponsiveContainer width="100%" height={300}>
+        <ComposedChart
+          data={rows}
+          margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="rgba(255,255,255,0.06)"
+            vertical={false}
           />
-        )}
-      </BarChart>
-    </ResponsiveContainer>
+          <XAxis
+            dataKey="bucket_day"
+            tickFormatter={fmtDate}
+            tick={{ fill: "#71717a", fontSize: 12 }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <YAxis
+            tickFormatter={(v) => fmt(Number(v))}
+            tick={{ fill: "#71717a", fontSize: 12 }}
+            tickLine={false}
+            axisLine={false}
+            width={72}
+            label={{
+              value: yAxisLabel,
+              angle: -90,
+              position: "insideLeft",
+              offset: 0,
+              dx: -8,
+              style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+            }}
+          />
+          <Tooltip
+            cursor={{ fill: "rgba(255,255,255,0.05)" }}
+            contentStyle={{
+              background: "#18181b",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: "8px",
+              fontSize: "13px",
+            }}
+            labelFormatter={(label) => fmtFullDate(String(label))}
+            formatter={(value, name) => {
+              const key = String(name);
+              if (key === "previous_tokens" || key === "previous_cost_cents") {
+                return [fmt(Number(value)), "Previous period"];
+              }
+              const seriesLabel = isTokens
+                ? key === "input_tokens"
+                  ? "Input"
+                  : "Output"
+                : "Cost";
+              return [fmt(Number(value)), seriesLabel];
+            }}
+          />
+          {isTokens ? (
+            <>
+              <Bar
+                dataKey="input_tokens"
+                stackId="value"
+                fill="#3b82f6"
+                maxBarSize={28}
+                radius={[0, 0, 0, 0]}
+                isAnimationActive={false}
+              />
+              <Bar
+                dataKey="output_tokens"
+                stackId="value"
+                fill="#8b5cf6"
+                maxBarSize={28}
+                radius={[4, 4, 0, 0]}
+                isAnimationActive={false}
+              />
+              {showPrevious && hasPrevious && (
+                <Line
+                  type="monotone"
+                  dataKey="previous_tokens"
+                  stroke="rgba(255,255,255,0.45)"
+                  strokeDasharray="4 4"
+                  strokeWidth={1.5}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              )}
+            </>
+          ) : (
+            <>
+              <Bar
+                dataKey="cost_cents"
+                fill="#3b82f6"
+                maxBarSize={28}
+                radius={[4, 4, 0, 0]}
+                isAnimationActive={false}
+              />
+              {showPrevious && hasPrevious && (
+                <Line
+                  type="monotone"
+                  dataKey="previous_cost_cents"
+                  stroke="rgba(255,255,255,0.45)"
+                  strokeDasharray="4 4"
+                  strokeWidth={1.5}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              )}
+            </>
+          )}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
   );
 }

--- a/src/components/stat-card.tsx
+++ b/src/components/stat-card.tsx
@@ -1,19 +1,46 @@
 import { Card } from "@/components/ui/card";
 
+interface Delta {
+  label: string;
+  direction: "up" | "down" | "flat";
+}
+
 export function StatCard({
   title,
   value,
   subtitle,
+  delta,
+  deltaCaption,
 }: {
   title: string;
   value: string;
   subtitle?: string;
+  /**
+   * Period-over-period change vs the previous comparable window (#150). Color
+   * follows direction; a `flat` direction renders zinc so the comparison
+   * stays neutral when the baseline is missing or the change is sub-rounding.
+   */
+  delta?: Delta;
+  /** e.g. `vs previous 7d`. Required when `delta` is supplied. */
+  deltaCaption?: string;
 }) {
+  const deltaColor =
+    delta?.direction === "up"
+      ? "text-emerald-400"
+      : delta?.direction === "down"
+        ? "text-rose-400"
+        : "text-zinc-500";
   return (
     <Card>
       <p className="text-sm font-medium text-zinc-400">{title}</p>
       <p className="mt-2 text-3xl font-semibold text-white">{value}</p>
       {subtitle && <p className="mt-1 text-sm text-zinc-500">{subtitle}</p>}
+      {delta && deltaCaption && (
+        <p className="mt-1 text-xs text-zinc-500">
+          <span className={`font-medium ${deltaColor}`}>{delta.label}</span>{" "}
+          {deltaCaption}
+        </p>
+      )}
     </Card>
   );
 }

--- a/src/lib/date-range.test.ts
+++ b/src/lib/date-range.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { dateRangeFromDays } from "@/lib/date-range";
+import { dateRangeFromDays, previousDateRange } from "@/lib/date-range";
 
 /**
  * Pins the rolling-window contract introduced in #75. Each `days=N` query
@@ -163,5 +163,45 @@ describe("dateRangeFromDays (TZ-aware bucket bounds, #78)", () => {
     // the daemon already wrote it in UTC, so the literal date is correct.
     expect(r.bucketFrom).toBe("2026-01-15");
     expect(r.bucketTo).toBe("2026-04-28");
+  });
+});
+
+describe("previousDateRange (#150 — period-over-period on Overview)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("7d: returns the 8-day window immediately preceding the current 8-day window", () => {
+    // Current 7d range is Apr 11 → Apr 18 (8 day buckets); the comparable
+    // previous window is the 8 days ending the day before — Apr 3 → Apr 10.
+    const current = dateRangeFromDays("7");
+    const prev = previousDateRange(current);
+    expect(prev?.from).toBe("2026-04-03");
+    expect(prev?.to).toBe("2026-04-10");
+  });
+
+  it("1d: previous window is the two days before yesterday/today", () => {
+    const current = dateRangeFromDays("1");
+    const prev = previousDateRange(current);
+    expect(prev?.from).toBe("2026-04-15");
+    expect(prev?.to).toBe("2026-04-16");
+  });
+
+  it("preserves bucket and started_at bounds in the supplied timezone", () => {
+    vi.setSystemTime(new Date("2026-04-28T00:30:00Z"));
+    const current = dateRangeFromDays("1", null, "America/Los_Angeles");
+    const prev = previousDateRange(current, "America/Los_Angeles");
+    // Current is Apr 26–27 PDT; previous is Apr 24–25 PDT, with a UTC bucket
+    // upper bound of Apr 26 (the bucket containing Apr 25 PDT evening) — same
+    // shape as the current-window contract pinned above.
+    expect(prev?.from).toBe("2026-04-24");
+    expect(prev?.to).toBe("2026-04-25");
+    expect(prev?.bucketFrom).toBe("2026-04-24");
+    expect(prev?.bucketTo).toBe("2026-04-26");
   });
 });

--- a/src/lib/date-range.ts
+++ b/src/lib/date-range.ts
@@ -57,6 +57,34 @@ export function dateRangeFromDays(
 }
 
 /**
+ * Same-length window immediately preceding `range`, for period-over-period
+ * comparison on the Overview page (#150). Both bounds are derived in the same
+ * `timeZone` as `range` so daylight-saving boundaries don't introduce a
+ * one-hour drift between the two windows.
+ *
+ * Returns `null` when no meaningful comparison exists — the lifetime
+ * (`?days=all`) preset already starts at the org's earliest activity, so
+ * "the period before that" is by definition empty.
+ */
+export function previousDateRange(
+  range: DateRange,
+  timeZone?: string | null
+): DateRange | null {
+  const tz = timeZone && isValidTimeZone(timeZone) ? timeZone : "UTC";
+  const lengthDays = daysBetweenIso(range.from, range.to);
+  if (lengthDays < 0) return null;
+  const prevTo = subDaysIso(range.from, 1);
+  const prevFrom = subDaysIso(prevTo, lengthDays);
+  return makeRange(prevFrom, prevTo, tz);
+}
+
+function daysBetweenIso(from: string, to: string): number {
+  const a = new Date(`${from}T00:00:00Z`).getTime();
+  const b = new Date(`${to}T00:00:00Z`).getTime();
+  return Math.round((b - a) / 86_400_000);
+}
+
+/**
  * Resolve the lower bound of the local-TZ range from `days` and the optional
  * earliest-activity date. Kept separate so the rolling-window math reads
  * cleanly without the timezone plumbing on top.

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDuration, repoName } from "./format";
+import { fmtDelta, formatDuration, repoName } from "./format";
 
 describe("formatDuration (#88)", () => {
   it("uses duration_ms when provided", () => {
@@ -46,6 +46,29 @@ describe("formatDuration (#88)", () => {
     expect(
       formatDuration(60_000, "2026-04-29T10:00:00Z", "2026-04-29T11:00:00Z")
     ).toBe("1m");
+  });
+});
+
+describe("fmtDelta (#150 — period-over-period on Overview)", () => {
+  it("returns a signed percentage for non-zero baselines", () => {
+    expect(fmtDelta(110, 100)).toEqual({ label: "+10.0%", direction: "up" });
+    expect(fmtDelta(95, 100)).toEqual({ label: "-5.0%", direction: "down" });
+    expect(fmtDelta(123_456, 100_000)).toEqual({
+      label: "+23.5%",
+      direction: "up",
+    });
+  });
+
+  it("collapses to '—' when the previous window is zero — neither +Inf% nor 0% would be honest", () => {
+    expect(fmtDelta(50, 0)).toEqual({ label: "—", direction: "flat" });
+    expect(fmtDelta(0, 0)).toEqual({ label: "—", direction: "flat" });
+  });
+
+  it("rounds sub-promille changes to 0.0% so a stable baseline reads neutrally", () => {
+    expect(fmtDelta(100.0001, 100)).toEqual({
+      label: "0.0%",
+      direction: "flat",
+    });
   });
 });
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -77,6 +77,32 @@ export function formatModelName(model: string): string {
   return model.replace(/-\d{8}$/, "");
 }
 
+/**
+ * Period-over-period delta for the Overview headline cards (#150).
+ *
+ * Returns the percentage change of `current` vs `previous` along with a
+ * pre-formatted label. We can't render `+Inf%` when the previous window had
+ * zero baseline, and a literal `0%` would be misleading for a window that
+ * went from nothing to something — both cases collapse to a `—` sentinel
+ * so the card stays informative without inventing a number.
+ */
+export function fmtDelta(
+  current: number,
+  previous: number
+): { label: string; direction: "up" | "down" | "flat" } {
+  if (previous === 0) return { label: "—", direction: "flat" };
+  const ratio = (current - previous) / previous;
+  if (!Number.isFinite(ratio) || Math.abs(ratio) < 0.0005) {
+    return { label: "0.0%", direction: "flat" };
+  }
+  const pct = ratio * 100;
+  const sign = pct > 0 ? "+" : "";
+  return {
+    label: `${sign}${pct.toFixed(1)}%`,
+    direction: pct > 0 ? "up" : "down",
+  };
+}
+
 /** Format a date string for chart labels. */
 export function fmtDate(dateStr: string): string {
   const d = new Date(dateStr + "T00:00:00");


### PR DESCRIPTION
## Summary

Slice 1 of #150 — turn `/dashboard` into the at-a-glance comparison page rather than three lonely stat cards.

- **Headline deltas.** Each `StatCard` (Total Cost/Tokens, Messages, Sessions) now shows a signed % change vs the same-length previous window — green up, rose down. Zero-baseline windows collapse to a `—` so brand-new orgs don't render `+Inf%`.
- **Daily Activity overlay.** The chart can ghost-overlay the previous period as a dashed line. Off by default so the default render stays uncluttered.
- **TZ-correct previous range.** New `previousDateRange` derives both bounds in the viewer's IANA timezone so the comparison doesn't drift by an hour across DST.
- **Lifetime preset stays uncompared.** `?days=all` already starts at earliest-activity; "the period before that" is empty by definition, so we skip the comparison entirely.

Slices 2 (top-breakdowns row) and 3 (DOW × hour heatmap) from #150 are deliberately separate PRs per the issue's "individually shippable" framing.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (190 → 196 passing; new coverage for `fmtDelta` + `previousDateRange` including DST/TZ edge cases)
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Manual: load `/dashboard?days=7` — confirm `vs previous 7d` captions appear, toggle the overlay, switch unit toggle, and verify `?days=all` hides the comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)