### PR TITLE
fix(overview): make Activity by Day & Hour heatmap fill full width

### DIFF
--- a/src/components/charts/activity-heatmap.tsx
+++ b/src/components/charts/activity-heatmap.tsx
@@ -48,7 +48,7 @@ export function ActivityHeatmap({
 
   return (
     <div className="overflow-x-auto">
-      <div className="inline-grid min-w-full gap-y-1" style={{ minWidth: 600 }}>
+      <div className="grid w-full gap-y-1" style={{ minWidth: 600 }}>
         <div className="grid grid-cols-[2.5rem_repeat(24,minmax(0,1fr))] gap-x-1 pl-0">
           <div />
           {Array.from({ length: 24 }, (_, h) => (


### PR DESCRIPTION
## Summary
- The heatmap wrapper used `inline-grid`, which shrink-wraps to content width and left a gap on the right of the card.
- Swapped to block-level `grid w-full` so the 24 hour columns (each `1fr`) fan out across the full card width.
- Kept the 600px min-width fallback + `overflow-x-auto` so narrow viewports still get a horizontal scroller.

## Test plan
- [ ] `/dashboard` heatmap card spans the full Card width on desktop
- [ ] Below ~600px viewport, the heatmap scrolls horizontally inside the card
- [ ] Empty-state and tooltip behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)