### PR TITLE
fix(sidebar): persist ?days=/?user= filters across navigation

### DIFF
--- a/src/components/sidebar.test.ts
+++ b/src/components/sidebar.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { buildPreservedSearch } from "@/components/sidebar";
+
+function reader(record: Record<string, string>) {
+  return (key: string) => record[key] ?? null;
+}
+
+describe("buildPreservedSearch", () => {
+  it("returns an empty string when no preserved params are set", () => {
+    expect(buildPreservedSearch(reader({}))).toBe("");
+  });
+
+  it("preserves the period switcher across navigations (#172)", () => {
+    expect(buildPreservedSearch(reader({ days: "30" }))).toBe("?days=30");
+    expect(buildPreservedSearch(reader({ days: "all" }))).toBe("?days=all");
+  });
+
+  it("preserves the manager teammate filter alongside the period", () => {
+    expect(
+      buildPreservedSearch(reader({ days: "30", user: "abc-123" }))
+    ).toBe("?days=30&user=abc-123");
+  });
+
+  it("drops page-scoped params (cursor, sort, …)", () => {
+    expect(
+      buildPreservedSearch(
+        reader({ days: "7", cursor: "eyJ0IjoiMTIzIn0", sort: "cost" })
+      )
+    ).toBe("?days=7");
+  });
+
+  it("ignores empty preserved values rather than emitting `?days=`", () => {
+    expect(buildPreservedSearch(reader({ days: "", user: "" }))).toBe("");
+  });
+});

