### PR TITLE
feat(surface): surface dimension filter + Spend by Surface chart (#187)

### DIFF
--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -260,8 +260,12 @@ export async function POST(request: NextRequest) {
     const { error: rollupError, count } = await supabase
       .from("daily_rollups")
       .upsert(rollupRows, {
+        // Surface added to the PK in migration 014 so two surfaces on the
+        // same (device, day, role, provider, model, repo, branch) combo
+        // don't UPSERT-collide; the conflict target must mirror the new PK
+        // shape exactly or PostgREST 400s with `no unique constraint`.
         onConflict:
-          "device_id,bucket_day,role,provider,model,repo_id,git_branch",
+          "device_id,bucket_day,role,provider,model,repo_id,git_branch,surface",
         count: "exact",
       });
 

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -20,6 +20,13 @@ export interface IngestDailyRollup {
   cache_creation_tokens: number;
   cache_read_tokens: number;
   cost_cents: number;
+  // Surface dimension (#187): which IDE / CLI drove the daemon for this
+  // rollup — `vscode`, `cursor`, `jetbrains`, `terminal`, … Optional because
+  // older daemons (pre siropkin/budi#701) don't emit it; missing values land
+  // as the literal `'unknown'` so all-surface aggregations still see them
+  // and the dashboard can render them in the unfiltered "where is the team
+  // working?" chart on Overview.
+  surface?: string | null;
 }
 
 /**
@@ -45,6 +52,26 @@ function normalizeVitalState(raw: unknown): VitalState | null {
 function normalizeVitalMetric(raw: unknown): number | null {
   if (typeof raw !== "number") return null;
   return Number.isFinite(raw) ? raw : null;
+}
+
+// Cap on the stored surface tag so a malformed envelope can't store an
+// unbounded string and the dashboard's chip dropdown stays readable. Real
+// daemon-side values are short (`vscode`, `jetbrains`, …); 64 is comfortably
+// above that ceiling.
+const MAX_SURFACE_LENGTH = 64;
+
+/**
+ * Normalize the envelope's `surface` value. The cloud column is `NOT NULL
+ * DEFAULT 'unknown'` (014), so we coalesce missing / invalid / empty inputs
+ * to that literal rather than letting the daemon's omission collapse the
+ * row out of all-surface aggregations. Whitespace is trimmed and length is
+ * capped before storage.
+ */
+function normalizeSurface(raw: unknown): string {
+  if (typeof raw !== "string") return "unknown";
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return "unknown";
+  return trimmed.slice(0, MAX_SURFACE_LENGTH);
 }
 
 export interface IngestSessionSummary {
@@ -77,6 +104,10 @@ export interface IngestSessionSummary {
   vital_cost_acceleration_state?: string | null;
   vital_cost_acceleration_metric?: number | null;
   vital_overall_state?: string | null;
+  // Surface dimension (#187). Same shape and rationale as the rollup field —
+  // missing values fall through to the literal `'unknown'` so the Sessions
+  // table never has a null hole in the column.
+  surface?: string | null;
 }
 
 export function buildRollupRows(
@@ -99,6 +130,7 @@ export function buildRollupRows(
     cache_creation_tokens: r.cache_creation_tokens,
     cache_read_tokens: r.cache_read_tokens,
     cost_cents: r.cost_cents,
+    surface: normalizeSurface(r.surface),
     synced_at: syncedAt,
   }));
 }
@@ -159,6 +191,7 @@ export function buildSessionRows(
       s.vital_cost_acceleration_metric
     ),
     vital_overall_state: normalizeVitalState(s.vital_overall_state),
+    surface: normalizeSurface(s.surface),
     synced_at: syncedAt,
   }));
 }

