### PR TITLE
fix(repos): companion tables mirror their chart's row count and order

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -15,7 +15,10 @@ import { fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
-import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import {
+  CostBarChart,
+  COST_BAR_CHART_MAX_ITEMS,
+} from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function ReposPage({
@@ -71,20 +74,38 @@ export default async function ReposPage({
       });
     }
   }
+  // Pick the same metric the chart sorts on so the table mirrors the chart's
+  // order regardless of the active unit toggle.
+  const sortValue = (r: {
+    cost_cents: number;
+    input_tokens: number;
+    output_tokens: number;
+  }) => (isTokens ? r.input_tokens + r.output_tokens : r.cost_cents);
+
   const repoRows = Array.from(repoBuckets, ([label, totals]) => ({
     label,
     cost_cents: totals.cost_cents,
     input_tokens: totals.input_tokens,
     output_tokens: totals.output_tokens,
-  })).sort((a, b) => b.cost_cents - a.cost_cents);
+  }))
+    .sort((a, b) => sortValue(b) - sortValue(a))
+    .slice(0, COST_BAR_CHART_MAX_ITEMS);
 
-  const branchRows = branches.map((b) => ({
-    project: repoName(b.repo_id),
-    branch: b.git_branch.replace(/^refs\/heads\//, ""),
-    cost_cents: b.cost_cents,
-    input_tokens: b.input_tokens,
-    output_tokens: b.output_tokens,
-  }));
+  const branchRows = branches
+    .map((b) => ({
+      project: repoName(b.repo_id),
+      branch: b.git_branch.replace(/^refs\/heads\//, ""),
+      cost_cents: b.cost_cents,
+      input_tokens: b.input_tokens,
+      output_tokens: b.output_tokens,
+    }))
+    .sort((a, b) => sortValue(b) - sortValue(a))
+    .slice(0, COST_BAR_CHART_MAX_ITEMS);
+
+  const ticketRows = tickets
+    .slice()
+    .sort((a, b) => sortValue(b) - sortValue(a))
+    .slice(0, COST_BAR_CHART_MAX_ITEMS);
 
   return (
     <div className="space-y-6">
@@ -298,7 +319,7 @@ export default async function ReposPage({
           <CardTitle>{`${valueWord} by Ticket`}</CardTitle>
         </CardHeader>
         <CardContent>
-          {tickets.length === 0 ? (
+          {ticketRows.length === 0 ? (
             <CostBarChart
               data={[]}
               emptyLabel="No ticket data for this period"
@@ -307,7 +328,7 @@ export default async function ReposPage({
           ) : (
             <div className="grid gap-6 sm:grid-cols-2">
               <CostBarChart
-                data={tickets.map((t) => ({
+                data={ticketRows.map((t) => ({
                   label: t.ticket,
                   cost_cents: t.cost_cents,
                   tokens: t.input_tokens + t.output_tokens,
@@ -328,7 +349,7 @@ export default async function ReposPage({
                     </tr>
                   </thead>
                   <tbody>
-                    {tickets.map((t, i) => (
+                    {ticketRows.map((t, i) => (
                       <tr key={i} className="border-b border-white/5">
                         <td className="py-2 text-zinc-200">{t.ticket}</td>
                         <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
@@ -348,7 +369,7 @@ export default async function ReposPage({
                   </tbody>
                 </table>
                 <ul className="divide-y divide-white/5 text-sm sm:hidden">
-                  {tickets.map((t, i) => (
+                  {ticketRows.map((t, i) => (
                     <li key={i} className="flex flex-col gap-1 py-2">
                       <div className="flex items-center justify-between">
                         <span className="text-zinc-200">{t.ticket}</span>

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -19,7 +19,10 @@ interface CostBarDatum {
   tokens: number;
 }
 
-const MAX_ITEMS = 10;
+/** Cap on rows the bar chart will render. Exported so companion tables on the
+ * Repos page can apply the same cap and stay in lockstep with the chart. */
+export const COST_BAR_CHART_MAX_ITEMS = 10;
+const MAX_ITEMS = COST_BAR_CHART_MAX_ITEMS;
 const BAR_SIZE = 28;
 const BAR_GAP = 8;
 


### PR DESCRIPTION
## Summary
- Each Repos card pairs a horizontal bar chart with a companion table. The chart caps at 10 rows sorted by the active unit's value (`tokens` or `cost_cents`), but the tables ran on the unsorted/uncapped DAL output — so a 50-branch period showed 10 bars and 50 table rows, in different orders.
- Exported `COST_BAR_CHART_MAX_ITEMS = 10` from the chart so the cap has a single source of truth.
- On the page, sort each row collection (Project, Branch, Ticket) by the active unit's value and slice to the same cap before feeding it into both the chart and the table.

## Test plan
- [ ] `/dashboard/repos` Project / Branch / Ticket tables show **the same rows in the same order** as their charts
- [ ] Toggling units between **Cost** and **Tokens** re-orders both chart and table identically
- [ ] When fewer than 10 rows exist, no padding rows appear
- [ ] Empty state still renders the empty `CostBarChart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)