### PR TITLE
fix(repos): import row cap from server-safe module

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -15,10 +15,8 @@ import { fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
-import {
-  CostBarChart,
-  COST_BAR_CHART_MAX_ITEMS,
-} from "@/components/charts/cost-bar-chart";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { COST_BAR_CHART_MAX_ITEMS } from "@/components/charts/cost-bar-chart-config";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 export default async function ReposPage({

--- a/src/components/charts/cost-bar-chart-config.ts
+++ b/src/components/charts/cost-bar-chart-config.ts
@@ -1,0 +1,8 @@
+/** Cap on rows the bar chart will render. Lives in a server-and-client safe
+ * module (no `"use client"` directive) so the Repos page's server component
+ * can import it directly to keep its companion tables in lockstep with the
+ * chart. Importing the same constant from `cost-bar-chart.tsx` (which IS a
+ * client module) makes it a client reference at server build time — the
+ * imported value is `undefined` server-side, and `Array.slice(0, undefined)`
+ * silently returns the full array. */
+export const COST_BAR_CHART_MAX_ITEMS = 10;

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -12,6 +12,7 @@ import {
 import { fmtCost, fmtNum } from "@/lib/format";
 import type { Unit } from "@/lib/units";
 import { useMediaQuery } from "@/lib/use-media-query";
+import { COST_BAR_CHART_MAX_ITEMS } from "./cost-bar-chart-config";
 
 interface CostBarDatum {
   label: string;
@@ -19,9 +20,6 @@ interface CostBarDatum {
   tokens: number;
 }
 
-/** Cap on rows the bar chart will render. Exported so companion tables on the
- * Repos page can apply the same cap and stay in lockstep with the chart. */
-export const COST_BAR_CHART_MAX_ITEMS = 10;
 const MAX_ITEMS = COST_BAR_CHART_MAX_ITEMS;
 const BAR_SIZE = 28;
 const BAR_GAP = 8;


### PR DESCRIPTION
## Summary
- The Repos page is a server component, but in #163 it began importing `COST_BAR_CHART_MAX_ITEMS` from `cost-bar-chart.tsx`, which is a `\"use client\"` module.
- Next.js App Router converts named exports from client modules into **Client References** on the server. So at server runtime, `COST_BAR_CHART_MAX_ITEMS` is not the literal `10` — it's a proxy/undefined. `Array.slice(0, undefined)` silently returns the whole array, which downstream produces unexpected shapes (and is the most likely root cause of the empty Project / Branch / Ticket sections that surfaced after #163 deployed to production).
- Move the constant to a plain TS module (`cost-bar-chart-config.ts`, no `\"use client\"`) so both sides import a real runtime value.

## Test plan
- [ ] After deploy, `/dashboard/repos?days=30` shows the Project / Branch / Ticket charts and tables again, with up to 10 rows each in unit-correct sort order
- [ ] `/dashboard?days=7` Top repo card still resolves
- [ ] No build/lint regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)