### PR TITLE
fix(ingest): require UUID device_id and cap auto-register per org (#181)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -285,7 +285,7 @@ describe("POST /v1/ingest + dashboard read path (#14)", () => {
 
     const envelope = {
       schema_version: 1,
-      device_id: "dev_test",
+      device_id: "11111111-1111-4111-8111-111111111111",
       org_id: "org_test",
       synced_at: "2026-04-15T12:00:00Z",
       payload: {
@@ -453,7 +453,7 @@ describe("POST /v1/ingest + dashboard read path (#14)", () => {
     };
     const baseEnvelope: Envelope = {
       schema_version: 1,
-      device_id: "dev_test",
+      device_id: "11111111-1111-4111-8111-111111111111",
       org_id: "org_test",
       synced_at: "2026-04-15T12:00:00Z",
       payload: {
@@ -546,7 +546,7 @@ describe("POST /v1/ingest — device label persistence (#60)", () => {
 
   const baseEnvelope = {
     schema_version: 1,
-    device_id: "dev_test",
+    device_id: "11111111-1111-4111-8111-111111111111",
     org_id: "org_test",
     synced_at: "2026-04-15T12:00:00Z",
     payload: { daily_rollups: [], session_summaries: [] },
@@ -580,7 +580,7 @@ describe("POST /v1/ingest — device label persistence (#60)", () => {
     seedUser();
     fake.seed("devices", [
       {
-        id: "dev_test",
+        id: "11111111-1111-4111-8111-111111111111",
         user_id: "usr_test",
         label: "old-name",
         last_seen: "2026-04-14T00:00:00Z",
@@ -604,7 +604,7 @@ describe("POST /v1/ingest — device label persistence (#60)", () => {
     seedUser();
     fake.seed("devices", [
       {
-        id: "dev_test",
+        id: "11111111-1111-4111-8111-111111111111",
         user_id: "usr_test",
         label: "already-set",
         last_seen: "2026-04-14T00:00:00Z",
@@ -623,7 +623,7 @@ describe("POST /v1/ingest — device label persistence (#60)", () => {
     seedUser();
     fake.seed("devices", [
       {
-        id: "dev_test",
+        id: "11111111-1111-4111-8111-111111111111",
         user_id: "usr_test",
         label: "going-away",
         last_seen: "2026-04-14T00:00:00Z",
@@ -656,5 +656,128 @@ describe("POST /v1/ingest — device label persistence (#60)", () => {
 
     const [device] = fake.rows("devices");
     expect((device.label as string).length).toBe(128);
+  });
+});
+
+describe("POST /v1/ingest — device_id squatting protections (#181)", () => {
+  function seedUser() {
+    fake.seed("orgs", [{ id: "org_test", name: "test" }]);
+    fake.seed("users", [
+      {
+        id: "usr_test",
+        org_id: "org_test",
+        role: "manager",
+        api_key: "budi_testkey",
+        display_name: "Test",
+        email: "t@example.com",
+      },
+    ]);
+  }
+
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const baseEnvelope = {
+    schema_version: 1,
+    device_id: "11111111-1111-4111-8111-111111111111",
+    org_id: "org_test",
+    synced_at: "2026-04-15T12:00:00Z",
+    payload: { daily_rollups: [], session_summaries: [] },
+  };
+
+  it("rejects non-UUID device_ids with 422 so callers can't squat predictable ids", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        device_id: "victim-org-laptop",
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/device_id must be a UUID/i);
+    // No row was inserted on the way out.
+    expect(fake.rows("devices")).toHaveLength(0);
+  });
+
+  it("accepts a well-formed UUID device_id and auto-registers it", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq(baseEnvelope) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    expect(fake.rows("devices")).toHaveLength(1);
+  });
+
+  it("returns 429 once the org hits the auto-register cap", async () => {
+    seedUser();
+    // Pre-seed 50 devices already owned by this org's user — the cap is
+    // exclusive, so the 51st auto-register attempt must be rejected.
+    const seed = Array.from({ length: 50 }, (_, i) => ({
+      id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(i).padStart(12, "0")}`,
+      user_id: "usr_test",
+      label: null,
+      first_seen: "2026-04-14T00:00:00Z",
+      last_seen: "2026-04-14T00:00:00Z",
+    }));
+    fake.seed("devices", seed);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        device_id: "22222222-2222-4222-8222-222222222222",
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/device cap/i);
+    // 51st row was not inserted.
+    expect(fake.rows("devices")).toHaveLength(50);
+  });
+
+  it("does not apply the cap to ingest against an existing device row", async () => {
+    seedUser();
+    // 50 devices already, but one of them is the device the daemon is now
+    // syncing against — this is the "existing device" branch, which must not
+    // be blocked by the auto-register cap.
+    const existingId = "11111111-1111-4111-8111-111111111111";
+    const seed = Array.from({ length: 49 }, (_, i) => ({
+      id: `aaaaaaaa-aaaa-4aaa-8aaa-${String(i).padStart(12, "0")}`,
+      user_id: "usr_test",
+      label: null,
+      first_seen: "2026-04-14T00:00:00Z",
+      last_seen: "2026-04-14T00:00:00Z",
+    }));
+    seed.push({
+      id: existingId,
+      user_id: "usr_test",
+      label: null,
+      first_seen: "2026-04-14T00:00:00Z",
+      last_seen: "2026-04-14T00:00:00Z",
+    });
+    fake.seed("devices", seed);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      mkReq(baseEnvelope) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
   });
 });

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -16,6 +16,18 @@ const CURRENT_SCHEMA_VERSION = 1;
 // 128 chars is comfortably above any sane hostname or user-chosen nickname.
 const MAX_LABEL_LENGTH = 128;
 
+// Per-org cap on auto-registered devices. The daemon ships one device row per
+// machine, and even prolific orgs sit comfortably under this. The cap exists
+// to make device-id squatting (#181) economically uninteresting: an attacker
+// with a valid key can't pre-register an unbounded list of guessed ids.
+const MAX_DEVICES_PER_ORG = 50;
+
+// Accept any RFC-9562 UUID (versions 1–8, including v4/v7 the daemon ships).
+// Rejecting non-UUID ids closes the squatting vector from #181: a caller can
+// no longer auto-register an arbitrary, predictable string under their org.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 interface SyncEnvelope {
   schema_version: number;
   device_id: string;
@@ -84,6 +96,9 @@ function validateEnvelope(body: SyncEnvelope): string | null {
   }
   if (!body.device_id || typeof body.device_id !== "string") {
     return "Missing or invalid device_id";
+  }
+  if (!UUID_RE.test(body.device_id)) {
+    return "device_id must be a UUID";
   }
   if (!body.org_id || typeof body.org_id !== "string") {
     return "Missing or invalid org_id";
@@ -168,6 +183,27 @@ export async function POST(request: NextRequest) {
   const now = new Date().toISOString();
 
   if (deviceError || !device) {
+    // #181: cap auto-registration per org so a single compromised key can't
+    // bulk-squat device ids. Counting via a join through `users` keeps the
+    // limit at the org level — multiple users in the same org share the cap.
+    const { data: orgUserIds } = await supabase
+      .from("users")
+      .select("id")
+      .eq("org_id", user.org_id);
+    const userIds = (orgUserIds ?? []).map((u) => u.id as string);
+    const { count: orgDeviceCount } = await supabase
+      .from("devices")
+      .select("id", { count: "exact", head: true })
+      .in("user_id", userIds.length > 0 ? userIds : [user.id]);
+    if ((orgDeviceCount ?? 0) >= MAX_DEVICES_PER_ORG) {
+      return Response.json(
+        {
+          error: `Device cap reached: an org may auto-register at most ${MAX_DEVICES_PER_ORG} devices. Contact a manager to release unused ids.`,
+        },
+        { status: 429 }
+      );
+    }
+
     // Auto-register the device if it doesn't exist yet. `label` is persisted
     // here (when sent) so the Devices dashboard shows a recognisable name
     // from the very first sync rather than the truncated id fallback (#60).


### PR DESCRIPTION
Closes #181.

## Summary
- Validate `device_id` matches an RFC-9562 UUID (v1–v8) before any DB write, so a caller can no longer auto-register a predictable plain-text id under their org.
- Cap auto-registration at 50 devices per org and return `429` above the cap, so a single valid key can't bulk-squat random UUIDs. The cap only gates the insert branch — ingest against an existing device row is unaffected.

This combines options (2) from the issue's suggested fixes: UUID-shape check + per-org cap. The audit-row + release-tool path (option 3) is left for a follow-up since it touches the schema and the dashboard.

## Test plan
- [x] `npm test` — full suite (222 tests) passes
- [x] New cases in `route.test.ts`:
  - non-UUID `device_id` → 422 with `device_id must be a UUID`, no insert
  - well-formed UUID auto-registers as before
  - 51st auto-register attempt returns 429, no row inserted
  - cap does not block ingest against an existing device row
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)