### PR TITLE
feat(overview): GitHub-style calendar heatmap for >7d periods

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -63,6 +63,13 @@ export default async function OverviewPage({
   // a `?user=` filter the rest of the page already narrows to one teammate, so
   // a "leader" card showing that same teammate at 100% would be noise.
   const showTopContributor = user.role === "manager" && !scopedUserId;
+  // Pick heatmap shape by period: hourly (DOW × hour) for short windows where
+  // time-of-day is the interesting signal; GitHub-style calendar (DOW × week)
+  // for 30d / lifetime where "which calendar days were active" is what the
+  // viewer actually wants. Default `?days` is 7d, so missing → hourly.
+  const heatmapMode: "hourly" | "calendar" = isHourlyHeatmapPeriod(params.days)
+    ? "hourly"
+    : "calendar";
   const [
     stats,
     activity,
@@ -84,7 +91,9 @@ export default async function OverviewPage({
     getCostByModel(user, range, scope),
     getCostByRepo(user, range, scope),
     showTopContributor ? getCostByUser(user, range) : Promise.resolve([]),
-    getActivityHeatmap(user, range, tz, scope),
+    heatmapMode === "hourly"
+      ? getActivityHeatmap(user, range, tz, scope)
+      : Promise.resolve([]),
   ]);
 
   // Caption for the headline-card delta (e.g. "vs previous 7d"). For numeric
@@ -241,15 +250,40 @@ export default async function OverviewPage({
       {hasSynced && (
         <Card>
           <CardHeader>
-            <CardTitle>{`Activity by Day & Hour (${unit === "tokens" ? "Sessions" : "Cost"})`}</CardTitle>
+            <CardTitle>{heatmapTitle(heatmapMode, unit)}</CardTitle>
           </CardHeader>
           <CardContent>
-            <ActivityHeatmap data={heatmap} unit={unit} />
+            {heatmapMode === "hourly" ? (
+              <ActivityHeatmap mode="hourly" data={heatmap} unit={unit} />
+            ) : (
+              <ActivityHeatmap
+                mode="calendar"
+                data={activity}
+                range={{ from: range.from, to: range.to }}
+                unit={unit}
+              />
+            )}
           </CardContent>
         </Card>
       )}
     </div>
   );
+}
+
+function isHourlyHeatmapPeriod(days: string | undefined): boolean {
+  // Default window is 7d (matches `dateRangeFromDays`), so an absent `days`
+  // param is hourly. Anything beyond 7 days switches to the calendar view.
+  if (days === undefined || days === "" || days === "1" || days === "7") {
+    return true;
+  }
+  return false;
+}
+
+function heatmapTitle(mode: "hourly" | "calendar", unit: Unit): string {
+  if (mode === "hourly") {
+    return `Activity by Day & Hour (${unit === "tokens" ? "Sessions" : "Cost"})`;
+  }
+  return `Activity Calendar (${unit === "tokens" ? "Tokens" : "Cost"})`;
 }
 
 function sparkValues(

--- a/src/components/charts/activity-heatmap.tsx
+++ b/src/components/charts/activity-heatmap.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { clsx } from "clsx";
+import { addDays, differenceInDays, format, startOfWeek } from "date-fns";
 import { fmtCost, fmtNum } from "@/lib/format";
 import type { Unit } from "@/lib/units";
 
-interface HeatmapDatum {
+interface HourlyDatum {
   dow: number;
   hour: number;
   session_count: number;
   cost_cents: number;
+}
+
+interface DailyDatum {
+  bucket_day: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_cents: number;
+  message_count: number;
 }
 
 // Mon-first ordering: developers think in work-week shape (Mon..Fri block,
@@ -16,18 +25,39 @@ interface HeatmapDatum {
 // index → Postgres dow rather than reordering the data server-side.
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const DAY_ROW_TO_PG_DOW = [1, 2, 3, 4, 5, 6, 0];
+const WEEK_STARTS_ON = 1;
 
 // Match the Daily Activity chart's `ResponsiveContainer height={300}` so the
 // two cards on the Overview line up vertically (#150).
 const HEATMAP_HEIGHT = 300;
 
-export function ActivityHeatmap({
-  data,
-  unit,
-}: {
-  data: HeatmapDatum[];
-  unit: Unit;
-}) {
+type Props =
+  | {
+      mode: "hourly";
+      data: HourlyDatum[];
+      unit: Unit;
+    }
+  | {
+      mode: "calendar";
+      data: DailyDatum[];
+      /** Inclusive ISO date strings (`YYYY-MM-DD`) defining the period. */
+      range: { from: string; to: string };
+      unit: Unit;
+    };
+
+export function ActivityHeatmap(props: Props) {
+  return props.mode === "hourly" ? (
+    <HourlyHeatmap {...props} />
+  ) : (
+    <CalendarHeatmap {...props} />
+  );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Hourly view: 7 (DOW) × 24 (hour) — answers "what hours of the day are busy".
+// ────────────────────────────────────────────────────────────────────────────
+
+function HourlyHeatmap({ data, unit }: { data: HourlyDatum[]; unit: Unit }) {
   if (data.length === 0) {
     return (
       <div
@@ -41,9 +71,9 @@ export function ActivityHeatmap({
 
   // Materialize a 7×24 grid keyed by `${dow}-${hour}`. Empty cells stay zero
   // — the SQL only emits non-empty buckets, so the client decides the shape.
-  const cells = new Map<string, HeatmapDatum>();
+  const cells = new Map<string, HourlyDatum>();
   for (const d of data) cells.set(`${d.dow}-${d.hour}`, d);
-  const valueOf = (d: HeatmapDatum | undefined): number =>
+  const valueOf = (d: HourlyDatum | undefined): number =>
     d ? (unit === "tokens" ? d.session_count : d.cost_cents) : 0;
   // Color is opacity-on-blue scaled by cell value vs the period's max cell.
   // Without a per-period max the scale would compress every empty week into
@@ -114,23 +144,182 @@ export function ActivityHeatmap({
             </div>
           ))}
         </div>
-        <div className="mt-3 flex flex-none items-center gap-2 text-[11px] text-zinc-500">
-          <span>Less</span>
-          {[0, 0.25, 0.5, 0.75, 1].map((step) => (
-            <div
-              key={step}
-              className="h-3 w-3 rounded-sm"
-              style={{
-                backgroundColor:
-                  step === 0
-                    ? "rgba(255,255,255,0.06)"
-                    : `rgba(59, 130, 246, ${Math.max(0.08, step)})`,
-              }}
-            />
-          ))}
-          <span>More</span>
-        </div>
+        <Legend />
       </div>
     </div>
   );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Calendar view: 7 (DOW) × N (weeks) — GitHub-style contributions graph.
+// Used for windows >7 days where time-of-day signal is too noisy and the
+// user wants "which calendar days were active" instead.
+// ────────────────────────────────────────────────────────────────────────────
+
+function CalendarHeatmap({
+  data,
+  range,
+  unit,
+}: {
+  data: DailyDatum[];
+  range: { from: string; to: string };
+  unit: Unit;
+}) {
+  const fromDate = parseISODate(range.from);
+  const toDate = parseISODate(range.to);
+  if (!fromDate || !toDate || differenceInDays(toDate, fromDate) < 0) {
+    return (
+      <div
+        className="flex items-center justify-center text-sm text-zinc-500"
+        style={{ height: HEATMAP_HEIGHT }}
+      >
+        No activity for this period
+      </div>
+    );
+  }
+
+  const byDay = new Map<string, DailyDatum>();
+  for (const d of data) byDay.set(d.bucket_day, d);
+
+  const valueOf = (d: DailyDatum | undefined): number => {
+    if (!d) return 0;
+    return unit === "tokens" ? d.input_tokens + d.output_tokens : d.cost_cents;
+  };
+  const maxValue = Math.max(1, ...data.map((d) => valueOf(d)));
+
+  // Pad the visible range out to the nearest week boundary on each side so the
+  // grid is always a clean 7-row block. Out-of-range days render blank.
+  const gridStart = startOfWeek(fromDate, { weekStartsOn: WEEK_STARTS_ON });
+  const totalDays = differenceInDays(toDate, gridStart) + 1;
+  const weekCount = Math.max(1, Math.ceil(totalDays / 7));
+
+  const weeks: Array<Array<{ date: Date; key: string; inRange: boolean }>> = [];
+  for (let w = 0; w < weekCount; w++) {
+    const col: Array<{ date: Date; key: string; inRange: boolean }> = [];
+    for (let r = 0; r < 7; r++) {
+      const date = addDays(gridStart, w * 7 + r);
+      const key = format(date, "yyyy-MM-dd");
+      const inRange = date >= fromDate && date <= toDate;
+      col.push({ date, key, inRange });
+    }
+    weeks.push(col);
+  }
+
+  // Emit a month label when a week's first day kicks off a new month — keeps
+  // the header sparse so labels don't crash into each other on narrow cards.
+  const monthLabels: Array<string | null> = weeks.map((col, i) => {
+    const firstDay = col[0].date;
+    if (i === 0) return format(firstDay, "MMM");
+    if (firstDay.getDate() <= 7) return format(firstDay, "MMM");
+    return null;
+  });
+
+  const isTokens = unit === "tokens";
+  const fmt = isTokens ? fmtNum : fmtCost;
+
+  // Inline grid template since `weekCount` is dynamic and Tailwind's JIT
+  // can't pre-compute every possible value at build time.
+  const gridTemplate = `2.5rem repeat(${weekCount}, minmax(0, 1fr))`;
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="flex flex-col"
+        style={{ minWidth: 600, height: HEATMAP_HEIGHT }}
+      >
+        <div
+          className="grid flex-none gap-x-1"
+          style={{ gridTemplateColumns: gridTemplate }}
+        >
+          <div />
+          {monthLabels.map((label, i) => (
+            <div
+              key={i}
+              className="text-center text-[10px] text-zinc-500"
+              aria-hidden="true"
+            >
+              {label ?? ""}
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-1 flex flex-1 flex-col gap-y-1">
+          {DAY_ROW_TO_PG_DOW.map((_dow, rowIdx) => (
+            <div
+              key={rowIdx}
+              className="grid flex-1 gap-x-1"
+              style={{ gridTemplateColumns: gridTemplate }}
+            >
+              <div className="flex items-center text-xs text-zinc-500">
+                {/* Show every other label (Mon/Wed/Fri/Sun) so rows don't
+                    crowd when the cell height shrinks — same trick GitHub
+                    uses on its contribution graph. */}
+                {rowIdx % 2 === 0 ? DAY_LABELS[rowIdx] : ""}
+              </div>
+              {weeks.map((col, weekIdx) => {
+                const cell = col[rowIdx];
+                if (!cell.inRange) {
+                  return <div key={weekIdx} className="h-full rounded-sm" />;
+                }
+                const datum = byDay.get(cell.key);
+                const value = valueOf(datum);
+                const intensity =
+                  value === 0 ? 0 : Math.max(0.08, value / maxValue);
+                const dayLabel = format(cell.date, "EEE, MMM d");
+                const valueLabel =
+                  datum && value > 0 ? fmt(value) : "no activity";
+                return (
+                  <div
+                    key={weekIdx}
+                    className={clsx(
+                      "h-full rounded-sm",
+                      value === 0 && "bg-white/[0.03]"
+                    )}
+                    style={
+                      value > 0
+                        ? {
+                            backgroundColor: `rgba(59, 130, 246, ${intensity})`,
+                          }
+                        : undefined
+                    }
+                    title={`${dayLabel} — ${valueLabel}`}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <Legend />
+      </div>
+    </div>
+  );
+}
+
+function Legend() {
+  return (
+    <div className="mt-3 flex flex-none items-center gap-2 text-[11px] text-zinc-500">
+      <span>Less</span>
+      {[0, 0.25, 0.5, 0.75, 1].map((step) => (
+        <div
+          key={step}
+          className="h-3 w-3 rounded-sm"
+          style={{
+            backgroundColor:
+              step === 0
+                ? "rgba(255,255,255,0.06)"
+                : `rgba(59, 130, 246, ${Math.max(0.08, step)})`,
+          }}
+        />
+      ))}
+      <span>More</span>
+    </div>
+  );
+}
+
+/** ISO `YYYY-MM-DD` → local Date. Returns `null` for invalid input. */
+function parseISODate(s: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return null;
+  const d = new Date(s + "T00:00:00");
+  return isNaN(d.getTime()) ? null : d;
 }


### PR DESCRIPTION
## Summary
- For 30d / lifetime windows the **DOW × hour** heatmap is too noisy — what viewers actually want is *\"which calendar days were active\"*. Switch those windows to a **GitHub-style DOW × week calendar**.
- Short windows (1d / 7d) stay on the hourly heatmap because *\"what hours do we work\"* is still the useful signal there.
- `ActivityHeatmap` is now a discriminated union — `mode: \"hourly\"` keeps the existing 7×24 input; `mode: \"calendar\"` takes a per-day series and a date range and lays out 7 rows × N week columns.
- The calendar reuses `getDailyActivity` data already fetched on the page, so calendar mode skips the `dashboard_activity_heatmap` RPC entirely.
- Card title flips between **\"Activity by Day & Hour\"** and **\"Activity Calendar\"** so the legend matches what the viewer is seeing.

## Test plan
- [ ] `/dashboard?days=7` (default) — hourly heatmap renders unchanged
- [ ] `/dashboard?days=30` — calendar heatmap with ~5 week columns, Mon-first row order, blank cells outside range
- [ ] `/dashboard?days=all` — calendar fills with up to ~13 week columns (90d retention cap)
- [ ] Toggle Tokens vs Cost — calendar intensities recompute against the active unit
- [ ] Empty-state copy renders at the same fixed height as the chart
- [ ] Below 600px viewport still scrolls horizontally inside the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)