### PR TITLE
feat(overview): top model / contributor / repo breakdown cards (#150)

### DIFF
--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -39,8 +39,14 @@ const dal = {
   getEarliestActivity: vi.fn(),
   getOrgMembers: vi.fn(),
   getSyncFreshness: vi.fn(),
+  getCostByModel: vi.fn(),
+  getCostByRepo: vi.fn(),
+  getCostByUser: vi.fn(),
 };
-vi.mock("@/lib/dal", () => dal);
+vi.mock("@/lib/dal", () => ({
+  ...dal,
+  UNASSIGNED_USER_ID: "__unassigned__",
+}));
 
 const MANAGER = {
   id: "usr_ivan",
@@ -78,6 +84,32 @@ beforeEach(() => {
     lastRollupAt: "2026-04-15T10:00:00Z",
     lastSessionAt: "2026-04-15T10:00:00Z",
   });
+  dal.getCostByModel.mockResolvedValue([
+    {
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      cost_cents: 80_000,
+      input_tokens: 3000,
+      output_tokens: 1500,
+    },
+  ]);
+  dal.getCostByRepo.mockResolvedValue([
+    {
+      repo_id: "github.com/acme/widgets",
+      cost_cents: 60_000,
+      input_tokens: 2000,
+      output_tokens: 1000,
+    },
+  ]);
+  dal.getCostByUser.mockResolvedValue([
+    {
+      id: "usr_alice",
+      name: "Alice",
+      cost_cents: 90_000,
+      input_tokens: 3500,
+      output_tokens: 1800,
+    },
+  ]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {
@@ -171,5 +203,45 @@ describe("dashboard /page (Overview)", () => {
     dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
     const node = await render();
     expect(node).toBeNull();
+  });
+
+  it("top-breakdowns: manager sees Top model / Top contributor / Top repo cards once data has synced (#150)", async () => {
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Top model");
+    expect(text).toContain("Top contributor");
+    expect(text).toContain("Top repo");
+    expect(text).toContain("claude-sonnet-4-5");
+    expect(text).toContain("Alice");
+  });
+
+  it("top-breakdowns: members never see the Top contributor card (their own row would be the only one)", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, role: "member" });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Top model");
+    expect(text).toContain("Top repo");
+    expect(text).not.toContain("Top contributor");
+  });
+
+  it("top-breakdowns: do not render before first sync (link banner / first-sync banner suppress the row)", async () => {
+    dal.getSyncFreshness.mockResolvedValue({
+      deviceCount: 0,
+      lastSeenAt: null,
+      lastRollupAt: null,
+      lastSessionAt: null,
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).not.toContain("Top model");
+    expect(text).not.toContain("Top repo");
+  });
+
+  it("top-breakdowns: a manager who has scoped to a single user does not see Top contributor (it would only echo the filter)", async () => {
+    const node = await render({ user: "usr_bob" });
+    const text = extractText(node);
+    expect(text).toContain("Top model");
+    expect(text).toContain("Top repo");
+    expect(text).not.toContain("Top contributor");
   });
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,13 +6,24 @@ import {
   getEarliestActivity,
   getOrgMembers,
   getSyncFreshness,
+  getCostByModel,
+  getCostByRepo,
+  getCostByUser,
+  UNASSIGNED_USER_ID,
 } from "@/lib/dal";
 import { dateRangeFromDays, previousDateRange } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
-import { parseUnit } from "@/lib/units";
-import { fmtCost, fmtDelta, fmtNum } from "@/lib/format";
+import { parseUnit, type Unit } from "@/lib/units";
+import {
+  fmtCost,
+  fmtDelta,
+  fmtNum,
+  formatModelName,
+  repoName,
+} from "@/lib/format";
 import { StatCard } from "@/components/stat-card";
+import { TopBreakdownCard } from "@/components/top-breakdown-card";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -46,21 +57,35 @@ export default async function OverviewPage({
   // earliest-activity" is empty by definition.
   const previousRange =
     params.days === ALL_PERIOD_VALUE ? null : previousDateRange(range, tz);
-  const [stats, activity, freshness, members, previousStats, previousActivity] =
-    await Promise.all([
-      getOverviewStats(user, range, scope),
-      getDailyActivity(user, range, scope),
-      getSyncFreshness(user),
-      user.role === "manager"
-        ? getOrgMembers(user.org_id)
-        : Promise.resolve([]),
-      previousRange
-        ? getOverviewStats(user, previousRange, scope)
-        : Promise.resolve(null),
-      previousRange
-        ? getDailyActivity(user, previousRange, scope)
-        : Promise.resolve([]),
-    ]);
+  // Top contributor only renders for managers viewing the unfiltered org. With
+  // a `?user=` filter the rest of the page already narrows to one teammate, so
+  // a "leader" card showing that same teammate at 100% would be noise.
+  const showTopContributor = user.role === "manager" && !scopedUserId;
+  const [
+    stats,
+    activity,
+    freshness,
+    members,
+    previousStats,
+    previousActivity,
+    topModels,
+    topRepos,
+    topUsers,
+  ] = await Promise.all([
+    getOverviewStats(user, range, scope),
+    getDailyActivity(user, range, scope),
+    getSyncFreshness(user),
+    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+    previousRange
+      ? getOverviewStats(user, previousRange, scope)
+      : Promise.resolve(null),
+    previousRange
+      ? getDailyActivity(user, previousRange, scope)
+      : Promise.resolve([]),
+    getCostByModel(user, range, scope),
+    getCostByRepo(user, range, scope),
+    showTopContributor ? getCostByUser(user, range) : Promise.resolve([]),
+  ]);
 
   // Caption for the headline-card delta (e.g. "vs previous 7d"). For numeric
   // ?days= we show the length verbatim; for any other window we say "previous
@@ -83,6 +108,29 @@ export default async function OverviewPage({
   const showLinkBanner = freshness.deviceCount === 0;
   const showFirstSyncBanner =
     freshness.deviceCount > 0 && freshness.lastRollupAt === null;
+  const hasSynced = !showLinkBanner && !showFirstSyncBanner;
+
+  // Top breakdowns: pick the leader for each category and compute its share of
+  // the period total. Same denominator as the headline card so the share lines
+  // up with what the rest of the row reports. Sparkline reuses the period's
+  // daily activity series — every card shows the same trend curve, since the
+  // value is "did the period spike or coast?" not "did this leader spike?".
+  const sparkline = sparkValues(activity, unit);
+  const deepLinkSuffix = buildSearchParams({
+    days: params.days,
+    user: params.user,
+    units: params.units,
+  });
+  const totalCostCents = stats.totalCostCents;
+  const topModelLeader = topModels[0] ?? null;
+  const topRepoLeader = topRepos[0] ?? null;
+  // `getCostByUser` keeps the synthetic `Unassigned` bucket at the end, but
+  // for "top contributor" we want a real teammate as the leader, not a
+  // catch-all. Filter the bucket out before picking the head row.
+  const topUserLeader =
+    topUsers.find((u) => u.id !== UNASSIGNED_USER_ID) ?? null;
+  const sharePct = (n: number) =>
+    totalCostCents > 0 ? (n / totalCostCents) * 100 : null;
 
   return (
     <div className="space-y-6">
@@ -147,6 +195,40 @@ export default async function OverviewPage({
         />
       </div>
 
+      {hasSynced && (
+        <div
+          className={`grid gap-4 sm:grid-cols-2 ${showTopContributor ? "lg:grid-cols-3" : "lg:grid-cols-2"}`}
+        >
+          <TopBreakdownCard
+            title="Top model"
+            name={topModelLeader ? formatModelName(topModelLeader.model) : null}
+            sharePct={
+              topModelLeader ? sharePct(topModelLeader.cost_cents) : null
+            }
+            sparkline={sparkline}
+            href={`/dashboard/models${deepLinkSuffix}`}
+          />
+          {showTopContributor && (
+            <TopBreakdownCard
+              title="Top contributor"
+              name={topUserLeader ? topUserLeader.name : null}
+              sharePct={
+                topUserLeader ? sharePct(topUserLeader.cost_cents) : null
+              }
+              sparkline={sparkline}
+              href={`/dashboard/team${deepLinkSuffix}`}
+            />
+          )}
+          <TopBreakdownCard
+            title="Top repo"
+            name={topRepoLeader ? repoName(topRepoLeader.repo_id) : null}
+            sharePct={topRepoLeader ? sharePct(topRepoLeader.cost_cents) : null}
+            sparkline={sparkline}
+            href={`/dashboard/repos${deepLinkSuffix}`}
+          />
+        </div>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>{`Daily Activity (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
@@ -161,4 +243,35 @@ export default async function OverviewPage({
       </Card>
     </div>
   );
+}
+
+function sparkValues(
+  series: Array<{
+    cost_cents: number;
+    input_tokens: number;
+    output_tokens: number;
+  }>,
+  unit: Unit
+): number[] {
+  return series.map((d) =>
+    unit === "tokens" ? d.input_tokens + d.output_tokens : d.cost_cents
+  );
+}
+
+/**
+ * Forward the active filters when linking from a leader card to its deep page,
+ * so a manager who's viewing `/dashboard?days=30&user=abc` lands on
+ * `/dashboard/models?days=30&user=abc` rather than the page's default window.
+ */
+function buildSearchParams(params: {
+  days?: string;
+  user?: string;
+  units?: string;
+}): string {
+  const sp = new URLSearchParams();
+  if (params.days) sp.set("days", params.days);
+  if (params.user) sp.set("user", params.user);
+  if (params.units) sp.set("units", params.units);
+  const q = sp.toString();
+  return q ? `?${q}` : "";
 }

--- a/src/components/top-breakdown-card.tsx
+++ b/src/components/top-breakdown-card.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { Card } from "@/components/ui/card";
+
+/**
+ * Mini "leader card" for the Overview top-breakdowns row (#150 slice 2).
+ *
+ * Each card answers a single "who/what dominates this period?" question — top
+ * model, top contributor, top repo — and links to the page where the full
+ * breakdown lives. The sparkline reuses the period's daily totals so we don't
+ * issue a second per-leader query just to render a six-pixel decoration.
+ */
+export function TopBreakdownCard({
+  title,
+  name,
+  sharePct,
+  sparkline,
+  href,
+  emptyLabel = "No data",
+}: {
+  title: string;
+  /** Leader display name; `null` when the period has no data. */
+  name: string | null;
+  sharePct: number | null;
+  /** Period daily totals, ascending. Empty array hides the sparkline. */
+  sparkline: number[];
+  href: string;
+  emptyLabel?: string;
+}) {
+  const isEmpty = name === null;
+  return (
+    <Link
+      href={href}
+      className="block transition hover:bg-white/[0.04] rounded-xl"
+    >
+      <Card className="h-full">
+        <p className="text-sm font-medium text-zinc-400">{title}</p>
+        {isEmpty ? (
+          <p className="mt-2 text-2xl font-semibold text-zinc-500">
+            {emptyLabel}
+          </p>
+        ) : (
+          <>
+            <p
+              className="mt-2 truncate text-2xl font-semibold text-white"
+              title={name}
+            >
+              {name}
+            </p>
+            <div className="mt-1 flex items-end justify-between gap-3">
+              <p className="text-sm text-zinc-500">
+                {sharePct !== null ? `${sharePct.toFixed(1)}% of period` : ""}
+              </p>
+              {sparkline.length >= 2 && <Sparkline values={sparkline} />}
+            </div>
+          </>
+        )}
+      </Card>
+    </Link>
+  );
+}
+
+/**
+ * Inline SVG sparkline. Stays self-contained so the card doesn't pull in
+ * recharts for what is effectively a single polyline — recharts already
+ * renders the full-width Daily Activity chart on the same page.
+ */
+function Sparkline({ values }: { values: number[] }) {
+  const width = 80;
+  const height = 24;
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const range = max - min || 1;
+  const stepX = values.length > 1 ? width / (values.length - 1) : 0;
+  const points = values
+    .map((v, i) => {
+      const x = i * stepX;
+      const y = height - ((v - min) / range) * height;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="shrink-0"
+      aria-hidden
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="#3b82f6"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

- Second shippable slice of #150. Adds a 3-card "top breakdowns" row to `/dashboard` (Top model, Top contributor, Top repo) showing the leader name, share-of-period, and a small inline sparkline. Each card deep-links to the matching page (`/dashboard/models`, `/dashboard/team`, `/dashboard/repos`) with the active `?days` / `?user` / `?units` filters preserved.
- Top contributor is omitted for members (their own row would be the only one) and for managers who have already scoped to a single user (the card would just echo the filter).
- Top breakdowns share the existing first-sync gate: they don't render when `LinkDaemonBanner` or `FirstSyncInProgressBanner` is showing, so a brand-new org sees the link prompt instead of a row of "No data" cards.
- The sparkline is a self-contained inline SVG to avoid pulling recharts into a 6-pixel decoration on the same page where it already renders the full Daily Activity chart.

Slice (3) — the DOW × hour activity heatmap — is still open and will land in a follow-up PR.

## Test plan

- [x] `npm test` — 203/203 pass; `src/app/dashboard/page.test.tsx` adds 4 cases covering the populated-row, member-hides-contributor, pre-sync-suppresses-row, and scoped-manager-hides-contributor contracts
- [x] `npm run lint` clean
- [x] `npm run build` clean (TypeScript + page collection)
- [ ] Spot-check `/dashboard` as both a manager (with and without `?user=`) and a member against a synced org and a brand-new org

🤖 Generated with [Claude Code](https://claude.com/claude-code)