### PR TITLE
fix(overview): align Sessions count with bucket_day window (#155)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -46,8 +46,6 @@ class FakeSupabase {
     const deviceIds = new Set(args.p_device_ids as string[]);
     const from = args.p_bucket_from as string;
     const to = args.p_bucket_to as string;
-    const startedFrom = args.p_started_from as string;
-    const startedTo = args.p_started_to as string;
     const rollups = (this.tables.get("daily_rollups") ?? []).filter(
       (r) =>
         deviceIds.has(r.device_id as string) &&
@@ -74,10 +72,15 @@ class FakeSupabase {
       }
     );
     const total_sessions = (this.tables.get("session_summaries") ?? []).filter(
-      (s) =>
-        deviceIds.has(s.device_id as string) &&
-        String(s.started_at ?? "") >= startedFrom &&
-        String(s.started_at ?? "") <= startedTo
+      (s) => {
+        if (!deviceIds.has(s.device_id as string)) return false;
+        // Mirrors `COALESCE(started_at, ended_at, synced_at)::date` (#155).
+        const anchor = (s.started_at ?? s.ended_at ?? s.synced_at ?? "") as
+          | string
+          | null;
+        const date = anchor ? String(anchor).slice(0, 10) : "";
+        return date !== "" && date >= from && date <= to;
+      }
     ).length;
     return Promise.resolve({
       data: [{ ...totals, total_sessions }],

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -104,13 +104,21 @@ const RPC_HANDLERS: Record<string, RpcHandler> = {
     );
 
     const deviceIds = new Set(args.p_device_ids as string[]);
-    const startedFrom = args.p_started_from as string;
-    const startedTo = args.p_started_to as string;
+    const bucketFrom = args.p_bucket_from as string;
+    const bucketTo = args.p_bucket_to as string;
     const total_sessions = (tables.get("session_summaries") ?? []).filter(
-      (s) =>
-        deviceIds.has(s.device_id as string) &&
-        String(s.started_at ?? "") >= startedFrom &&
-        String(s.started_at ?? "") <= startedTo
+      (s) => {
+        if (!deviceIds.has(s.device_id as string)) return false;
+        // Mirrors `COALESCE(started_at, ended_at, synced_at)::date` on the SQL
+        // side (#155): use the first non-null timestamp and compare its date
+        // component against the bucket range, so a row with NULL `started_at`
+        // still counts and the date key matches what the rollup totals see.
+        const anchor = (s.started_at ?? s.ended_at ?? s.synced_at ?? "") as
+          | string
+          | null;
+        const date = anchor ? String(anchor).slice(0, 10) : "";
+        return date !== "" && date >= bucketFrom && date <= bucketTo;
+      }
     ).length;
 
     return [{ ...totals, total_sessions }];
@@ -1041,6 +1049,87 @@ describe("server-side aggregation (#92)", () => {
 
     expect(ivanDeviceCost).toBeGreaterThan(0);
     expect(ivanDeviceCost).toBe(scopedTotal);
+  });
+});
+
+describe("Overview session count: bucket_day alignment (#155)", () => {
+  // Regression: pre-#155 the session count filtered `started_at` over a
+  // precise TIMESTAMPTZ window while every other column on the same row
+  // summed `daily_rollups` over a calendar-day range. On `?days=1` the
+  // previous-period count collapsed to zero — `fmtDelta` rendered the `—`
+  // sentinel — while the cost/tokens/messages cards on the same row showed
+  // real period-over-period deltas. The fix counts sessions on the same
+  // `bucket_day` range as the rollup totals, with a COALESCE fallback so a
+  // NULL `started_at` doesn't silently disappear.
+
+  const baseUser = {
+    id: "usr_ivan",
+    org_id: "org_solo",
+    role: "manager" as const,
+    api_key: "budi_x",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+
+  function seedOrg() {
+    fake.seed("orgs", [{ id: "org_solo", name: "solo" }]);
+    fake.seed("users", [{ ...baseUser }]);
+    fake.seed("devices", [{ id: "dev_laptop", user_id: "usr_ivan" }]);
+  }
+
+  it("counts a session whose started_at IS NULL via ended_at/synced_at fallback", async () => {
+    seedOrg();
+    fake.seed("daily_rollups", [rollup("dev_laptop", "2026-04-15", 100)]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_laptop",
+        session_id: "sess_a",
+        provider: "claude_code",
+        started_at: null,
+        ended_at: "2026-04-15T11:00:00Z",
+        synced_at: "2026-04-15T11:30:00Z",
+        message_count: 1,
+      },
+    ]);
+
+    const { getOverviewStats } = await loadDal();
+    const overview = await getOverviewStats(
+      baseUser,
+      utcRange("2026-04-15", "2026-04-15")
+    );
+
+    expect(overview.totalMessages).toBeGreaterThan(0);
+    expect(overview.totalSessions).toBe(1);
+  });
+
+  it("the bucket_day window is the source of truth — sessions and rollups never disagree on inclusion", async () => {
+    seedOrg();
+    // Both a rollup and a session are dated to the same calendar day.
+    fake.seed("daily_rollups", [rollup("dev_laptop", "2026-04-15", 100)]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_laptop",
+        session_id: "sess_a",
+        provider: "claude_code",
+        // Late-evening timestamp — pre-#155 this could fall outside a precise
+        // TIMESTAMPTZ window even when its `bucket_day` was inside the range,
+        // because the bucket bound was widened to cover local-TZ overlap
+        // (`src/lib/timezone.ts`) while the session bound was not.
+        started_at: "2026-04-15T23:30:00Z",
+        ended_at: "2026-04-15T23:55:00Z",
+        synced_at: "2026-04-15T23:55:00Z",
+        message_count: 1,
+      },
+    ]);
+
+    const { getOverviewStats } = await loadDal();
+    const overview = await getOverviewStats(
+      baseUser,
+      utcRange("2026-04-15", "2026-04-15")
+    );
+
+    expect(overview.totalMessages).toBe(1);
+    expect(overview.totalSessions).toBe(1);
   });
 });
 

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -83,6 +83,13 @@ export async function getCurrentUser(): Promise<BudiUser | null> {
  * Aggregation runs server-side via `dashboard_overview_stats` (#92) so the
  * sums are independent of any PostgREST row cap — `getOverviewStats` and
  * every breakdown query agree on the same row set regardless of org size.
+ *
+ * The session count is filtered by the same `bucket_day` calendar range as
+ * the rollup totals (#155). Pre-#155 the count used a precise TIMESTAMPTZ
+ * window over `started_at`, which excluded sessions with NULL `started_at`
+ * and was narrower than the rollup window — on `?days=1` that asymmetry
+ * was enough to collapse the previous-period count to zero while every
+ * other card on the same row showed real period-over-period deltas.
  */
 export async function getOverviewStats(
   user: BudiUser,
@@ -106,8 +113,6 @@ export async function getOverviewStats(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
-    p_started_from: range.startedAtFrom,
-    p_started_to: range.startedAtTo,
   });
   if (error) throw error;
 

--- a/supabase/migrations/012_overview_session_count_bucket_day.sql
+++ b/supabase/migrations/012_overview_session_count_bucket_day.sql
@@ -1,0 +1,79 @@
+-- Align Overview's `total_sessions` with the cost/tokens/messages totals on
+-- the same row (#155).
+--
+-- Pre-#155 the function counted sessions whose `started_at` fell inside a
+-- precise TIMESTAMPTZ window (`p_started_from..p_started_to`), while every
+-- other column on the same row summed `daily_rollups` over a calendar-day
+-- range (`p_bucket_from..p_bucket_to`). Two structural reasons made the
+-- session count collapse to zero on narrow windows where the rollup-sourced
+-- columns still showed real numbers:
+--
+--   1. `session_summaries.started_at` is nullable (`001_ingest_schema.sql`);
+--      any row with `started_at IS NULL` was silently excluded by `BETWEEN`,
+--      while the corresponding `daily_rollups` row (keyed by `bucket_day`)
+--      still counted toward cost/tokens/messages.
+--   2. The TIMESTAMPTZ window is narrower than the `bucket_day` window — the
+--      latter widens by up to one UTC day on the earlier edge to capture all
+--      buckets overlapping the viewer's local-TZ day (`src/lib/timezone.ts`),
+--      so a session whose `started_at` is just outside the precise window
+--      could still have its rollup row included on the cost/tokens side.
+--
+-- On `?days=1` the previous-period window is two calendar days; either bias
+-- alone could (and did, per #155) collapse the previous count to zero,
+-- producing the `—` sentinel in `fmtDelta` (`src/lib/format.ts:89-104`)
+-- while every other card on the same row showed a real percentage.
+--
+-- The fix is to drive both sources off the same date key. We keep the count
+-- on `session_summaries` (no rollup-side `session_count` column to add yet)
+-- and:
+--   - filter on `COALESCE(started_at, ended_at, synced_at)::date` so a row
+--     with NULL `started_at` falls back to the next non-null timestamp
+--     instead of disappearing,
+--   - compare that date against `p_bucket_from..p_bucket_to`, the same
+--     `bucket_day` range the rollup totals use.
+--
+-- Postgres won't let `CREATE OR REPLACE FUNCTION` change a function's
+-- argument list (signature is part of identity), so we drop the old shape
+-- first; the next CREATE re-establishes it without the obsolete
+-- `p_started_from` / `p_started_to` parameters.
+
+DROP FUNCTION IF EXISTS public.dashboard_overview_stats(TEXT[], DATE, DATE, TIMESTAMPTZ, TIMESTAMPTZ);
+
+CREATE OR REPLACE FUNCTION public.dashboard_overview_stats(
+    p_device_ids   TEXT[],
+    p_bucket_from  DATE,
+    p_bucket_to    DATE
+)
+RETURNS TABLE (
+    total_cost_cents     NUMERIC,
+    total_input_tokens   BIGINT,
+    total_output_tokens  BIGINT,
+    total_messages       BIGINT,
+    total_sessions       BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH r AS (
+        SELECT
+            COALESCE(SUM(cost_cents), 0)             AS total_cost_cents,
+            COALESCE(SUM(input_tokens), 0)::BIGINT   AS total_input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT  AS total_output_tokens,
+            COALESCE(SUM(message_count), 0)::BIGINT  AS total_messages
+        FROM daily_rollups
+        WHERE device_id = ANY(p_device_ids)
+          AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+    ),
+    s AS (
+        SELECT COUNT(*)::BIGINT AS total_sessions
+        FROM session_summaries
+        WHERE device_id = ANY(p_device_ids)
+          AND COALESCE(started_at, ended_at, synced_at)::date
+              BETWEEN p_bucket_from AND p_bucket_to
+    )
+    SELECT r.total_cost_cents, r.total_input_tokens, r.total_output_tokens,
+           r.total_messages, s.total_sessions
+    FROM r, s;
+$$;


### PR DESCRIPTION
## Summary

- Closes #155. On `?days=1` the Sessions card rendered `— vs previous 1d` while the Total Cost / Total Tokens / Messages cards on the same row showed real period-over-period deltas. The asymmetry was in the underlying queries, not the range builder.
- `dashboard_overview_stats` (`004_dashboard_aggregates.sql`) filtered sessions by a precise TIMESTAMPTZ window (`p_started_from..p_started_to`) while every other column summed `daily_rollups` over a calendar-day range (`p_bucket_from..p_bucket_to`). Two reasons biased only the sessions number toward zero on narrow windows: rows with `started_at IS NULL` were silently excluded, and the bucket window is wider than the instant window because it intentionally widens by up to one UTC day to capture every UTC bucket overlapping the viewer's local-TZ window (`src/lib/timezone.ts`).
- Migration `012` drops + recreates the function so the session count uses the same `bucket_day` range as the rollup totals: `COALESCE(started_at, ended_at, synced_at)::date BETWEEN p_bucket_from AND p_bucket_to`. The obsolete `p_started_from` / `p_started_to` parameters are removed; `getOverviewStats` and the in-memory test handlers are updated to match.

## Test plan

- [x] `npm test` — 199 / 199 (added two regression tests in `src/lib/dal.test.ts`: NULL `started_at` falls back to `ended_at`, and a late-evening session is counted on the same `bucket_day` it shares with its rollup).
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Manual: deploy migration `012`, hit `/dashboard?days=1` against an org with previous-1d activity, verify the Sessions card shows a real percentage instead of `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)