### PR TITLE
feat(security): full CSP with nonce + strict-dynamic via proxy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,8 +8,10 @@ const securityHeaders = [
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
   },
-  // Start with frame-ancestors only; expand CSP after auditing inline scripts/styles.
-  { key: "Content-Security-Policy", value: "frame-ancestors 'none'" },
+  // Content-Security-Policy is set per-request in src/proxy.ts (#180) so it
+  // can include a script-src nonce. Anything not covered by the proxy
+  // matcher (static files, /api/*) does not execute scripts, so a static
+  // CSP fallback here would only add maintenance cost.
 ];
 
 const nextConfig: NextConfig = {

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/csp-report (#180)
+ *
+ * Receives Content-Security-Policy violation reports from the browser.
+ * Browsers send these as either:
+ *   - `application/csp-report` (legacy `report-uri` directive)
+ *   - `application/reports+json` (Reporting API / `report-to` directive)
+ *
+ * The endpoint exists so we can run CSP in report-only mode and triage
+ * violations before flipping to enforcing. Reports are logged to stderr;
+ * downstream log shipping captures them without us standing up a separate
+ * sink. Never echo the body back — it can include user-pasted URLs.
+ */
+export async function POST(request: NextRequest) {
+  let body: unknown = null;
+  try {
+    body = await request.json();
+  } catch {
+    // Fall through; some browsers send empty bodies on opaque redirect blocks.
+  }
+
+  console.warn("[csp-report]", JSON.stringify(body));
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/lib/csp.test.ts
+++ b/src/lib/csp.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+/**
+ * #180: CSP builder smoke tests. The proxy stamps these headers on every
+ * non-API response so we want to keep the directive shape stable —
+ * forgetting `frame-ancestors` or letting `'unsafe-eval'` slip back in are
+ * the kind of regressions a smoke test catches cheaply.
+ */
+
+beforeEach(() => {
+  delete process.env.CSP_REPORT_ONLY;
+});
+
+afterEach(() => {
+  delete process.env.CSP_REPORT_ONLY;
+});
+
+describe("buildCsp", () => {
+  it("includes a script-src nonce, strict-dynamic, and the core directives", async () => {
+    const { buildCsp } = await import("./csp");
+    const csp = buildCsp("abc123");
+
+    expect(csp).toContain("script-src 'self' 'nonce-abc123' 'strict-dynamic'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("report-uri /api/csp-report");
+    expect(csp).toContain("report-to csp-endpoint");
+  });
+
+  it("never emits 'unsafe-eval'", async () => {
+    const { buildCsp } = await import("./csp");
+    expect(buildCsp("n")).not.toContain("unsafe-eval");
+  });
+});
+
+describe("isReportOnly", () => {
+  it("defaults to report-only when the env var is unset", async () => {
+    const { isReportOnly } = await import("./csp");
+    expect(isReportOnly()).toBe(true);
+  });
+
+  it("flips to enforcing when CSP_REPORT_ONLY is falsy", async () => {
+    process.env.CSP_REPORT_ONLY = "false";
+    const { isReportOnly } = await import("./csp");
+    expect(isReportOnly()).toBe(false);
+  });
+});

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,79 @@
+/**
+ * Content-Security-Policy builder used by the proxy (#180).
+ *
+ * Strategy: nonce + 'strict-dynamic' for scripts. Per-request nonce means CSP
+ * has to be set in the proxy (not in `next.config.ts`). Next.js automatically
+ * applies the nonce to its bootstrap scripts when it sees `x-nonce` on the
+ * forwarded request headers.
+ *
+ * Defaults to *report-only* so violations are surfaced before we enforce
+ * (the issue explicitly recommends one release in report-only). Flip with
+ * `CSP_REPORT_ONLY=false` once the report stream is clean.
+ */
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+
+let supabaseOrigin = "";
+let supabaseWsOrigin = "";
+try {
+  if (SUPABASE_URL) {
+    const u = new URL(SUPABASE_URL);
+    supabaseOrigin = u.origin;
+    supabaseWsOrigin = `wss://${u.host}`;
+  }
+} catch {
+  // Misconfigured env — fall back to wildcard so auth still works rather
+  // than silently blocking it via CSP.
+  supabaseOrigin = "https://*.supabase.co";
+  supabaseWsOrigin = "wss://*.supabase.co";
+}
+
+export function generateNonce(): string {
+  // crypto.randomUUID is available on Node 19+ and the Edge runtime.
+  return Buffer.from(crypto.randomUUID()).toString("base64");
+}
+
+export function buildCsp(nonce: string): string {
+  const connectSrc = ["'self'", supabaseOrigin, supabaseWsOrigin]
+    .filter(Boolean)
+    .join(" ");
+
+  const directives = [
+    `default-src 'self'`,
+    // 'strict-dynamic' lets nonce'd scripts (Next.js bootstrap, framework
+    // chunks) load further scripts they need without us enumerating CDNs.
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https:`,
+    // Tailwind/Next emit inline <style> blocks; 'unsafe-inline' is a known
+    // necessary evil here. Worth revisiting if Next ships nonced styles.
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src 'self' data: blob: https:`,
+    `font-src 'self' data:`,
+    `connect-src ${connectSrc}`,
+    `frame-ancestors 'none'`,
+    `frame-src 'none'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `upgrade-insecure-requests`,
+    `report-uri /api/csp-report`,
+    `report-to csp-endpoint`,
+  ];
+
+  return directives.join("; ");
+}
+
+export function isReportOnly(): boolean {
+  // Default to report-only (issue #180 recommends one release in
+  // report-only before flipping to enforcing).
+  const v = process.env.CSP_REPORT_ONLY;
+  if (v === undefined) return true;
+  return !["0", "false", "no", "off"].includes(v.toLowerCase());
+}
+
+export function reportToHeaderValue(): string {
+  return JSON.stringify({
+    group: "csp-endpoint",
+    max_age: 10886400,
+    endpoints: [{ url: "/api/csp-report" }],
+  });
+}

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -38,7 +38,9 @@ describe("proxy — CSP wiring (#180)", () => {
 
     const reportOnly = res.headers.get("content-security-policy-report-only");
     expect(reportOnly).toBeTruthy();
-    expect(reportOnly).toMatch(/script-src 'self' 'nonce-[^']+' 'strict-dynamic'/);
+    expect(reportOnly).toMatch(
+      /script-src 'self' 'nonce-[^']+' 'strict-dynamic'/
+    );
     expect(reportOnly).toContain("frame-ancestors 'none'");
     expect(reportOnly).not.toContain("unsafe-eval");
     expect(res.headers.get("report-to")).toContain("csp-endpoint");

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * #180: end-to-end smoke test for the per-request CSP. Confirms the proxy
+ * stamps a CSP header (with nonce, frame-ancestors, no 'unsafe-eval') on
+ * `/dashboard` and `/login` responses — the two surfaces called out in the
+ * issue. Supabase auth is mocked: the proxy's only job here is the
+ * security headers, redirects, and nonce wiring.
+ */
+
+let mockUser: { id: string } | null = null;
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: () => ({
+    auth: {
+      getUser: async () => ({ data: { user: mockUser }, error: null }),
+    },
+  }),
+}));
+
+beforeEach(() => {
+  mockUser = null;
+  process.env.NEXT_PUBLIC_SUPABASE_URL = "https://abc.supabase.co";
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon_test_key";
+  delete process.env.CSP_REPORT_ONLY;
+});
+
+async function callProxy(url: string) {
+  const { proxy } = await import("./proxy");
+  const req = new NextRequest(new Request(url));
+  return proxy(req);
+}
+
+describe("proxy — CSP wiring (#180)", () => {
+  it("stamps CSP-Report-Only with a nonce on /login by default", async () => {
+    const res = await callProxy("http://localhost:3000/login");
+
+    const reportOnly = res.headers.get("content-security-policy-report-only");
+    expect(reportOnly).toBeTruthy();
+    expect(reportOnly).toMatch(/script-src 'self' 'nonce-[^']+' 'strict-dynamic'/);
+    expect(reportOnly).toContain("frame-ancestors 'none'");
+    expect(reportOnly).not.toContain("unsafe-eval");
+    expect(res.headers.get("report-to")).toContain("csp-endpoint");
+  });
+
+  it("stamps CSP on the /dashboard redirect for unauth users", async () => {
+    mockUser = null;
+    const res = await callProxy("http://localhost:3000/dashboard");
+
+    // Unauthenticated → 307 redirect to /login.
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/login");
+    const csp =
+      res.headers.get("content-security-policy") ??
+      res.headers.get("content-security-policy-report-only");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).not.toContain("unsafe-eval");
+  });
+
+  it("stamps CSP on the authenticated /dashboard pass-through", async () => {
+    mockUser = { id: "usr_a" };
+    const res = await callProxy("http://localhost:3000/dashboard");
+
+    const csp =
+      res.headers.get("content-security-policy") ??
+      res.headers.get("content-security-policy-report-only");
+    expect(csp).toMatch(/script-src 'self' 'nonce-[^']+'/);
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).not.toContain("unsafe-eval");
+  });
+
+  it("uses enforcing CSP header when CSP_REPORT_ONLY=false", async () => {
+    process.env.CSP_REPORT_ONLY = "false";
+    vi.resetModules();
+
+    const res = await callProxy("http://localhost:3000/login");
+    expect(res.headers.get("content-security-policy")).toBeTruthy();
+    expect(res.headers.get("content-security-policy-report-only")).toBeNull();
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,14 +1,38 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
+import {
+  buildCsp,
+  generateNonce,
+  isReportOnly,
+  reportToHeaderValue,
+} from "@/lib/csp";
 
 /**
  * Next.js 16 Proxy (formerly Middleware).
  *
- * Refreshes the Supabase auth session on every navigation and
- * protects /dashboard/* routes from unauthenticated users.
+ * Refreshes the Supabase auth session on every navigation, protects
+ * /dashboard/* routes from unauthenticated users, and stamps a per-request
+ * Content-Security-Policy with a nonce (#180).
  */
 export async function proxy(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request });
+  // CSP nonce is generated per request so 'strict-dynamic' can pin script
+  // trust to scripts we render. The nonce travels via request headers so the
+  // App Router picks it up and applies it to its own injected scripts.
+  const nonce = generateNonce();
+  const csp = buildCsp(nonce);
+  const cspHeaderName = isReportOnly()
+    ? "Content-Security-Policy-Report-Only"
+    : "Content-Security-Policy";
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  // Forwarding the policy on the request lets Next strip it from inline
+  // scripts where we cannot annotate them, per the App Router CSP guide.
+  requestHeaders.set("content-security-policy", csp);
+
+  let supabaseResponse = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -22,7 +46,9 @@ export async function proxy(request: NextRequest) {
           for (const { name, value } of cookiesToSet) {
             request.cookies.set(name, value);
           }
-          supabaseResponse = NextResponse.next({ request });
+          supabaseResponse = NextResponse.next({
+            request: { headers: requestHeaders },
+          });
           for (const { name, value, options } of cookiesToSet) {
             supabaseResponse.cookies.set(name, value, options);
           }
@@ -38,6 +64,12 @@ export async function proxy(request: NextRequest) {
 
   const path = request.nextUrl.pathname;
 
+  const stampSecurityHeaders = (res: NextResponse) => {
+    res.headers.set(cspHeaderName, csp);
+    res.headers.set("Report-To", reportToHeaderValue());
+    return res;
+  };
+
   // Protect dashboard routes
   if (path.startsWith("/dashboard") && !user) {
     const url = request.nextUrl.clone();
@@ -47,7 +79,7 @@ export async function proxy(request: NextRequest) {
     supabaseResponse.cookies.getAll().forEach((cookie) => {
       redirect.cookies.set(cookie.name, cookie.value);
     });
-    return redirect;
+    return stampSecurityHeaders(redirect);
   }
 
   // Redirect authenticated users away from login
@@ -60,10 +92,10 @@ export async function proxy(request: NextRequest) {
     supabaseResponse.cookies.getAll().forEach((cookie) => {
       redirect.cookies.set(cookie.name, cookie.value);
     });
-    return redirect;
+    return stampSecurityHeaders(redirect);
   }
 
-  return supabaseResponse;
+  return stampSecurityHeaders(supabaseResponse);
 }
 
 export const config = {


### PR DESCRIPTION
Closes #180.

## Summary

- Replaces the `frame-ancestors`-only CSP with a full nonce + `strict-dynamic` policy generated per request in `src/proxy.ts`.
- Adds `src/lib/csp.ts` that scopes `connect-src` to the configured Supabase origin (falls back to `*.supabase.co` if the env var is malformed) and emits both `report-uri` and `report-to` directives.
- Adds `POST /api/csp-report` so the browser has somewhere to send violations (logged to stderr; downstream log shipping picks them up).
- Drops the static CSP from `next.config.ts` — the proxy is now the only source of truth.

## Rollout

Defaults to **Report-Only** (the env var `CSP_REPORT_ONLY` is unset/truthy). This matches the issue's recommendation: ship report-only, watch the report stream, then flip `CSP_REPORT_ONLY=false` in Vercel to enforce.

## Test plan

- [x] `npm test` — 230/230 passing, including new `src/lib/csp.test.ts` and `src/proxy.test.ts` smoke tests
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Deploy preview, hit `/login` and `/dashboard`, confirm `Content-Security-Policy-Report-Only` header is present with a fresh nonce, no `'unsafe-eval'`, and `frame-ancestors 'none'` retained
- [ ] Confirm Vercel Analytics + Supabase auth (GitHub/Google/magic-link) keep working under the new CSP — if anything fires a violation in report-only, address before flipping `CSP_REPORT_ONLY=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)