--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -5,6 +5,7 @@ import {
   getDeviceActivityByDay,
   getEarliestActivity,
   getOrgMembers,
+  getKnownSurfaces,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
@@ -14,6 +15,7 @@ import { deviceLabel, fmtCost, fmtNum } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
+import { SurfaceFilter, parseSurfaceParam } from "@/components/surface-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { DeviceCountChart } from "@/components/charts/device-count-chart";
 import { CostPerDeviceChart } from "@/components/charts/cost-per-device-chart";
@@ -23,24 +25,31 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function DevicesPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
+  searchParams: Promise<{
+    days?: string;
+    user?: string;
+    units?: string;
+    surface?: string;
+  }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
   const unit = parseUnit(params.units);
-  const scope = { scopedUserId: params.user || null };
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { scopedUserId: params.user || null, surfaces };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
       ? await getEarliestActivity(user, scope)
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [devices, deviceActivity, members] = await Promise.all([
+  const [devices, deviceActivity, members, knownSurfaces] = await Promise.all([
     getCostByDevice(user, range, scope),
     getDeviceActivityByDay(user, range, scope),
     user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+    getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
   ]);
 
   const showOwnerColumn = user.role === "manager";
@@ -101,6 +110,7 @@ export default async function DevicesPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <SurfaceFilter surfaces={knownSurfaces} />
             <UnitsSelector />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/models/page.test.tsx
+++ b/src/app/dashboard/models/page.test.tsx
@@ -24,6 +24,7 @@ const dal = {
   getModelActivityByDay: vi.fn(),
   getEarliestActivity: vi.fn(),
   getOrgMembers: vi.fn(),
+  getKnownSurfaces: vi.fn(),
 };
 vi.mock("@/lib/dal", () => dal);
 
@@ -72,6 +73,8 @@ beforeEach(() => {
   ]);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
   dal.getOrgMembers.mockReset().mockResolvedValue([]);
+  // #187 surface filter chip — populates from known surfaces in the org.
+  dal.getKnownSurfaces.mockReset().mockResolvedValue(["cursor", "vscode"]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {
@@ -134,5 +137,15 @@ describe("dashboard/models /page", () => {
     dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
     const node = await render();
     expect(node).toBeNull();
+  });
+
+  it("surface filter: ?surface=vscode is threaded into getCostByModel and getModelActivityByDay so the per-model bars narrow to one surface (#187)", async () => {
+    await render({ surface: "vscode" });
+    for (const fn of [dal.getCostByModel, dal.getModelActivityByDay]) {
+      const lastCall = fn.mock.calls.at(-1);
+      expect(lastCall).toBeTruthy();
+      const scope = lastCall![lastCall!.length - 1];
+      expect(scope).toMatchObject({ surfaces: ["vscode"] });
+    }
   });
 });

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -5,6 +5,7 @@ import {
   getModelActivityByDay,
   getEarliestActivity,
   getOrgMembers,
+  getKnownSurfaces,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
@@ -14,6 +15,7 @@ import { fmtCost, fmtNum, formatModelName, formatProvider } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
+import { SurfaceFilter, parseSurfaceParam } from "@/components/surface-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { ModelCountChart } from "@/components/charts/model-count-chart";
 import { CostPerModelChart } from "@/components/charts/cost-per-model-chart";
@@ -23,24 +25,31 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function ModelsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
+  searchParams: Promise<{
+    days?: string;
+    user?: string;
+    units?: string;
+    surface?: string;
+  }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
   const unit = parseUnit(params.units);
-  const scope = { scopedUserId: params.user || null };
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { scopedUserId: params.user || null, surfaces };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
       ? await getEarliestActivity(user, scope)
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [models, modelActivity, members] = await Promise.all([
+  const [models, modelActivity, members, knownSurfaces] = await Promise.all([
     getCostByModel(user, range, scope),
     getModelActivityByDay(user, range, scope),
     user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+    getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
   ]);
 
   const isTokens = unit === "tokens";
@@ -91,6 +100,7 @@ export default async function ModelsPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <SurfaceFilter surfaces={knownSurfaces} />
             <UnitsSelector />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -42,6 +42,8 @@ const dal = {
   getCostByModel: vi.fn(),
   getCostByRepo: vi.fn(),
   getCostByUser: vi.fn(),
+  getCostBySurface: vi.fn(),
+  getKnownSurfaces: vi.fn(),
   getActivityHeatmap: vi.fn(),
 };
 vi.mock("@/lib/dal", () => ({
@@ -113,6 +115,24 @@ beforeEach(() => {
   ]);
   dal.getActivityHeatmap.mockResolvedValue([
     { dow: 2, hour: 14, session_count: 3, cost_cents: 50_000 },
+  ]);
+  // #187 surface dimension. Default fixture: a multi-surface org so the
+  // chip renders and the "Spend by Surface" card has non-zero data;
+  // single-surface coverage is in the dedicated test.
+  dal.getKnownSurfaces.mockResolvedValue(["cursor", "vscode"]);
+  dal.getCostBySurface.mockResolvedValue([
+    {
+      surface: "vscode",
+      cost_cents: 80_000,
+      input_tokens: 3000,
+      output_tokens: 1500,
+    },
+    {
+      surface: "cursor",
+      cost_cents: 40_000,
+      input_tokens: 1000,
+      output_tokens: 500,
+    },
   ]);
 });
 
@@ -247,5 +267,62 @@ describe("dashboard /page (Overview)", () => {
     expect(text).toContain("Top model");
     expect(text).toContain("Top repo");
     expect(text).not.toContain("Top contributor");
+  });
+
+  it("surface filter: ?surface=vscode threads through to every breakdown DAL call so every chart on the page narrows to one surface (#187)", async () => {
+    await render({ surface: "vscode" });
+    // Every breakdown helper that takes scope should see the surface
+    // narrowed to ["vscode"]. The chip carries the URL into the DAL via
+    // `parseSurfaceParam`, so a regression that drops the wiring on a
+    // single helper would surface here.
+    for (const fn of [
+      dal.getOverviewStats,
+      dal.getDailyActivity,
+      dal.getCostByModel,
+      dal.getCostByRepo,
+      dal.getCostByUser,
+      dal.getCostBySurface,
+    ]) {
+      const lastCall = fn.mock.calls.at(-1);
+      expect(lastCall, `${fn.getMockName?.() ?? "dal fn"} was not called`)
+        .toBeTruthy();
+      const scope = lastCall![lastCall!.length - 1];
+      expect(scope).toMatchObject({ surfaces: ["vscode"] });
+    }
+  });
+
+  it("surface filter: CSV `?surface=vscode,cursor` is parsed into a multi-value scope (#187 acceptance)", async () => {
+    await render({ surface: "vscode,cursor" });
+    const overviewCall = dal.getOverviewStats.mock.calls.at(-1);
+    expect(overviewCall).toBeTruthy();
+    const scope = overviewCall![overviewCall!.length - 1];
+    expect(scope).toMatchObject({ surfaces: ["vscode", "cursor"] });
+  });
+
+  it("surface chart: renders the 'Spend by Surface' card and pulls per-surface costs from the DAL (#187)", async () => {
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Spend by Surface");
+    expect(dal.getCostBySurface).toHaveBeenCalled();
+    // The chart receives bars as a prop array (not visible in extractText),
+    // so the user-facing assertion lives on the card title — the DAL-call
+    // assertion above is what catches a regression that drops the data
+    // pipeline upstream of the chart.
+  });
+
+  it("surface chart: single-surface org renders an empty-state copy that names the next-state condition (#187)", async () => {
+    dal.getKnownSurfaces.mockResolvedValue(["vscode"]);
+    dal.getCostBySurface.mockResolvedValue([
+      {
+        surface: "vscode",
+        cost_cents: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    ]);
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Spend by Surface");
+    expect(text).toContain("Single-surface org");
   });
 });

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -284,8 +284,10 @@ describe("dashboard /page (Overview)", () => {
       dal.getCostBySurface,
     ]) {
       const lastCall = fn.mock.calls.at(-1);
-      expect(lastCall, `${fn.getMockName?.() ?? "dal fn"} was not called`)
-        .toBeTruthy();
+      expect(
+        lastCall,
+        `${fn.getMockName?.() ?? "dal fn"} was not called`
+      ).toBeTruthy();
       const scope = lastCall![lastCall!.length - 1];
       expect(scope).toMatchObject({ surfaces: ["vscode"] });
     }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,8 @@ import {
   getCostByModel,
   getCostByRepo,
   getCostByUser,
+  getCostBySurface,
+  getKnownSurfaces,
   getActivityHeatmap,
   UNASSIGNED_USER_ID,
 } from "@/lib/dal";
@@ -28,8 +30,14 @@ import { TopBreakdownCard } from "@/components/top-breakdown-card";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
+import {
+  SurfaceFilter,
+  formatSurface,
+  parseSurfaceParam,
+} from "@/components/surface-filter";
 import { ActivityChart } from "@/components/charts/activity-chart";
 import { ActivityHeatmap } from "@/components/charts/activity-heatmap";
+import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import {
   LinkDaemonBanner,
   FirstSyncInProgressBanner,
@@ -39,7 +47,12 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function OverviewPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
+  searchParams: Promise<{
+    days?: string;
+    user?: string;
+    units?: string;
+    surface?: string;
+  }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
@@ -47,7 +60,8 @@ export default async function OverviewPage({
 
   const unit = parseUnit(params.units);
   const scopedUserId = params.user || null;
-  const scope = { scopedUserId };
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { scopedUserId, surfaces };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
       ? await getEarliestActivity(user, scope)
@@ -80,6 +94,8 @@ export default async function OverviewPage({
     topRepos,
     topUsers,
     heatmap,
+    knownSurfaces,
+    surfaceShare,
   ] = await Promise.all([
     getOverviewStats(user, range, scope),
     getDailyActivity(user, range, scope),
@@ -90,10 +106,18 @@ export default async function OverviewPage({
       : Promise.resolve(null),
     getCostByModel(user, range, scope),
     getCostByRepo(user, range, scope),
-    showTopContributor ? getCostByUser(user, range) : Promise.resolve([]),
+    showTopContributor
+      ? getCostByUser(user, range, scope)
+      : Promise.resolve([]),
     heatmapMode === "hourly"
       ? getActivityHeatmap(user, range, tz, scope)
       : Promise.resolve([]),
+    // The chip's option list is derived from data, not a hardcoded enum
+    // (#187 part 1 — let JetBrains show up the day the first row arrives).
+    // Intentionally not narrowed by the active `?surface=` so the chip can
+    // still let the user widen out from a single-surface state.
+    getKnownSurfaces(user, { scopedUserId }),
+    getCostBySurface(user, range, scope),
   ]);
 
   // Caption for the headline-card delta (e.g. "vs previous 7d"). For numeric
@@ -129,6 +153,7 @@ export default async function OverviewPage({
     days: params.days,
     user: params.user,
     units: params.units,
+    surface: params.surface,
   });
   const totalCostCents = stats.totalCostCents;
   const topModelLeader = topModels[0] ?? null;
@@ -148,6 +173,7 @@ export default async function OverviewPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <SurfaceFilter surfaces={knownSurfaces} />
             <UnitsSelector />
             <PeriodSelector />
           </div>
@@ -250,6 +276,29 @@ export default async function OverviewPage({
       {hasSynced && (
         <Card>
           <CardHeader>
+            <CardTitle>{`Spend by Surface (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <CostBarChart
+              data={surfaceShare.map((s) => ({
+                label: formatSurface(s.surface),
+                cost_cents: s.cost_cents,
+                tokens: s.input_tokens + s.output_tokens,
+              }))}
+              emptyLabel={
+                knownSurfaces.length <= 1
+                  ? "Single-surface org — break out per-surface spend after a second IDE / CLI starts syncing."
+                  : "No surface activity for this period"
+              }
+              unit={unit}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {hasSynced && (
+        <Card>
+          <CardHeader>
             <CardTitle>{heatmapTitle(heatmapMode, unit)}</CardTitle>
           </CardHeader>
           <CardContent>
@@ -308,11 +357,13 @@ function buildSearchParams(params: {
   days?: string;
   user?: string;
   units?: string;
+  surface?: string;
 }): string {
   const sp = new URLSearchParams();
   if (params.days) sp.set("days", params.days);
   if (params.user) sp.set("user", params.user);
   if (params.units) sp.set("units", params.units);
+  if (params.surface) sp.set("surface", params.surface);
   const q = sp.toString();
   return q ? `?${q}` : "";
 }

--- a/src/app/dashboard/repos/page.test.tsx
+++ b/src/app/dashboard/repos/page.test.tsx
@@ -25,6 +25,7 @@ const dal = {
   getCostByTicket: vi.fn(),
   getEarliestActivity: vi.fn(),
   getOrgMembers: vi.fn(),
+  getKnownSurfaces: vi.fn(),
 };
 vi.mock("@/lib/dal", () => dal);
 
@@ -66,6 +67,7 @@ beforeEach(() => {
   ]);
   dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
   dal.getOrgMembers.mockReset().mockResolvedValue([]);
+  dal.getKnownSurfaces.mockReset().mockResolvedValue(["cursor", "vscode"]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -6,6 +6,7 @@ import {
   getCostByTicket,
   getEarliestActivity,
   getOrgMembers,
+  getKnownSurfaces,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
@@ -15,6 +16,7 @@ import { fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
+import { SurfaceFilter, parseSurfaceParam } from "@/components/surface-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { COST_BAR_CHART_MAX_ITEMS } from "@/components/charts/cost-bar-chart-config";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -22,25 +24,32 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function ReposPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; user?: string; units?: string }>;
+  searchParams: Promise<{
+    days?: string;
+    user?: string;
+    units?: string;
+    surface?: string;
+  }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
 
   const unit = parseUnit(params.units);
-  const scope = { scopedUserId: params.user || null };
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { scopedUserId: params.user || null, surfaces };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
       ? await getEarliestActivity(user, scope)
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [repos, branches, tickets, members] = await Promise.all([
+  const [repos, branches, tickets, members, knownSurfaces] = await Promise.all([
     getCostByRepo(user, range, scope),
     getCostByBranch(user, range, scope),
     getCostByTicket(user, range, scope),
     user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
+    getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
   ]);
 
   const isTokens = unit === "tokens";
@@ -112,6 +121,7 @@ export default async function ReposPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <SurfaceFilter surfaces={knownSurfaces} />
             <UnitsSelector />
             <PeriodSelector />
           </div>

--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -68,6 +68,7 @@ const SESSION = {
   total_cost_cents: 250,
   main_model: "claude-opus-4-7-20260101",
   owner_name: "Jane Smith",
+  surface: "vscode",
 };
 
 beforeEach(() => {

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   formatProvider,
   repoName,
 } from "@/lib/format";
+import { formatSurface } from "@/components/surface-filter";
 
 /**
  * Session detail page (#99). The id segment is the daemon-emitted
@@ -92,6 +93,7 @@ export default async function SessionDetailPage({
               <Field label="Member" value={session.owner_name ?? "-"} />
             )}
             <Field label="Provider" value={formatProvider(session.provider)} />
+            <Field label="Surface" value={formatSurface(session.surface)} />
             <Field
               label="Model"
               value={

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -32,6 +32,7 @@ const dal = {
   getEarliestActivity: vi.fn(),
   getOrgMembers: vi.fn(),
   getSessions: vi.fn(),
+  getKnownSurfaces: vi.fn(),
   SESSIONS_PAGE_SIZE: 50,
 };
 vi.mock("@/lib/dal", () => dal);
@@ -76,6 +77,7 @@ beforeEach(() => {
         total_cost_cents: 250,
         main_model: "claude-opus-4-7-20260101",
         owner_name: "Ivan",
+        surface: "vscode",
       },
       {
         // Older daemon (#140): no main_model on the wire, column NULL in the
@@ -96,10 +98,12 @@ beforeEach(() => {
         total_cost_cents: 30,
         main_model: null,
         owner_name: "Jane",
+        surface: "cursor",
       },
     ],
     nextCursor: null,
   });
+  dal.getKnownSurfaces.mockReset().mockResolvedValue(["cursor", "vscode"]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {
@@ -190,5 +194,34 @@ describe("dashboard/sessions /page", () => {
     dal.getCurrentUser.mockResolvedValue({ ...MANAGER, org_id: null });
     const node = await render();
     expect(node).toBeNull();
+  });
+
+  it("surface filter: ?surface=vscode threads the search-param into getSessions so the table narrows to one surface (#187)", async () => {
+    await render({ surface: "vscode" });
+    const lastCall = dal.getSessions.mock.calls.at(-1);
+    expect(lastCall).toBeTruthy();
+    // getSessions(user, range, scope, pagination) — scope is index 2.
+    expect(lastCall![2]).toMatchObject({ surfaces: ["vscode"] });
+  });
+
+  it("surface column: rendered when the org has 2+ surfaces, hidden when only one (#187)", async () => {
+    // Multi-surface org: column header + per-row cells render the formatted
+    // surface label, not the raw daemon id.
+    let node = await render();
+    let text = extractText(node);
+    expect(text).toContain("Surface");
+    expect(text).toContain("VS Code");
+    expect(text).toContain("Cursor");
+
+    // Single-surface org: column collapses out so every row doesn't repeat
+    // the same value.
+    dal.getKnownSurfaces.mockResolvedValue(["vscode"]);
+    node = await render();
+    text = extractText(node);
+    // Surface table-header text is gone (the `Provider` / `Model` / `Started`
+    // headers still render, so a contains-check on them isn't useful here).
+    // Use a regex tied to the cell column-header position to avoid matching
+    // unrelated copy.
+    expect(text).not.toMatch(/Provider.*Model.*Surface/);
   });
 });

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import {
   getCurrentUser,
   getEarliestActivity,
+  getKnownSurfaces,
   getOrgMembers,
   getSessions,
   SESSIONS_PAGE_SIZE,
@@ -26,6 +27,11 @@ import {
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
+import {
+  SurfaceFilter,
+  formatSurface,
+  parseSurfaceParam,
+} from "@/components/surface-filter";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 function formatTimestamp(ts: string | null): string {
@@ -56,6 +62,7 @@ export default async function SessionsPage({
     days?: string;
     user?: string;
     units?: string;
+    surface?: string;
     cursor?: string;
     p?: string;
   }>;
@@ -67,7 +74,8 @@ export default async function SessionsPage({
   const unit = parseUnit(params.units);
   const isTokens = unit === "tokens";
   const isManager = user.role === "manager";
-  const scope = { scopedUserId: params.user || null };
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { scopedUserId: params.user || null, surfaces };
   const earliestActivity =
     params.days === ALL_PERIOD_VALUE
       ? await getEarliestActivity(user, scope)
@@ -77,10 +85,12 @@ export default async function SessionsPage({
   const cursor = decodeSessionsCursor(params.cursor);
   const page = parsePage(params.p);
 
-  const [{ rows: sessions, nextCursor }, members] = await Promise.all([
-    getSessions(user, range, scope, { cursor }),
-    isManager ? getOrgMembers(user.org_id) : Promise.resolve([]),
-  ]);
+  const [{ rows: sessions, nextCursor }, members, knownSurfaces] =
+    await Promise.all([
+      getSessions(user, range, scope, { cursor }),
+      isManager ? getOrgMembers(user.org_id) : Promise.resolve([]),
+      getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
+    ]);
 
   const startIndex = (page - 1) * SESSIONS_PAGE_SIZE + 1;
   const endIndex = startIndex + sessions.length - 1;
@@ -95,6 +105,24 @@ export default async function SessionsPage({
   if (params.days) baseParams.set("days", params.days);
   if (params.user) baseParams.set("user", params.user);
   if (params.units) baseParams.set("units", params.units);
+  if (params.surface) baseParams.set("surface", params.surface);
+
+  // Hide the Surface column on single-surface orgs — every row would carry
+  // the same value, which is just visual noise. Once a second surface
+  // appears the column starts rendering automatically (acceptance for #187).
+  const showSurfaceColumn = knownSurfaces.length > 1;
+  // Click-to-filter target for a session-row's surface cell. Preserves the
+  // other active filters; resets cursor / page so the filtered list starts
+  // from the first page rather than wherever the user happened to be.
+  function surfaceFilterHref(surface: string): string {
+    const sp = new URLSearchParams();
+    if (params.days) sp.set("days", params.days);
+    if (params.user) sp.set("user", params.user);
+    if (params.units) sp.set("units", params.units);
+    sp.set("surface", surface);
+    const qs = sp.toString();
+    return qs ? `?${qs}` : "?";
+  }
 
   const newerParams = new URLSearchParams(baseParams);
   // "Newer" returns to the first page — drops cursor and `p`. Browser back
@@ -113,6 +141,7 @@ export default async function SessionsPage({
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
+            <SurfaceFilter surfaces={knownSurfaces} />
             <UnitsSelector />
             <PeriodSelector />
           </div>
@@ -142,6 +171,9 @@ export default async function SessionsPage({
                     )}
                     <th className="pr-3 pb-2 font-medium">Provider</th>
                     <th className="pr-3 pb-2 font-medium">Model</th>
+                    {showSurfaceColumn && (
+                      <th className="pr-3 pb-2 font-medium">Surface</th>
+                    )}
                     <th className="pr-3 pb-2 font-medium">Started</th>
                     <th className="pr-3 pb-2 font-medium">Duration</th>
                     <th className="pr-3 pb-2 font-medium">Repo</th>
@@ -193,6 +225,20 @@ export default async function SessionsPage({
                             {s.main_model ? formatModelName(s.main_model) : "-"}
                           </Link>
                         </td>
+                        {showSurfaceColumn && (
+                          <td
+                            className="text-zinc-400"
+                            title={`Filter to ${formatSurface(s.surface)}`}
+                          >
+                            <Link
+                              href={surfaceFilterHref(s.surface)}
+                              className="block py-2 pr-3 hover:text-zinc-200"
+                              data-testid="session-surface-cell"
+                            >
+                              {formatSurface(s.surface)}
+                            </Link>
+                          </td>
+                        )}
                         <td className="text-zinc-400">
                           <Link href={href} className="block py-2 pr-3">
                             {formatTimestamp(s.started_at)}

--- a/src/app/dashboard/team/page.test.tsx
+++ b/src/app/dashboard/team/page.test.tsx
@@ -34,6 +34,7 @@ const dal = {
   getCostByUser: vi.fn(),
   getEarliestActivity: vi.fn(),
   getTeamActivityByDay: vi.fn(),
+  getKnownSurfaces: vi.fn(),
   UNASSIGNED_USER_ID: "__unassigned__",
 };
 vi.mock("@/lib/dal", () => dal);
@@ -83,6 +84,7 @@ beforeEach(() => {
       output_tokens: 0,
     },
   ]);
+  dal.getKnownSurfaces.mockReset().mockResolvedValue(["cursor", "vscode"]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -5,6 +5,7 @@ import {
   getCostByUser,
   getEarliestActivity,
   getTeamActivityByDay,
+  getKnownSurfaces,
   UNASSIGNED_USER_ID,
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
@@ -14,6 +15,7 @@ import { parseUnit } from "@/lib/units";
 import { fmtCost, fmtNum } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
+import { SurfaceFilter, parseSurfaceParam } from "@/components/surface-filter";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { TeamCountChart } from "@/components/charts/team-count-chart";
 import { CostPerPersonChart } from "@/components/charts/cost-per-person-chart";
@@ -23,7 +25,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 export default async function TeamPage({
   searchParams,
 }: {
-  searchParams: Promise<{ days?: string; units?: string }>;
+  searchParams: Promise<{ days?: string; units?: string; surface?: string }>;
 }) {
   const params = await searchParams;
   const user = await getCurrentUser();
@@ -34,13 +36,18 @@ export default async function TeamPage({
   if (user.role !== "manager") redirect("/dashboard");
 
   const unit = parseUnit(params.units);
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { surfaces };
   const earliestActivity =
-    params.days === ALL_PERIOD_VALUE ? await getEarliestActivity(user) : null;
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [userCosts, teamActivity] = await Promise.all([
-    getCostByUser(user, range),
-    getTeamActivityByDay(user, range),
+  const [userCosts, teamActivity, knownSurfaces] = await Promise.all([
+    getCostByUser(user, range, scope),
+    getTeamActivityByDay(user, range, scope),
+    getKnownSurfaces(user),
   ]);
 
   const isTokens = unit === "tokens";
@@ -89,6 +96,7 @@ export default async function TeamPage({
         <h1 className="text-xl font-bold">Team</h1>
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
+            <SurfaceFilter surfaces={knownSurfaces} />
             <UnitsSelector />
             <PeriodSelector />
           </div>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -19,9 +19,10 @@ import {
 } from "lucide-react";
 
 // Filter params that scope every dashboard page (period switcher, manager
-// teammate filter). The sidebar carries them across navigations so users
-// don't have to re-pick `30d` / `All team` on each page (#172).
-const PRESERVED_PARAMS = ["days", "user"] as const;
+// teammate filter, surface chip from #187). The sidebar carries them across
+// navigations so users don't have to re-pick `30d` / `All team` /
+// `?surface=vscode` on each page (#172).
+const PRESERVED_PARAMS = ["days", "user", "surface"] as const;
 
 /**
  * Build the `?days=…&user=…` suffix to graft onto every sidebar link, dropping

--- a/src/components/surface-filter.tsx
+++ b/src/components/surface-filter.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+
+const ALL_SURFACE_VALUE = "";
+const ALL_SURFACE_LABEL = "All surfaces";
+
+/**
+ * Parse the URL-shaped `?surface=` value into the canonical CSV list. Mirrors
+ * the wire shape from siropkin/budi#702: `?surface=vscode,cursor` →
+ * `["vscode", "cursor"]`. Empty / missing → `[]` (the all-surfaces default).
+ *
+ * Exported so server-side page code can use the same parser without dragging
+ * the `"use client"` chip into a server component.
+ */
+export function parseSurfaceParam(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Header chip that scopes the rest of the dashboard to a single surface
+ * (#187). Mirrors `<UserFilter />` and `<PeriodSelector />`: lifts the URL
+ * into the source of truth so the breakdown queries can read it on the
+ * server without prop drilling.
+ *
+ * The DAL filter accepts a CSV (`?surface=vscode,cursor`) so future
+ * multi-select UIs can ship without a wire-shape change. For v1 the chip
+ * surfaces a single-select dropdown — that covers the "filter to one
+ * surface" use case and matches the existing `<UserFilter />` ergonomics; a
+ * multi-select expansion is a follow-up if the data tells us users want it.
+ *
+ * Hidden when `surfaces` has 0 or 1 entries — a chip that can only filter
+ * to "everything" or "the only thing" adds noise. Once a second surface
+ * appears in the org's data the chip starts rendering automatically.
+ */
+export function SurfaceFilter({ surfaces }: { surfaces: string[] }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  if (surfaces.length < 2) return null;
+
+  const raw = searchParams.get("surface");
+  // The CSV may carry multiple ids from a future multi-select UI; for the v1
+  // single-select chip we display the first match and treat anything else as
+  // "All surfaces" so the dropdown's selection stays in sync with the URL.
+  const parsed = parseSurfaceParam(raw);
+  const current =
+    parsed.length === 1 && surfaces.includes(parsed[0])
+      ? parsed[0]
+      : ALL_SURFACE_VALUE;
+
+  function selectSurface(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === ALL_SURFACE_VALUE) {
+      params.delete("surface");
+    } else {
+      params.set("surface", value);
+    }
+    const qs = params.toString();
+    router.push(qs ? `?${qs}` : "?");
+  }
+
+  return (
+    <label
+      className="flex items-center gap-2 text-sm"
+      data-testid="surface-filter"
+    >
+      <span className="sr-only">Filter by surface</span>
+      <select
+        value={current}
+        onChange={(e) => selectSurface(e.target.value)}
+        className="rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2.5 text-sm font-medium text-zinc-200 transition-colors hover:bg-white/[0.04] focus:outline-none focus:ring-1 focus:ring-white/20"
+      >
+        <option value={ALL_SURFACE_VALUE}>{ALL_SURFACE_LABEL}</option>
+        {surfaces.map((s) => (
+          <option key={s} value={s}>
+            {formatSurface(s)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * Friendly display label for a surface id. Matches what the daemon sends on
+ * the wire (`vscode`, `jetbrains`, …) but title-cased for the chip. Falls
+ * back to the raw id for surfaces we don't have a hand-tuned label for so
+ * a never-before-seen surface still renders rather than a blank entry.
+ */
+export function formatSurface(surface: string | null | undefined): string {
+  // Tolerate the null/undefined seam: pre-#187 daemons didn't emit a surface
+  // and every other code path that consumes a session/rollup has its own
+  // null-fallback. Centralizing the coalesce here means callers never have
+  // to remember to coerce before passing through (and matches the
+  // dashboard's "missing surface displays as Unknown" rule).
+  if (!surface) return "Unknown";
+  switch (surface) {
+    case "vscode":
+      return "VS Code";
+    case "cursor":
+      return "Cursor";
+    case "jetbrains":
+      return "JetBrains";
+    case "terminal":
+      return "Terminal";
+    case "unknown":
+      return "Unknown";
+    default:
+      return surface.charAt(0).toUpperCase() + surface.slice(1);
+  }
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -51,6 +51,29 @@ interface BudiUser {
  */
 export interface ScopeOptions {
   scopedUserId?: string | null;
+  /**
+   * Narrow every aggregation to one or more surfaces (#187), e.g. `['vscode']`
+   * for the JetBrains-vs-VS Code rollout question. `null`, `undefined`, or an
+   * empty array all mean "no filter" — the dashboard's `<SurfaceFilter>` chip
+   * collapses an all-deselected state back to the default rather than zeroing
+   * the page out. The breakdown RPCs treat `NULL p_surfaces` and an empty
+   * array identically (015) so callers don't have to remember which sentinel
+   * to pass.
+   */
+  surfaces?: string[] | null;
+}
+
+/**
+ * Normalize a `ScopeOptions.surfaces` value to the wire shape the RPCs want.
+ * Returns `null` for any "no filter" case; otherwise a deduped, non-empty
+ * array. Centralized so callers can pass a raw URL-derived value without
+ * branching on undefined / [] themselves.
+ */
+function normalizeSurfaces(raw: string[] | null | undefined): string[] | null {
+  if (!raw || raw.length === 0) return null;
+  const trimmed = raw.map((s) => s.trim()).filter((s) => s.length > 0);
+  if (trimmed.length === 0) return null;
+  return Array.from(new Set(trimmed));
 }
 
 /**
@@ -113,6 +136,7 @@ export async function getOverviewStats(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -156,6 +180,7 @@ export async function getDailyActivity(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -208,6 +233,7 @@ export async function getActivityHeatmap(
     p_started_from: range.startedAtFrom,
     p_started_to: range.startedAtTo,
     p_time_zone: timeZone ?? "UTC",
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -247,10 +273,13 @@ export async function getEarliestActivity(
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) return null;
 
-  const { data } = await admin
+  const surfaces = normalizeSurfaces(options?.surfaces);
+  let query = admin
     .from("daily_rollups")
     .select("bucket_day")
-    .in("device_id", deviceIds)
+    .in("device_id", deviceIds);
+  if (surfaces) query = query.in("surface", surfaces);
+  const { data } = await query
     .order("bucket_day", { ascending: true })
     .limit(1)
     .maybeSingle();
@@ -276,7 +305,11 @@ export const UNASSIGNED_USER_ID = "__unassigned__";
  * for the same (user, range), fixing the Overview/Team reconciliation gap
  * described in #15.
  */
-export async function getCostByUser(user: BudiUser, range: DateRange) {
+export async function getCostByUser(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+) {
   const admin = createAdminClient();
 
   // Use the identical device set as `getOverviewStats` so the two pages
@@ -291,6 +324,7 @@ export async function getCostByUser(user: BudiUser, range: DateRange) {
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
   const deviceCostRows = (rows ?? []) as DeviceCostRow[];
@@ -401,7 +435,8 @@ export interface TeamActivityDay {
  */
 export async function getTeamActivityByDay(
   user: BudiUser,
-  range: DateRange
+  range: DateRange,
+  options?: ScopeOptions
 ): Promise<TeamActivityDay[]> {
   const admin = createAdminClient();
   const deviceIds = await getVisibleDeviceIds(admin, user);
@@ -411,6 +446,7 @@ export async function getTeamActivityByDay(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -465,6 +501,7 @@ export async function getDeviceActivityByDay(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -519,6 +556,7 @@ export async function getModelActivityByDay(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -588,6 +626,7 @@ export async function getCostByDevice(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
   const rollups = (rows ?? []) as DeviceCostRow[];
@@ -686,6 +725,7 @@ export async function getCostByModel(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -727,6 +767,7 @@ export async function getCostByRepo(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -766,6 +807,7 @@ export async function getCostByBranch(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -807,6 +849,7 @@ export async function getCostByTicket(
     p_device_ids: deviceIds,
     p_bucket_from: range.bucketFrom,
     p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
   });
   if (error) throw error;
 
@@ -826,6 +869,92 @@ interface TicketCostRow {
   cost_cents: number | string;
   input_tokens?: number | string;
   output_tokens?: number | string;
+}
+
+export interface SurfaceCost {
+  surface: string;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+/**
+ * Cost share by surface for the "Spend by Surface" card on the dashboard
+ * (#187 part 2). Manager sees full org; member sees own devices only
+ * (ADR-0083 §6). `options.scopedUserId` further narrows a manager view to a
+ * single teammate; `options.surfaces` (from the chip) further narrows the
+ * surfaces aggregated over — useful for the "show only `vscode` and
+ * `cursor`" comparison.
+ *
+ * Returned rows include `unknown` whenever a device has rollups from a
+ * pre-bump daemon, matching the issue acceptance ("rows from pre-bump
+ * daemons display as `unknown` and remain in the all-surfaces aggregation").
+ * The empty-state for single-surface orgs (one bar, full width) is the
+ * caller's call — we always return whatever is present in the data.
+ */
+export async function getCostBySurface(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<SurfaceCost[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_cost_by_surface", {
+    p_device_ids: deviceIds,
+    p_bucket_from: range.bucketFrom,
+    p_bucket_to: range.bucketTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as SurfaceCostRow[])
+    .map((r) => ({
+      surface: r.surface,
+      cost_cents: Number(r.cost_cents),
+      input_tokens: Number(r.input_tokens ?? 0),
+      output_tokens: Number(r.output_tokens ?? 0),
+    }))
+    .filter((s) => s.cost_cents > 0 || s.input_tokens + s.output_tokens > 0)
+    .sort((a, b) => b.cost_cents - a.cost_cents);
+}
+
+interface SurfaceCostRow {
+  surface: string;
+  cost_cents: number | string;
+  input_tokens?: number | string;
+  output_tokens?: number | string;
+}
+
+/**
+ * Distinct surfaces with at least one rollup row visible to the viewer.
+ * Powers the `<SurfaceFilter>` chip's options (#187 part 1) — drawn from
+ * data so the day a JetBrains daemon first syncs the chip picks up
+ * `jetbrains` automatically; no hardcoded enum to keep in sync with core.
+ *
+ * Deliberately not range-scoped: a surface that appeared in the org's
+ * history but not in the current period still belongs in the chip so the
+ * "filter to JetBrains" path remains usable after the team migrates off it.
+ * `unknown` is included when present so a manager investigating "rows
+ * without a surface tag" can still drill in.
+ */
+export async function getKnownSurfaces(
+  user: BudiUser,
+  options?: ScopeOptions
+): Promise<string[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_known_surfaces", {
+    p_device_ids: deviceIds,
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as { surface: string }[])
+    .map((r) => r.surface)
+    .filter((s) => typeof s === "string" && s.length > 0);
 }
 
 /**
@@ -877,6 +1006,7 @@ export async function getSessions(
   const pageSize = pagination?.pageSize ?? SESSIONS_PAGE_SIZE;
   const cursor = pagination?.cursor ?? null;
 
+  const surfaces = normalizeSurfaces(options?.surfaces);
   let query = admin
     .from("session_summaries")
     .select("*")
@@ -889,6 +1019,8 @@ export async function getSessions(
     // requests, causing rows to skip or duplicate as the user paginates.
     .order("session_id", { ascending: false })
     .limit(pageSize + 1);
+
+  if (surfaces) query = query.in("surface", surfaces);
 
   if (cursor) {
     // Composite tuple compare: (started_at, session_id) < cursor.
@@ -989,6 +1121,11 @@ export interface SessionRow {
   // Not a column on `session_summaries` — joined in by the DAL via
   // `attachOwners`.
   owner_name?: string | null;
+  // Surface dimension (#187). Pre-#187 rows backfill to the literal
+  // `'unknown'`, so the Sessions table column never has a null hole — the
+  // dashboard treats `unknown` as its own bucket and filters/displays
+  // accordingly.
+  surface: string;
   // The schema also has `vital_*` columns (006_session_vitals.sql) but the
   // daemon has never populated them, so the dashboard stopped reading them in
   // #141. Reintroduce typed fields here once budi-core ships vitals on the

--- a/supabase/migrations/014_surface_dimension.sql
+++ b/supabase/migrations/014_surface_dimension.sql
@@ -1,0 +1,49 @@
+-- Surface dimension (#187): track which IDE / CLI ("surface") the daemon was
+-- driving when each rollup or session was recorded — `vscode`, `cursor`,
+-- `jetbrains`, `terminal`, …. Lets the dashboard answer "where is our team
+-- AI-coding?" and lets a manager filter every chart to a single surface for
+-- the rollout-comparison story (siropkin/budi-cloud#187).
+--
+-- The local-side `surface` column lands in budi-core via siropkin/budi#701
+-- and the canonical wire shape is defined by siropkin/budi#702. Cloud is
+-- forward-compatible: until core starts sending `surface`, every rollup /
+-- session row backfills to the literal `'unknown'` and all-surface
+-- aggregations keep their existing answer.
+--
+-- Why `'unknown'` (not NULL):
+--   1. The PK on `daily_rollups` has to extend to include `surface` so two
+--      surfaces on the same `(device, day, role, provider, model, repo,
+--      branch)` combo don't UPSERT-collide. PK columns must be NOT NULL, so
+--      we pick a literal sentinel that round-trips cleanly through PostgREST
+--      and matches the dashboard's "rows from pre-bump daemons display as
+--      unknown" rule from the ticket.
+--   2. Filtering becomes a simple `surface = ANY(p_surfaces)` rather than a
+--      `(surface IS NULL OR surface = ANY(...))` disjunction every RPC has to
+--      remember.
+--
+-- Sessions are 1:1 with `(device_id, session_id)` — surface is a property of
+-- the session itself, not a partitioning dimension. We still default to
+-- `'unknown'` for symmetry with `daily_rollups` so DAL filters never have to
+-- branch on null vs. literal.
+
+-- ============================================================
+-- 1. daily_rollups
+-- ============================================================
+ALTER TABLE daily_rollups
+    ADD COLUMN surface TEXT NOT NULL DEFAULT 'unknown';
+
+-- Extend the PK so a daemon that ships rollups from two surfaces on the same
+-- (device, day, role, provider, model, repo, branch) combo doesn't have one
+-- silently overwrite the other on UPSERT. Existing rows backfill to
+-- 'unknown', so no PK collision is possible during the constraint swap.
+ALTER TABLE daily_rollups DROP CONSTRAINT daily_rollups_pkey;
+ALTER TABLE daily_rollups
+    ADD CONSTRAINT daily_rollups_pkey PRIMARY KEY (
+        device_id, bucket_day, role, provider, model, repo_id, git_branch, surface
+    );
+
+-- ============================================================
+-- 2. session_summaries
+-- ============================================================
+ALTER TABLE session_summaries
+    ADD COLUMN surface TEXT NOT NULL DEFAULT 'unknown';

--- a/supabase/migrations/015_surface_filter_rpcs.sql
+++ b/supabase/migrations/015_surface_filter_rpcs.sql
@@ -1,0 +1,488 @@
+-- Plumb the new `surface` dimension (#187, migration 014) through every
+-- dashboard breakdown RPC, plus add two new RPCs the surface UI needs:
+--
+--   * `dashboard_cost_by_surface`   — powers the "Spend by Surface" card on
+--     the Overview page.
+--   * `dashboard_known_surfaces`    — populates the `<SurfaceFilter>` chip's
+--     options from the data, not a hardcoded enum, so the day a JetBrains
+--     daemon first syncs the org's filter chip picks it up automatically.
+--
+-- Filter contract: every RPC takes a new `p_surfaces TEXT[]` parameter. NULL
+-- means "no filter" (existing behaviour); a non-NULL array narrows aggregation
+-- to the listed surfaces. We deliberately treat the empty array the same as
+-- NULL so a chip whose user deselected every option doesn't "filter to no
+-- surfaces and zero everything out" — that state is logically equivalent to
+-- the all-surfaces default.
+--
+-- Postgres rule: `CREATE OR REPLACE FUNCTION` cannot change a function's
+-- argument list (signature is part of identity), so we DROP the old shape
+-- first. The next CREATE re-establishes each RPC with the wider signature.
+
+DROP FUNCTION IF EXISTS public.dashboard_overview_stats(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_daily_activity(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_device(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_model(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_repo(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_branch(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_ticket(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_team_activity_by_day(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_device_activity_by_day(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_model_activity_by_day(TEXT[], DATE, DATE);
+DROP FUNCTION IF EXISTS public.dashboard_activity_heatmap(TEXT[], TIMESTAMPTZ, TIMESTAMPTZ, TEXT);
+
+-- ============================================================
+-- Overview totals
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_overview_stats(
+    p_device_ids   TEXT[],
+    p_bucket_from  DATE,
+    p_bucket_to    DATE,
+    p_surfaces     TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    total_cost_cents     NUMERIC,
+    total_input_tokens   BIGINT,
+    total_output_tokens  BIGINT,
+    total_messages       BIGINT,
+    total_sessions       BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH r AS (
+        SELECT
+            COALESCE(SUM(cost_cents), 0)             AS total_cost_cents,
+            COALESCE(SUM(input_tokens), 0)::BIGINT   AS total_input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT  AS total_output_tokens,
+            COALESCE(SUM(message_count), 0)::BIGINT  AS total_messages
+        FROM daily_rollups
+        WHERE device_id = ANY(p_device_ids)
+          AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+          AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+               OR surface = ANY(p_surfaces))
+    ),
+    s AS (
+        SELECT COUNT(*)::BIGINT AS total_sessions
+        FROM session_summaries
+        WHERE device_id = ANY(p_device_ids)
+          AND COALESCE(started_at, ended_at, synced_at)::date
+              BETWEEN p_bucket_from AND p_bucket_to
+          AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+               OR surface = ANY(p_surfaces))
+    )
+    SELECT r.total_cost_cents, r.total_input_tokens, r.total_output_tokens,
+           r.total_messages, s.total_sessions
+    FROM r, s;
+$$;
+
+-- ============================================================
+-- Daily activity series
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_daily_activity(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    bucket_day     DATE,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT,
+    cost_cents     NUMERIC,
+    message_count  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        SUM(input_tokens)::BIGINT     AS input_tokens,
+        SUM(output_tokens)::BIGINT    AS output_tokens,
+        SUM(cost_cents)               AS cost_cents,
+        SUM(message_count)::BIGINT    AS message_count
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;
+
+-- ============================================================
+-- Per-device breakdown (Devices, Team-by-user via JS join)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_device(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    device_id      TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        device_id,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY device_id;
+$$;
+
+-- ============================================================
+-- Per-(provider, model) breakdown
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_model(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    provider       TEXT,
+    model          TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        provider,
+        model,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY provider, model;
+$$;
+
+-- ============================================================
+-- Per-repo breakdown
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_repo(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    repo_id        TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        repo_id,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY repo_id;
+$$;
+
+-- ============================================================
+-- Per-(repo, branch) breakdown
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_branch(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    repo_id        TEXT,
+    git_branch     TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        repo_id,
+        git_branch,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY repo_id, git_branch;
+$$;
+
+-- ============================================================
+-- Per-ticket breakdown (rows with ticket IS NULL still excluded)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_ticket(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    ticket         TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        ticket,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND ticket IS NOT NULL
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY ticket;
+$$;
+
+-- ============================================================
+-- Team activity per day (#127)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_team_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    bucket_day      DATE,
+    active_members  BIGINT,
+    cost_cents      NUMERIC,
+    input_tokens    BIGINT,
+    output_tokens   BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        r.bucket_day,
+        COUNT(DISTINCT d.user_id)::BIGINT AS active_members,
+        SUM(r.cost_cents)                 AS cost_cents,
+        SUM(r.input_tokens)::BIGINT       AS input_tokens,
+        SUM(r.output_tokens)::BIGINT      AS output_tokens
+    FROM daily_rollups r
+    JOIN devices d ON d.id = r.device_id
+    WHERE r.device_id = ANY(p_device_ids)
+      AND r.bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR r.surface = ANY(p_surfaces))
+    GROUP BY r.bucket_day
+    ORDER BY r.bucket_day ASC;
+$$;
+
+-- ============================================================
+-- Device activity per day (#145)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_device_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    bucket_day      DATE,
+    active_devices  BIGINT,
+    cost_cents      NUMERIC,
+    input_tokens    BIGINT,
+    output_tokens   BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        COUNT(DISTINCT device_id)::BIGINT AS active_devices,
+        SUM(cost_cents)                   AS cost_cents,
+        SUM(input_tokens)::BIGINT         AS input_tokens,
+        SUM(output_tokens)::BIGINT        AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;
+
+-- ============================================================
+-- Model activity per day (#147)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_model_activity_by_day(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    bucket_day     DATE,
+    active_models  BIGINT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        COUNT(DISTINCT (provider, model))::BIGINT AS active_models,
+        SUM(cost_cents)                            AS cost_cents,
+        SUM(input_tokens)::BIGINT                  AS input_tokens,
+        SUM(output_tokens)::BIGINT                 AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;
+
+-- ============================================================
+-- Activity heatmap (#150)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_activity_heatmap(
+    p_device_ids     TEXT[],
+    p_started_from   TIMESTAMPTZ,
+    p_started_to     TIMESTAMPTZ,
+    p_time_zone      TEXT,
+    p_surfaces       TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    dow            INT,
+    hour           INT,
+    session_count  BIGINT,
+    cost_cents     NUMERIC
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        EXTRACT(DOW  FROM started_at AT TIME ZONE p_time_zone)::INT  AS dow,
+        EXTRACT(HOUR FROM started_at AT TIME ZONE p_time_zone)::INT  AS hour,
+        COUNT(*)::BIGINT                                              AS session_count,
+        COALESCE(SUM(total_cost_cents), 0)                            AS cost_cents
+    FROM session_summaries
+    WHERE device_id = ANY(p_device_ids)
+      AND started_at IS NOT NULL
+      AND started_at >= p_started_from
+      AND started_at <= p_started_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY 1, 2
+    ORDER BY 1, 2;
+$$;
+
+-- ============================================================
+-- New: cost share by surface (#187 part 2 — "Spend by Surface" card)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_cost_by_surface(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    surface        TEXT,
+    cost_cents     NUMERIC,
+    input_tokens   BIGINT,
+    output_tokens  BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        surface,
+        SUM(cost_cents)              AS cost_cents,
+        SUM(input_tokens)::BIGINT    AS input_tokens,
+        SUM(output_tokens)::BIGINT   AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY surface;
+$$;
+
+-- ============================================================
+-- New: distinct surfaces present in the org's data (#187 part 1 —
+-- populates the `<SurfaceFilter>` chip's options without a hardcoded enum).
+-- We deliberately do NOT range-filter the lookup: if a surface ever appeared
+-- for this org we want to keep it in the chip even when the current period
+-- has no rows for it, so the "Filter to JetBrains" history still works after
+-- the team migrates off it.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dashboard_known_surfaces(
+    p_device_ids  TEXT[]
+)
+RETURNS TABLE (
+    surface  TEXT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT DISTINCT surface
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+    ORDER BY surface ASC;
+$$;


### PR DESCRIPTION
## Summary

Implements [#187](https://github.com/siropkin/budi-cloud/issues/187): surface (`vscode`, `cursor`, `jetbrains`, `terminal`, …) the IDE / CLI driving each rollup or session, then exposes that dimension via:

1. **Global `<SurfaceFilter>` chip** beside `<UserFilter>` on every dashboard page. Auto-hidden on single-surface orgs; options populated from the data via `dashboard_known_surfaces`, never a hardcoded enum.
2. **"Spend by Surface" card** on Overview — horizontal-bar split of cost share. Empty-state copy on single-surface orgs names the next-state condition.
3. **Surface column** on the Sessions table (click-to-filter sets `?surface=`). Session detail page surfaces it in the metadata strip.

## Wire shape

- URL: `?surface=vscode` (single) or `?surface=vscode,cursor` (CSV multi).
- DAL: `ScopeOptions.surfaces` threads through every breakdown helper; `null` / `[]` = no filter.
- RPCs: each breakdown gains a `p_surfaces TEXT[] DEFAULT NULL` parameter; new `dashboard_cost_by_surface` + `dashboard_known_surfaces`.
- Schema: `surface TEXT NOT NULL DEFAULT 'unknown'` on `daily_rollups` (extending the PK so two surfaces don't UPSERT-collide) and `session_summaries`. Pre-#187 rows backfill to `unknown` and remain in the all-surfaces aggregation.
- Ingest: passes `surface` through `IngestDailyRollup` / `IngestSessionSummary` with a length-cap and `unknown` coalesce.

## Forward compatibility

Cloud lands ahead of `siropkin/budi#701` / `#702`: until core ships `surface` on the wire, every row's value is `'unknown'`, the chip stays hidden (single-surface fallback), and every existing chart returns identical numbers. This PR is therefore mergeable independently of core.

## Test plan

- [x] `npm test` — 237 tests pass (added page-level coverage for the surface filter on Overview, Models, and Sessions, plus regression coverage on existing tests).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: apply migrations 014 + 015 in a Supabase dev project, run `npm run dev`, hit `/dashboard?surface=vscode`, verify every chart narrows to one surface and the Sessions table renders the Surface column.
- [ ] Manual: confirm `?surface=` survives sidebar navigation across `/dashboard/{models,repos,team,devices,sessions}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)