### PR TITLE
fix(repos): truncate long branch and project names in Cost-by-Branch table

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -231,8 +231,22 @@ export default async function ReposPage({
                   <tbody>
                     {branchRows.map((b, i) => (
                       <tr key={i} className="border-b border-white/5">
-                        <td className="py-2 text-zinc-200">{b.project}</td>
-                        <td className="py-2 text-zinc-200">{b.branch}</td>
+                        <td className="py-2 text-zinc-200">
+                          <div
+                            className="max-w-[14rem] truncate"
+                            title={b.project}
+                          >
+                            {b.project}
+                          </div>
+                        </td>
+                        <td className="py-2 text-zinc-200">
+                          <div
+                            className="max-w-[18rem] truncate"
+                            title={b.branch}
+                          >
+                            {b.branch}
+                          </div>
+                        </td>
                         <td className="py-2 text-right tabular-nums text-zinc-400">
                           {fmtNum(b.input_tokens)}
                         </td>
@@ -252,11 +266,14 @@ export default async function ReposPage({
                 <ul className="divide-y divide-white/5 text-sm sm:hidden">
                   {branchRows.map((b, i) => (
                     <li key={i} className="flex flex-col gap-1 py-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-zinc-200">
+                      <div className="flex items-center justify-between gap-3">
+                        <span
+                          className="min-w-0 flex-1 truncate text-zinc-200"
+                          title={`${b.project} / ${b.branch}`}
+                        >
                           {b.project} / {b.branch}
                         </span>
-                        <span className="tabular-nums text-zinc-300">
+                        <span className="shrink-0 tabular-nums text-zinc-300">
                           {fmtValue(
                             b.cost_cents,
                             b.input_tokens + b.output_tokens


### PR DESCRIPTION
## Summary

- On `/dashboard/repos`, long branch names (e.g. ticket-derived branches like `feat/very-long-descriptive-branch-name-…`) pushed the Cost-by-Branch table wider than its card and shoved the right-aligned numeric columns off-screen.
- Cap the Project and Branch cells at fixed max-widths (`14rem` / `18rem`) with `truncate`; full string available on hover via `title`.
- Mirror the fix on the mobile list (`flex-1 min-w-0 truncate` on the label, `shrink-0` on the cost) so the cost stays anchored to the right edge.

## Test plan

- [x] `npx vitest run src/app/dashboard/repos` — 6 passing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/app/dashboard/repos/page.tsx` clean
- [ ] Manual: load `/dashboard/repos` with a branch like `feat/very-long-descriptive-branch-name`, confirm row width stays inside the card on desktop and mobile, hover shows the full name

🤖 Generated with [Claude Code](https://claude.com/claude-code)