--- a/src/components/sidebar.test.ts
+++ b/src/components/sidebar.test.ts
@@ -16,9 +16,9 @@ describe("buildPreservedSearch", () => {
   });
 
   it("preserves the manager teammate filter alongside the period", () => {
-    expect(
-      buildPreservedSearch(reader({ days: "30", user: "abc-123" }))
-    ).toBe("?days=30&user=abc-123");
+    expect(buildPreservedSearch(reader({ days: "30", user: "abc-123" }))).toBe(
+      "?days=30&user=abc-123"
+    );
   });
 
   it("drops page-scoped params (cursor, sort, …)", () => {

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import { clsx } from "clsx";
 import type { MouseEventHandler } from "react";
 import {
@@ -17,6 +17,28 @@ import {
   Users,
   X,
 } from "lucide-react";
+
+// Filter params that scope every dashboard page (period switcher, manager
+// teammate filter). The sidebar carries them across navigations so users
+// don't have to re-pick `30d` / `All team` on each page (#172).
+const PRESERVED_PARAMS = ["days", "user"] as const;
+
+/**
+ * Build the `?days=…&user=…` suffix to graft onto every sidebar link, dropping
+ * any other params (cursors, sorts, …) that are scoped to a single page.
+ * Exported for unit testing — production callers use {@link usePreservedSearch}.
+ */
+export function buildPreservedSearch(
+  read: (key: string) => string | null
+): string {
+  const params = new URLSearchParams();
+  for (const key of PRESERVED_PARAMS) {
+    const value = read(key);
+    if (value) params.set(key, value);
+  }
+  const qs = params.toString();
+  return qs ? `?${qs}` : "";
+}
 
 // `managerOnly: true` means the link is rendered only for `role === "manager"`.
 // `/dashboard/team` is scoped to the viewer's own devices (ADR-0083 §6), so for
@@ -43,10 +65,11 @@ function visibleNavItems(role: string) {
  * there so the 224px rail doesn't eat >50% of a 390px viewport.
  */
 export function Sidebar({ role }: { role: string }) {
+  const search = usePreservedSearch();
   return (
     <nav className="hidden w-56 flex-col border-r border-white/10 bg-[#0a0a0a] px-3 py-4 md:flex">
-      <BrandLink />
-      <NavList items={visibleNavItems(role)} />
+      <BrandLink search={search} />
+      <NavList items={visibleNavItems(role)} search={search} />
     </nav>
   );
 }
@@ -58,6 +81,7 @@ export function Sidebar({ role }: { role: string }) {
 export function MobileSidebar({ role }: { role: string }) {
   const [open, setOpen] = useState(false);
   const close = () => setOpen(false);
+  const search = usePreservedSearch();
 
   // ESC closes the drawer, matching the Danger-zone confirm dialog behavior.
   useEffect(() => {
@@ -96,7 +120,7 @@ export function MobileSidebar({ role }: { role: string }) {
           />
           <nav className="relative flex h-full w-64 max-w-[80vw] flex-col border-r border-white/10 bg-[#0a0a0a] px-3 py-4">
             <div className="mb-2 flex items-center justify-between pr-1">
-              <BrandLink onNavigate={close} />
+              <BrandLink onNavigate={close} search={search} />
               <button
                 type="button"
                 onClick={close}
@@ -108,7 +132,11 @@ export function MobileSidebar({ role }: { role: string }) {
             </div>
             {/* onNavigate fires before the router commits the new pathname, so
                 the drawer closes as the destination page mounts. */}
-            <NavList items={visibleNavItems(role)} onNavigate={close} />
+            <NavList
+              items={visibleNavItems(role)}
+              onNavigate={close}
+              search={search}
+            />
           </nav>
         </div>
       )}
@@ -116,10 +144,16 @@ export function MobileSidebar({ role }: { role: string }) {
   );
 }
 
-function BrandLink({ onNavigate }: { onNavigate?: MouseEventHandler }) {
+function BrandLink({
+  onNavigate,
+  search,
+}: {
+  onNavigate?: MouseEventHandler;
+  search: string;
+}) {
   return (
     <Link
-      href="/dashboard"
+      href={`/dashboard${search}`}
       onClick={onNavigate}
       className="mb-6 flex items-center gap-2 px-3 text-lg font-bold text-white"
     >
@@ -132,9 +166,11 @@ function BrandLink({ onNavigate }: { onNavigate?: MouseEventHandler }) {
 function NavList({
   items,
   onNavigate,
+  search,
 }: {
   items: ReadonlyArray<(typeof NAV_ITEMS)[number]>;
   onNavigate?: MouseEventHandler;
+  search: string;
 }) {
   const pathname = usePathname();
   return (
@@ -148,7 +184,7 @@ function NavList({
         return (
           <li key={item.href}>
             <Link
-              href={item.href}
+              href={`${item.href}${search}`}
               onClick={onNavigate}
               className={clsx(
                 "flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
@@ -164,5 +200,13 @@ function NavList({
         );
       })}
     </ul>
+  );
+}
+
+function usePreservedSearch(): string {
+  const searchParams = useSearchParams();
+  return useMemo(
+    () => buildPreservedSearch((key) => searchParams.get(key)),
+    [searchParams]
   );
 }


### PR DESCRIPTION
## Summary
- Sidebar links were hardcoded to bare paths (e.g. `/dashboard/team`), so the period switcher (`?days=30`) and manager teammate filter (`?user=…`) were dropped on every navigation and reset to the `7d` default.
- Carry both params through every `<Link>` — desktop rail, mobile drawer, and the brand link — while still discarding page-scoped params (cursors, sorts).
- Pure helper `buildPreservedSearch` is exported and unit-tested so the allowlist stays explicit.

Closes #172

## Test plan
- [x] `npm test` — added `src/components/sidebar.test.ts` covering the empty case, period-only, period+user, page-scoped param drop, and empty-value handling.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual: open `/dashboard?days=30`, click each sidebar entry, confirm `?days=30` survives.
- [ ] Manual: as a manager with `?days=30&user=<id>`, navigate Overview → Team → Devices → Models → Repos → Sessions → Settings; both params persist.
- [ ] Manual: page-scoped params (e.g. Sessions cursor) are dropped on sidebar navigation, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)