### PR TITLE
feat(overview): add day-of-week × hour activity heatmap (#150)

### DIFF
--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -42,6 +42,7 @@ const dal = {
   getCostByModel: vi.fn(),
   getCostByRepo: vi.fn(),
   getCostByUser: vi.fn(),
+  getActivityHeatmap: vi.fn(),
 };
 vi.mock("@/lib/dal", () => ({
   ...dal,
@@ -109,6 +110,9 @@ beforeEach(() => {
       input_tokens: 3500,
       output_tokens: 1800,
     },
+  ]);
+  dal.getActivityHeatmap.mockResolvedValue([
+    { dow: 2, hour: 14, session_count: 3, cost_cents: 50_000 },
   ]);
 });
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import {
   getCostByModel,
   getCostByRepo,
   getCostByUser,
+  getActivityHeatmap,
   UNASSIGNED_USER_ID,
 } from "@/lib/dal";
 import { dateRangeFromDays, previousDateRange } from "@/lib/date-range";
@@ -28,6 +29,7 @@ import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { ActivityChart } from "@/components/charts/activity-chart";
+import { ActivityHeatmap } from "@/components/charts/activity-heatmap";
 import {
   LinkDaemonBanner,
   FirstSyncInProgressBanner,
@@ -71,6 +73,7 @@ export default async function OverviewPage({
     topModels,
     topRepos,
     topUsers,
+    heatmap,
   ] = await Promise.all([
     getOverviewStats(user, range, scope),
     getDailyActivity(user, range, scope),
@@ -85,6 +88,7 @@ export default async function OverviewPage({
     getCostByModel(user, range, scope),
     getCostByRepo(user, range, scope),
     showTopContributor ? getCostByUser(user, range) : Promise.resolve([]),
+    getActivityHeatmap(user, range, tz, scope),
   ]);
 
   // Caption for the headline-card delta (e.g. "vs previous 7d"). For numeric
@@ -241,6 +245,17 @@ export default async function OverviewPage({
           />
         </CardContent>
       </Card>
+
+      {hasSynced && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{`Activity by Day & Hour (${unit === "tokens" ? "Sessions" : "Cost"})`}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ActivityHeatmap data={heatmap} unit={unit} />
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/components/charts/activity-heatmap.tsx
+++ b/src/components/charts/activity-heatmap.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { clsx } from "clsx";
+import { fmtCost, fmtNum } from "@/lib/format";
+import type { Unit } from "@/lib/units";
+
+interface HeatmapDatum {
+  dow: number;
+  hour: number;
+  session_count: number;
+  cost_cents: number;
+}
+
+// Mon-first ordering: developers think in work-week shape (Mon..Fri block,
+// Sat/Sun trailing). Postgres returns DOW as 0=Sun..6=Sat, so we map row
+// index → Postgres dow rather than reordering the data server-side.
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const DAY_ROW_TO_PG_DOW = [1, 2, 3, 4, 5, 6, 0];
+
+export function ActivityHeatmap({
+  data,
+  unit,
+}: {
+  data: HeatmapDatum[];
+  unit: Unit;
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No session activity for this period
+      </div>
+    );
+  }
+
+  // Materialize a 7×24 grid keyed by `${dow}-${hour}`. Empty cells stay zero
+  // — the SQL only emits non-empty buckets, so the client decides the shape.
+  const cells = new Map<string, HeatmapDatum>();
+  for (const d of data) cells.set(`${d.dow}-${d.hour}`, d);
+  const valueOf = (d: HeatmapDatum | undefined): number =>
+    d ? (unit === "tokens" ? d.session_count : d.cost_cents) : 0;
+  // Color is opacity-on-blue scaled by cell value vs the period's max cell.
+  // Without a per-period max the scale would compress every empty week into
+  // a single dim cell as soon as one busy week showed up in history.
+  const maxValue = Math.max(
+    1,
+    ...Array.from(cells.values()).map((d) => valueOf(d))
+  );
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="inline-grid min-w-full gap-y-1" style={{ minWidth: 600 }}>
+        <div className="grid grid-cols-[2.5rem_repeat(24,minmax(0,1fr))] gap-x-1 pl-0">
+          <div />
+          {Array.from({ length: 24 }, (_, h) => (
+            <div
+              key={h}
+              className="text-center text-[10px] text-zinc-500"
+              aria-hidden="true"
+            >
+              {h % 3 === 0 ? h : ""}
+            </div>
+          ))}
+        </div>
+        {DAY_ROW_TO_PG_DOW.map((dow, rowIdx) => (
+          <div
+            key={dow}
+            className="grid grid-cols-[2.5rem_repeat(24,minmax(0,1fr))] gap-x-1"
+          >
+            <div className="flex items-center text-xs text-zinc-500">
+              {DAY_LABELS[rowIdx]}
+            </div>
+            {Array.from({ length: 24 }, (_, hour) => {
+              const cell = cells.get(`${dow}-${hour}`);
+              const value = valueOf(cell);
+              const intensity =
+                value === 0 ? 0 : Math.max(0.08, value / maxValue);
+              const sessions = cell?.session_count ?? 0;
+              const cost = cell?.cost_cents ?? 0;
+              const dayLabel = DAY_LABELS[rowIdx];
+              const hourLabel = `${String(hour).padStart(2, "0")}:00`;
+              const valueLabel =
+                unit === "tokens"
+                  ? `${fmtNum(sessions)} session${sessions === 1 ? "" : "s"}`
+                  : `${fmtCost(cost)} • ${fmtNum(sessions)} session${sessions === 1 ? "" : "s"}`;
+              return (
+                <div
+                  key={hour}
+                  className={clsx(
+                    "aspect-square rounded-sm",
+                    value === 0 && "bg-white/[0.03]"
+                  )}
+                  style={
+                    value > 0
+                      ? { backgroundColor: `rgba(59, 130, 246, ${intensity})` }
+                      : undefined
+                  }
+                  title={`${dayLabel} ${hourLabel} — ${valueLabel}`}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="mt-3 flex items-center gap-2 text-[11px] text-zinc-500">
+        <span>Less</span>
+        {[0, 0.25, 0.5, 0.75, 1].map((step) => (
+          <div
+            key={step}
+            className="h-3 w-3 rounded-sm"
+            style={{
+              backgroundColor:
+                step === 0
+                  ? "rgba(255,255,255,0.06)"
+                  : `rgba(59, 130, 246, ${Math.max(0.08, step)})`,
+            }}
+          />
+        ))}
+        <span>More</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -218,6 +218,44 @@ const RPC_HANDLERS: Record<string, RpcHandler> = {
     }
     return Array.from(byBranch.values());
   },
+  dashboard_activity_heatmap(tables, args) {
+    // Mirrors `dashboard_activity_heatmap` (013_activity_heatmap.sql): bucket
+    // sessions by `(dow, hour)` after applying device + `started_at` filters.
+    // The fake ignores `p_time_zone` and reads dow/hour from the seeded
+    // `started_at` directly — tests that exercise TZ correctness should seed
+    // pre-converted timestamps so the assertion stays focused on aggregation
+    // behavior rather than re-deriving Postgres' `AT TIME ZONE` math here.
+    const deviceIds = new Set(args.p_device_ids as string[]);
+    const from = args.p_started_from as string;
+    const to = args.p_started_to as string;
+    type Cell = {
+      dow: number;
+      hour: number;
+      session_count: number;
+      cost_cents: number;
+    };
+    const cells = new Map<string, Cell>();
+    for (const s of tables.get("session_summaries") ?? []) {
+      const startedAt = s.started_at as string | null | undefined;
+      if (!startedAt) continue;
+      if (!deviceIds.has(s.device_id as string)) continue;
+      if (startedAt < from || startedAt > to) continue;
+      const d = new Date(startedAt);
+      const dow = d.getUTCDay();
+      const hour = d.getUTCHours();
+      const key = `${dow}-${hour}`;
+      const existing = cells.get(key) ?? {
+        dow,
+        hour,
+        session_count: 0,
+        cost_cents: 0,
+      };
+      existing.session_count += 1;
+      existing.cost_cents += Number(s.total_cost_cents ?? 0);
+      cells.set(key, existing);
+    }
+    return Array.from(cells.values());
+  },
   dashboard_cost_by_ticket(tables, args) {
     const rows = rollupsForRange(tables, args);
     const byTicket = new Map<string, number>();

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -179,6 +179,61 @@ interface DailyActivityRow {
 }
 
 /**
+ * Day-of-week × hour-of-day session counts for the Overview heatmap (#150).
+ * Manager sees full org; member sees own devices only (ADR-0083 §6).
+ * `options.scopedUserId` further narrows a manager view to a single teammate.
+ *
+ * Buckets are computed in the **viewer's IANA timezone** (server-side via
+ * `dashboard_activity_heatmap`) so a US/Pacific viewer's "5pm peak" sits at
+ * `hour=17` instead of drifting to UTC's `hour=00`. Falls back to UTC when
+ * the viewer's TZ cookie is missing — same fallback `dateRangeFromDays`
+ * uses, so the bucketing TZ matches the range-window TZ.
+ *
+ * Returns 0..168 rows (one per non-empty `(dow, hour)` cell). Empty cells
+ * are absent from the result; the client fills them with zero rather than
+ * paying for a `generate_series` cross join on every page load.
+ */
+export async function getActivityHeatmap(
+  user: BudiUser,
+  range: DateRange,
+  timeZone: string | null,
+  options?: ScopeOptions
+): Promise<HeatmapCell[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_activity_heatmap", {
+    p_device_ids: deviceIds,
+    p_started_from: range.startedAtFrom,
+    p_started_to: range.startedAtTo,
+    p_time_zone: timeZone ?? "UTC",
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as HeatmapRow[]).map((r) => ({
+    dow: Number(r.dow),
+    hour: Number(r.hour),
+    session_count: Number(r.session_count),
+    cost_cents: Number(r.cost_cents),
+  }));
+}
+
+export interface HeatmapCell {
+  dow: number;
+  hour: number;
+  session_count: number;
+  cost_cents: number;
+}
+
+interface HeatmapRow {
+  dow: number | string;
+  hour: number | string;
+  session_count: number | string;
+  cost_cents: number | string;
+}
+
+/**
  * Earliest day (`YYYY-MM-DD`) with a rollup for any device visible to the
  * viewer, or `null` if the org has never synced anything. Used to materialize
  * the `?days=all` sentinel into a concrete `from` before hitting the

--- a/supabase/migrations/013_activity_heatmap.sql
+++ b/supabase/migrations/013_activity_heatmap.sql
@@ -1,0 +1,51 @@
+-- Day-of-week × hour-of-day activity heatmap for the Overview page (#150).
+--
+-- Counts sessions whose `started_at` falls inside the viewer's local-TZ
+-- window, bucketed by `(dow, hour)` interpreted in the **viewer's IANA
+-- timezone**. The heatmap answers "when does this team actually work" — a
+-- US/Pacific viewer needs to see "5pm peak" at column 17, not at column 0
+-- where the UTC clock would put the same instant.
+--
+-- The grid is fixed-size (7 × 24); empty cells just don't appear in the
+-- result and the client fills them with zero, so we don't need a generate-
+-- series cross join here. Using `started_at` (not the rollup `bucket_day`)
+-- is intentional — only `session_summaries` carries the wall-clock instant
+-- needed to derive an hour-of-day. Sessions with NULL `started_at` are
+-- excluded, which matches what the Sessions page can render (#84) and
+-- keeps the heatmap source consistent with what users see when they drill
+-- in.
+--
+-- Postgres returns `dow` as `0=Sunday..6=Saturday` (per ISO/SQL spec); the
+-- client decides the visual ordering. The visibility scope is enforced
+-- upstream by `getVisibleDeviceIds`; `p_device_ids` is the authoritative
+-- gate, same pattern as every other `dashboard_*` RPC since #92.
+CREATE OR REPLACE FUNCTION public.dashboard_activity_heatmap(
+    p_device_ids     TEXT[],
+    p_started_from   TIMESTAMPTZ,
+    p_started_to     TIMESTAMPTZ,
+    p_time_zone      TEXT
+)
+RETURNS TABLE (
+    dow            INT,
+    hour           INT,
+    session_count  BIGINT,
+    cost_cents     NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        EXTRACT(DOW  FROM started_at AT TIME ZONE p_time_zone)::INT  AS dow,
+        EXTRACT(HOUR FROM started_at AT TIME ZONE p_time_zone)::INT  AS hour,
+        COUNT(*)::BIGINT                                              AS session_count,
+        COALESCE(SUM(total_cost_cents), 0)                            AS cost_cents
+    FROM session_summaries
+    WHERE device_id = ANY(p_device_ids)
+      AND started_at IS NOT NULL
+      AND started_at >= p_started_from
+      AND started_at <= p_started_to
+    GROUP BY 1, 2
+    ORDER BY 1, 2;
+$$;


### PR DESCRIPTION
## Summary

- Closes the third (and final) slice of #150 — the DOW × hour activity heatmap on `/dashboard`.
- Adds `dashboard_activity_heatmap` RPC (`013_activity_heatmap.sql`) bucketing `session_summaries.started_at` by `(dow, hour)` in the viewer's IANA timezone, so a US/Pacific viewer's "5pm peak" lands at column 17 instead of drifting to UTC's column 0. Returns sparse rows; the client materializes the 7×24 grid and scales cell opacity against the period's max so a single quiet week doesn't flatten the legend.
- Mon-first row order to match how developers read a work week. Empty-state copy follows the existing chart patterns and the heatmap is gated behind `hasSynced`, so it doesn't render before first sync (per the issue's empty-state note).

## Test plan

- [x] `npx vitest run` — 203 passing (added fake RPC handler + `getActivityHeatmap` mock)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on touched files
- [x] `npx next build` clean
- [ ] Manual: load `/dashboard` on Pacific time, confirm peak hour matches local wall clock; flip Units toggle and confirm cell coloring switches between session count and cost; confirm empty-state copy when range has no sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)