### PR TITLE
Display labels + output-only annotation for Copilot Chat (#168)

### DIFF
--- a/src/app/dashboard/models/page.test.tsx
+++ b/src/app/dashboard/models/page.test.tsx
@@ -88,8 +88,10 @@ describe("dashboard/models /page", () => {
     expect(text).toContain("Cost by Model");
     // Companion table promotes provider to its own column so the manager can
     // tell `gpt-4o` on OpenAI apart from a hypothetical `gpt-4o` on Azure.
-    expect(text).toContain("claude_code");
-    expect(text).toContain("openai");
+    // Provider keys are mapped to display labels via `formatProvider` (#168)
+    // so the dashboard never exposes the raw snake_case wire value.
+    expect(text).toContain("Claude Code");
+    expect(text).toContain("OpenAI");
     expect(text).toContain("claude-sonnet-4-5");
     expect(text).toContain("gpt-4o");
     // Headline tiles. 2 distinct active models, $1,000 total ⇒ $500 avg.

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -10,7 +10,7 @@ import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { fmtCost, fmtNum, formatModelName } from "@/lib/format";
+import { fmtCost, fmtNum, formatModelName, formatProvider } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -134,7 +134,9 @@ export default async function ModelsPage({
                         key={`${m.provider}/${m.model}/${i}`}
                         className="border-b border-white/5"
                       >
-                        <td className="py-2 text-zinc-200">{m.provider}</td>
+                        <td className="py-2 text-zinc-200">
+                          {formatProvider(m.provider)}
+                        </td>
                         <td className="py-2 text-zinc-200">
                           {formatModelName(m.model)}
                         </td>
@@ -172,8 +174,8 @@ export default async function ModelsPage({
                         </span>
                       </div>
                       <div className="text-xs tabular-nums text-zinc-500">
-                        {m.provider} · in {fmtNum(m.input_tokens)} · out{" "}
-                        {fmtNum(m.output_tokens)}
+                        {formatProvider(m.provider)} · in{" "}
+                        {fmtNum(m.input_tokens)} · out {fmtNum(m.output_tokens)}
                       </div>
                     </li>
                   ))}

--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -260,4 +260,34 @@ describe("dashboard/sessions/[id] /page", () => {
     const node = await render();
     expect(node).toBeNull();
   });
+
+  it("renders the canonical provider key as a display label so users never see the snake_case wire value (#168)", async () => {
+    // Copilot Chat lands on the dashboard via 8.4 (siropkin/budi#665) without a
+    // schema change — the polish ticket is making the raw `copilot_chat`
+    // render as "Copilot Chat" wherever the field is read.
+    dal.getSessionDetail.mockResolvedValue({
+      ...SESSION,
+      provider: "copilot_chat",
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Copilot Chat");
+    expect(text).not.toContain("copilot_chat");
+  });
+
+  it("annotates output-only sessions so a `0` input-token count reads as a known May-2026+ Copilot Chat state, not missing data (#168)", async () => {
+    // ADR-0092 §2.3 v3: VS Code Copilot Chat builds drop prompt-token counts
+    // on disk from May 2026 onward. The daemon's output-only fallback emits
+    // rows with `input_tokens = 0` and a non-zero `output_tokens`. The detail
+    // page tags those so the breakdown isn't ambiguous with "we lost the data".
+    dal.getSessionDetail.mockResolvedValue({
+      ...SESSION,
+      provider: "copilot_chat",
+      total_input_tokens: 0,
+      total_output_tokens: 1500,
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("output-only");
+  });
 });

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   fmtNum,
   formatDuration,
   formatModelName,
+  formatProvider,
   repoName,
 } from "@/lib/format";
 
@@ -57,8 +58,15 @@ export default async function SessionDetailPage({
   if (!session) notFound();
 
   const isManager = user.role === "manager";
-  const totalTokens =
-    Number(session.total_input_tokens) + Number(session.total_output_tokens);
+  const inputTokens = Number(session.total_input_tokens);
+  const outputTokens = Number(session.total_output_tokens);
+  const totalTokens = inputTokens + outputTokens;
+  // Output-only rows (#168): May-2026+ VS Code Copilot Chat builds drop
+  // prompt-token counts on disk, so the daemon ships rows with
+  // `input_tokens = 0` and a non-zero `output_tokens`. A bare "0" in the
+  // Tokens row would read as missing data; tag the breakdown so a viewer
+  // looking at one of these sessions sees the state honestly.
+  const isOutputOnly = inputTokens === 0 && outputTokens > 0;
 
   const backHref = buildSessionsBackHref(sp);
 
@@ -83,7 +91,7 @@ export default async function SessionDetailPage({
             {isManager && (
               <Field label="Member" value={session.owner_name ?? "-"} />
             )}
-            <Field label="Provider" value={session.provider} />
+            <Field label="Provider" value={formatProvider(session.provider)} />
             <Field
               label="Model"
               value={
@@ -112,7 +120,14 @@ export default async function SessionDetailPage({
               value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
             />
             <Field label="Messages" value={fmtNum(session.message_count)} />
-            <Field label="Tokens" value={fmtNum(totalTokens)} />
+            <Field
+              label="Tokens"
+              value={
+                isOutputOnly
+                  ? `${fmtNum(totalTokens)} (output-only)`
+                  : fmtNum(totalTokens)
+              }
+            />
             <Field
               label="Cost"
               value={fmtCost(Number(session.total_cost_cents))}

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -20,6 +20,7 @@ import {
   fmtNum,
   formatDuration,
   formatModelName,
+  formatProvider,
   repoName,
 } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
@@ -178,7 +179,7 @@ export default async function SessionsPage({
                         )}
                         <td className="text-zinc-300">
                           <Link href={href} className="block py-2 pr-3">
-                            {s.provider}
+                            {formatProvider(s.provider)}
                           </Link>
                         </td>
                         <td

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  fmtDelta,
-  formatDuration,
-  formatProvider,
-  repoName,
-} from "./format";
+import { fmtDelta, formatDuration, formatProvider, repoName } from "./format";
 
 describe("formatDuration (#88)", () => {
   it("uses duration_ms when provided", () => {

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { fmtDelta, formatDuration, repoName } from "./format";
+import {
+  fmtDelta,
+  formatDuration,
+  formatProvider,
+  repoName,
+} from "./format";
 
 describe("formatDuration (#88)", () => {
   it("uses duration_ms when provided", () => {
@@ -93,5 +98,26 @@ describe("repoName (#121)", () => {
 
   it("shortens hashed sha256 ids", () => {
     expect(repoName("sha256:abcdef0123456789xyz")).toBe("abcdef01...");
+  });
+});
+
+describe("formatProvider (#168)", () => {
+  it("maps the canonical providers to title-cased display labels", () => {
+    expect(formatProvider("claude_code")).toBe("Claude Code");
+    expect(formatProvider("cursor")).toBe("Cursor");
+    expect(formatProvider("codex")).toBe("Codex");
+    expect(formatProvider("copilot_cli")).toBe("Copilot CLI");
+    expect(formatProvider("copilot_chat")).toBe("Copilot Chat");
+    expect(formatProvider("openai")).toBe("OpenAI");
+  });
+
+  it("falls back to the raw key for unknown providers so a future daemon-emitted value still renders", () => {
+    expect(formatProvider("anthropic_api")).toBe("anthropic_api");
+  });
+
+  it("renders an em-dash sentinel for null / empty values", () => {
+    expect(formatProvider(null)).toBe("-");
+    expect(formatProvider(undefined)).toBe("-");
+    expect(formatProvider("")).toBe("-");
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -78,6 +78,30 @@ export function formatModelName(model: string): string {
 }
 
 /**
+ * Display label for a `provider` value (#168).
+ *
+ * The cloud schema treats `provider` as an opaque string so new providers can
+ * land on the dashboard without a migration, but the daemon ships them as
+ * snake_case canonical keys (`claude_code`, `copilot_chat`, …). Render those
+ * with title-cased product names so the Sessions list / detail / Models page
+ * don't expose the wire format. Unknown keys fall back to the raw value so a
+ * future provider still shows up rather than collapsing to "Unknown".
+ */
+const PROVIDER_LABELS: Record<string, string> = {
+  claude_code: "Claude Code",
+  cursor: "Cursor",
+  codex: "Codex",
+  copilot_cli: "Copilot CLI",
+  copilot_chat: "Copilot Chat",
+  openai: "OpenAI",
+};
+
+export function formatProvider(provider: string | null | undefined): string {
+  if (!provider) return "-";
+  return PROVIDER_LABELS[provider] ?? provider;
+}
+
+/**
  * Period-over-period delta for the Overview headline cards (#150).
  *
  * Returns the percentage change of `current` vs `previous` along with a


### PR DESCRIPTION
Closes #168.

## Summary
- Add `formatProvider` helper in `src/lib/format.ts` mapping canonical provider keys (`claude_code`, `cursor`, `codex`, `copilot_cli`, `copilot_chat`, `openai`) to title-cased display labels. Unknown keys fall through to the raw value so a future daemon-emitted provider still renders rather than collapsing.
- Wire `formatProvider` into the Sessions list, Sessions detail, and Models page (table + mobile list). The canonical key stays the underlying SQL/filter value — labels are presentation only.
- Tag sessions with `input_tokens = 0` and non-zero `output_tokens` on the detail page as `(output-only)` so May-2026+ VS Code Copilot Chat rows (per [ADR-0092](https://github.com/siropkin/budi/blob/main/docs/adr/0092-copilot-chat-data-contract.md) §2.3 v3) read honestly instead of looking like missing data.

## Out of scope
- No schema changes — `provider` and `pricing_source` remain opaque strings, and `pricing_source` / `cost_confidence` are not yet surfaced anywhere in this repo.
- Provider filter dropdown — none currently exist on the Sessions or Models pages, so there is no hardcoded provider list to update.
- Chart palette — chart colors are derived from per-row hashing or sequential indexing, not a hardcoded provider→color map, so `copilot_chat` rows pick up a stable color automatically.

## Test plan
- [x] `npm test` — 208 passing (added `formatProvider` unit tests + provider-label and output-only assertions on the Sessions detail page test)
- [x] `npm run lint` — clean
- [ ] Manual: load `/dashboard/sessions` and `/dashboard/models` with a `copilot_chat` row and confirm it renders as "Copilot Chat"

🤖 Generated with [Claude Code](https://claude.com/claude-code)