### PR TITLE
Revert "fix(repos): companion tables mirror their chart's row count and order"

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -15,10 +15,7 @@ import { fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
-import {
-  CostBarChart,
-  COST_BAR_CHART_MAX_ITEMS,
-} from "@/components/charts/cost-bar-chart";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function ReposPage({
@@ -74,38 +71,20 @@ export default async function ReposPage({
       });
     }
   }
-  // Pick the same metric the chart sorts on so the table mirrors the chart's
-  // order regardless of the active unit toggle.
-  const sortValue = (r: {
-    cost_cents: number;
-    input_tokens: number;
-    output_tokens: number;
-  }) => (isTokens ? r.input_tokens + r.output_tokens : r.cost_cents);
-
   const repoRows = Array.from(repoBuckets, ([label, totals]) => ({
     label,
     cost_cents: totals.cost_cents,
     input_tokens: totals.input_tokens,
     output_tokens: totals.output_tokens,
-  }))
-    .sort((a, b) => sortValue(b) - sortValue(a))
-    .slice(0, COST_BAR_CHART_MAX_ITEMS);
+  })).sort((a, b) => b.cost_cents - a.cost_cents);
 
-  const branchRows = branches
-    .map((b) => ({
-      project: repoName(b.repo_id),
-      branch: b.git_branch.replace(/^refs\/heads\//, ""),
-      cost_cents: b.cost_cents,
-      input_tokens: b.input_tokens,
-      output_tokens: b.output_tokens,
-    }))
-    .sort((a, b) => sortValue(b) - sortValue(a))
-    .slice(0, COST_BAR_CHART_MAX_ITEMS);
-
-  const ticketRows = tickets
-    .slice()
-    .sort((a, b) => sortValue(b) - sortValue(a))
-    .slice(0, COST_BAR_CHART_MAX_ITEMS);
+  const branchRows = branches.map((b) => ({
+    project: repoName(b.repo_id),
+    branch: b.git_branch.replace(/^refs\/heads\//, ""),
+    cost_cents: b.cost_cents,
+    input_tokens: b.input_tokens,
+    output_tokens: b.output_tokens,
+  }));
 
   return (
     <div className="space-y-6">
@@ -319,7 +298,7 @@ export default async function ReposPage({
           <CardTitle>{`${valueWord} by Ticket`}</CardTitle>
         </CardHeader>
         <CardContent>
-          {ticketRows.length === 0 ? (
+          {tickets.length === 0 ? (
             <CostBarChart
               data={[]}
               emptyLabel="No ticket data for this period"
@@ -328,7 +307,7 @@ export default async function ReposPage({
           ) : (
             <div className="grid gap-6 sm:grid-cols-2">
               <CostBarChart
-                data={ticketRows.map((t) => ({
+                data={tickets.map((t) => ({
                   label: t.ticket,
                   cost_cents: t.cost_cents,
                   tokens: t.input_tokens + t.output_tokens,
@@ -349,7 +328,7 @@ export default async function ReposPage({
                     </tr>
                   </thead>
                   <tbody>
-                    {ticketRows.map((t, i) => (
+                    {tickets.map((t, i) => (
                       <tr key={i} className="border-b border-white/5">
                         <td className="py-2 text-zinc-200">{t.ticket}</td>
                         <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
@@ -369,7 +348,7 @@ export default async function ReposPage({
                   </tbody>
                 </table>
                 <ul className="divide-y divide-white/5 text-sm sm:hidden">
-                  {ticketRows.map((t, i) => (
+                  {tickets.map((t, i) => (
                     <li key={i} className="flex flex-col gap-1 py-2">
                       <div className="flex items-center justify-between">
                         <span className="text-zinc-200">{t.ticket}</span>

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -19,10 +19,7 @@ interface CostBarDatum {
   tokens: number;
 }
 
-/** Cap on rows the bar chart will render. Exported so companion tables on the
- * Repos page can apply the same cap and stay in lockstep with the chart. */
-export const COST_BAR_CHART_MAX_ITEMS = 10;
-const MAX_ITEMS = COST_BAR_CHART_MAX_ITEMS;
+const MAX_ITEMS = 10;
 const BAR_SIZE = 28;
 const BAR_GAP = 8;
 


### PR DESCRIPTION
## Summary
- Reverts #163 because the live Repos page is showing empty state for all three sections (\"No project / branch / ticket data for this period\") even though Team and Models render correctly with the same date range and auth.
- The diff in #163 only adds sort+slice on already-fetched arrays — it does not change data fetching — so reverting is unlikely to be the actual fix, but it restores the page to its known-working pre-#163 state while we investigate the data side.
- Follow-up to investigate: production `dashboard_cost_by_repo` / `_by_branch` / `_by_ticket` RPCs returning empty for an org that has rollups (visible on Models / Team).

## Test plan
- [ ] After deploy, `/dashboard/repos` shows project / branch / ticket data again

🤖 Generated with [Claude Code](https://claude.com/claude-code)