### PR TITLE
fix(overview): drop previous-period overlay toggle from Daily Activity

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -69,7 +69,6 @@ export default async function OverviewPage({
     freshness,
     members,
     previousStats,
-    previousActivity,
     topModels,
     topRepos,
     topUsers,
@@ -82,9 +81,6 @@ export default async function OverviewPage({
     previousRange
       ? getOverviewStats(user, previousRange, scope)
       : Promise.resolve(null),
-    previousRange
-      ? getDailyActivity(user, previousRange, scope)
-      : Promise.resolve([]),
     getCostByModel(user, range, scope),
     getCostByRepo(user, range, scope),
     showTopContributor ? getCostByUser(user, range) : Promise.resolve([]),
@@ -238,11 +234,7 @@ export default async function OverviewPage({
           <CardTitle>{`Daily Activity (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
         </CardHeader>
         <CardContent>
-          <ActivityChart
-            data={activity}
-            previousData={previousActivity}
-            unit={unit}
-          />
+          <ActivityChart data={activity} unit={unit} />
         </CardContent>
       </Card>
 

--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { useState } from "react";
 import {
   Bar,
+  BarChart,
   CartesianGrid,
-  ComposedChart,
-  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -60,56 +58,13 @@ function rebucket(data: ActivityData[]): ActivityData[] {
   );
 }
 
-interface ChartRow extends ActivityData {
-  /** Previous-period token total at the same offset, when overlay is on. */
-  previous_tokens?: number;
-  /** Previous-period cost at the same offset, when overlay is on. */
-  previous_cost_cents?: number;
-  /** Bucket day from the previous-period series, for the tooltip label. */
-  previous_bucket_day?: string;
-}
-
-/**
- * Align previous-period rows to current-period rows by index. The two windows
- * are constructed to be the same length, so position N in `previous` maps to
- * position N in `current` — the overlay reads as "what we did last week, on
- * the same day-of-week". Length mismatches (e.g. brand-new orgs whose first
- * sync started mid-window) just truncate to whichever is shorter.
- */
-function withPreviousOverlay(
-  current: ActivityData[],
-  previous: ActivityData[],
-  unit: Unit
-): ChartRow[] {
-  return current.map((row, i) => {
-    const prev = previous[i];
-    if (!prev) return row;
-    return {
-      ...row,
-      previous_tokens:
-        unit === "tokens" ? prev.input_tokens + prev.output_tokens : undefined,
-      previous_cost_cents: unit === "tokens" ? undefined : prev.cost_cents,
-      previous_bucket_day: prev.bucket_day,
-    };
-  });
-}
-
 export function ActivityChart({
   data,
-  previousData = [],
   unit = "tokens",
 }: {
   data: ActivityData[];
-  /**
-   * Optional same-length series from the period immediately preceding `data`,
-   * rendered as a ghosted line overlay when the viewer toggles it on (#150).
-   * Off by default so the default page render stays uncluttered.
-   */
-  previousData?: ActivityData[];
   unit?: Unit;
 }) {
-  const [showPrevious, setShowPrevious] = useState(false);
-
   if (data.length === 0) {
     return (
       <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
@@ -119,138 +74,91 @@ export function ActivityChart({
   }
 
   const bucketed = rebucket(data);
-  const bucketedPrevious = rebucket(previousData);
   const isTokens = unit === "tokens";
   const fmt = isTokens ? fmtNum : fmtCost;
   const yAxisLabel = isTokens ? "Tokens" : "Cost";
-  const hasPrevious = bucketedPrevious.length > 0;
-  const rows: ChartRow[] = hasPrevious
-    ? withPreviousOverlay(bucketed, bucketedPrevious, unit)
-    : bucketed;
 
   return (
-    <div>
-      {hasPrevious && (
-        <div className="mb-2 flex justify-end">
-          <label className="flex items-center gap-2 text-xs text-zinc-400">
-            <input
-              type="checkbox"
-              className="h-3 w-3 cursor-pointer accent-zinc-500"
-              checked={showPrevious}
-              onChange={(e) => setShowPrevious(e.target.checked)}
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={bucketed}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => fmt(Number(v))}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={72}
+          label={{
+            value: yAxisLabel,
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(label) => fmtFullDate(String(label))}
+          formatter={(value, name) => {
+            const key = String(name);
+            const seriesLabel = isTokens
+              ? key === "input_tokens"
+                ? "Input"
+                : "Output"
+              : "Cost";
+            return [fmt(Number(value)), seriesLabel];
+          }}
+        />
+        {isTokens ? (
+          <>
+            <Bar
+              dataKey="input_tokens"
+              stackId="value"
+              fill="#3b82f6"
+              maxBarSize={28}
+              radius={[0, 0, 0, 0]}
+              isAnimationActive={false}
             />
-            Compare to previous period
-          </label>
-        </div>
-      )}
-      <ResponsiveContainer width="100%" height={300}>
-        <ComposedChart
-          data={rows}
-          margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
-        >
-          <CartesianGrid
-            strokeDasharray="3 3"
-            stroke="rgba(255,255,255,0.06)"
-            vertical={false}
+            <Bar
+              dataKey="output_tokens"
+              stackId="value"
+              fill="#8b5cf6"
+              maxBarSize={28}
+              radius={[4, 4, 0, 0]}
+              isAnimationActive={false}
+            />
+          </>
+        ) : (
+          <Bar
+            dataKey="cost_cents"
+            fill="#3b82f6"
+            maxBarSize={28}
+            radius={[4, 4, 0, 0]}
+            isAnimationActive={false}
           />
-          <XAxis
-            dataKey="bucket_day"
-            tickFormatter={fmtDate}
-            tick={{ fill: "#71717a", fontSize: 12 }}
-            tickLine={false}
-            axisLine={false}
-          />
-          <YAxis
-            tickFormatter={(v) => fmt(Number(v))}
-            tick={{ fill: "#71717a", fontSize: 12 }}
-            tickLine={false}
-            axisLine={false}
-            width={72}
-            label={{
-              value: yAxisLabel,
-              angle: -90,
-              position: "insideLeft",
-              offset: 0,
-              dx: -8,
-              style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
-            }}
-          />
-          <Tooltip
-            cursor={{ fill: "rgba(255,255,255,0.05)" }}
-            contentStyle={{
-              background: "#18181b",
-              border: "1px solid rgba(255,255,255,0.1)",
-              borderRadius: "8px",
-              fontSize: "13px",
-            }}
-            labelFormatter={(label) => fmtFullDate(String(label))}
-            formatter={(value, name) => {
-              const key = String(name);
-              if (key === "previous_tokens" || key === "previous_cost_cents") {
-                return [fmt(Number(value)), "Previous period"];
-              }
-              const seriesLabel = isTokens
-                ? key === "input_tokens"
-                  ? "Input"
-                  : "Output"
-                : "Cost";
-              return [fmt(Number(value)), seriesLabel];
-            }}
-          />
-          {isTokens ? (
-            <>
-              <Bar
-                dataKey="input_tokens"
-                stackId="value"
-                fill="#3b82f6"
-                maxBarSize={28}
-                radius={[0, 0, 0, 0]}
-                isAnimationActive={false}
-              />
-              <Bar
-                dataKey="output_tokens"
-                stackId="value"
-                fill="#8b5cf6"
-                maxBarSize={28}
-                radius={[4, 4, 0, 0]}
-                isAnimationActive={false}
-              />
-              {showPrevious && hasPrevious && (
-                <Line
-                  type="monotone"
-                  dataKey="previous_tokens"
-                  stroke="rgba(255,255,255,0.45)"
-                  strokeDasharray="4 4"
-                  strokeWidth={1.5}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-            </>
-          ) : (
-            <>
-              <Bar
-                dataKey="cost_cents"
-                fill="#3b82f6"
-                maxBarSize={28}
-                radius={[4, 4, 0, 0]}
-                isAnimationActive={false}
-              />
-              {showPrevious && hasPrevious && (
-                <Line
-                  type="monotone"
-                  dataKey="previous_cost_cents"
-                  stroke="rgba(255,255,255,0.45)"
-                  strokeDasharray="4 4"
-                  strokeWidth={1.5}
-                  dot={false}
-                  isAnimationActive={false}
-                />
-              )}
-            </>
-          )}
-        </ComposedChart>
-      </ResponsiveContainer>
-    </div>
+        )}
+      </BarChart>
+    </ResponsiveContainer>
   );
 }


### PR DESCRIPTION
## Summary
- Removes the **\"Compare to previous period\"** checkbox + ghosted overlay line from the Daily Activity chart on `/dashboard`.
- The headline stat cards already surface a clear, color-coded **\"vs previous Nd\"** delta on Total Cost / Tokens / Messages / Sessions, so the chart overlay was redundant signal at the cost of an unexplained control inside the chart card.
- Drops the `previousData` prop on `ActivityChart` and the `previousActivity` fetch on the page. `previousStats` is kept — headline-card deltas are unchanged.

## Test plan
- [ ] `/dashboard` Daily Activity chart no longer shows the toggle
- [ ] Bars still render correctly in both `tokens` and `cost` units
- [ ] Stat cards still show \"+X% vs previous 7d\" deltas
- [ ] Lifetime preset (`?days=all`) still renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)