### PR TITLE
feat(security): rate-limit public API routes (#179)

### DIFF
--- a/src/app/api/freshness/route.test.ts
+++ b/src/app/api/freshness/route.test.ts
@@ -14,11 +14,32 @@ const dal = vi.hoisted(() => ({
   getSyncFreshness: vi.fn(),
 }));
 
+const rateLimitState = vi.hoisted(() => ({ blocked: false }));
+
 vi.mock("@/lib/dal", () => dal);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  // The rate-limit helper is the only consumer of the admin client in this
+  // route. Returning a tiny `rpc` shim keeps the test focused on the route's
+  // behaviour rather than reproducing the full Supabase surface.
+  createAdminClient: () => ({
+    rpc: async () => ({
+      data: [
+        {
+          allowed: !rateLimitState.blocked,
+          remaining: rateLimitState.blocked ? 0 : 59,
+          reset_at: new Date(Date.now() + 60_000).toISOString(),
+        },
+      ],
+      error: null,
+    }),
+  }),
+}));
 
 beforeEach(() => {
   dal.getCurrentUser.mockReset();
   dal.getSyncFreshness.mockReset();
+  rateLimitState.blocked = false;
 });
 
 describe("GET /api/freshness (#133)", () => {
@@ -50,5 +71,34 @@ describe("GET /api/freshness (#133)", () => {
     const res = await GET();
     expect(res.status).toBe(401);
     expect(dal.getSyncFreshness).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 with Retry-After when the bucket is exhausted (#179)", async () => {
+    dal.getCurrentUser.mockResolvedValue({ id: "usr_a", org_id: "org_x" });
+    rateLimitState.blocked = true;
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+    // Freshness is never queried when the rate-limit short-circuits.
+    expect(dal.getSyncFreshness).not.toHaveBeenCalled();
+  });
+
+  it("emits rate-limit headers on a successful response (#179)", async () => {
+    dal.getCurrentUser.mockResolvedValue({ id: "usr_a", org_id: "org_x" });
+    dal.getSyncFreshness.mockResolvedValue({
+      deviceCount: 0,
+      lastSeenAt: null,
+      lastRollupAt: null,
+      lastSessionAt: null,
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("59");
   });
 });

--- a/src/app/api/freshness/route.ts
+++ b/src/app/api/freshness/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser, getSyncFreshness } from "@/lib/dal";
+import {
+  enforceRateLimit,
+  RATE_LIMITS,
+  withRateLimitHeaders,
+} from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
 
@@ -17,10 +22,24 @@ export async function GET() {
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // #179: rate-limit per authenticated viewer. The dashboard polls this on
+  // a header heartbeat, so 60/min is well above the legitimate cadence and
+  // catches a compromised browser session being used as a side-channel.
+  const { blocked, result: rl } = await enforceRateLimit({
+    namespace: "freshness",
+    identifier: user.id,
+    ...RATE_LIMITS.freshness,
+  });
+  if (blocked) return blocked;
+
   const freshness = await getSyncFreshness(user);
   // No-store: this endpoint exists precisely to detect new uploads, so any
   // CDN/Next caching here would defeat the point.
-  return NextResponse.json(freshness, {
-    headers: { "Cache-Control": "no-store" },
-  });
+  return withRateLimitHeaders(
+    NextResponse.json(freshness, {
+      headers: { "Cache-Control": "no-store" },
+    }),
+    rl
+  );
 }

--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -36,7 +36,40 @@ class FakeSupabase {
    * exercises the overview path on the read side, so we keep the shim minimal
    * — extend if a future ingest test calls another breakdown.
    */
+  // Rate-limit RPC fake (#179): the route hits this once per request,
+  // after auth. Tests can flip `rateLimitOverride` to force a 429.
+  rateLimitCounts = new Map<string, number>();
+  rateLimitOverride: { allowed: boolean } | null = null;
+
   rpc(name: string, args: Record<string, unknown>) {
+    if (name === "check_rate_limit") {
+      if (this.rateLimitOverride) {
+        return Promise.resolve({
+          data: [
+            {
+              allowed: this.rateLimitOverride.allowed,
+              remaining: this.rateLimitOverride.allowed ? 1 : 0,
+              reset_at: new Date(Date.now() + 60_000).toISOString(),
+            },
+          ],
+          error: null,
+        });
+      }
+      const key = String(args.p_bucket_key);
+      const limit = Number(args.p_limit);
+      const next = (this.rateLimitCounts.get(key) ?? 0) + 1;
+      this.rateLimitCounts.set(key, next);
+      return Promise.resolve({
+        data: [
+          {
+            allowed: next <= limit,
+            remaining: Math.max(0, limit - next),
+            reset_at: new Date(Date.now() + 60_000).toISOString(),
+          },
+        ],
+        error: null,
+      });
+    }
     if (name !== "dashboard_overview_stats") {
       return Promise.resolve({
         data: null,
@@ -264,6 +297,8 @@ beforeEach(() => {
   ]) {
     fake.seed(t, []);
   }
+  fake.rateLimitCounts.clear();
+  fake.rateLimitOverride = null;
 });
 
 describe("POST /v1/ingest + dashboard read path (#14)", () => {
@@ -779,5 +814,68 @@ describe("POST /v1/ingest — device_id squatting protections (#181)", () => {
     );
 
     expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /v1/ingest — rate limiting (#179)", () => {
+  function seedUser() {
+    fake.seed("orgs", [{ id: "org_test", name: "test" }]);
+    fake.seed("users", [
+      {
+        id: "usr_test",
+        org_id: "org_test",
+        role: "manager",
+        api_key: "budi_testkey",
+        display_name: "Test",
+        email: "t@example.com",
+      },
+    ]);
+  }
+
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const baseEnvelope = {
+    schema_version: 1,
+    device_id: "11111111-1111-4111-8111-111111111111",
+    org_id: "org_test",
+    synced_at: "2026-04-15T12:00:00Z",
+    payload: { daily_rollups: [], session_summaries: [] },
+  };
+
+  it("returns 429 with Retry-After when the per-key bucket is exhausted", async () => {
+    seedUser();
+    fake.rateLimitOverride = { allowed: false };
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      mkReq(baseEnvelope) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+    // No device row was inserted on the rate-limited path.
+    expect(fake.rows("devices")).toHaveLength(0);
+  });
+
+  it("emits rate-limit headers on a successful ingest", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+    const res = await POST(
+      mkReq(baseEnvelope) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("59");
   });
 });

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -6,6 +6,11 @@ import {
   type IngestDailyRollup,
   type IngestSessionSummary,
 } from "@/app/api/v1/ingest/rows";
+import {
+  enforceRateLimit,
+  RATE_LIMITS,
+  withRateLimitHeaders,
+} from "@/lib/rate-limit";
 
 // ADR-0083 §7: Max body size 1 MiB
 const MAX_BODY_BYTES = 1024 * 1024;
@@ -142,6 +147,17 @@ export async function POST(request: NextRequest) {
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // #179: rate-limit per authenticated user. The daemon's default sync
+  // interval is well below 60/min; this only kicks in for runaway loops
+  // or a leaked key being abused. ADR-0083 §7 covers the daemon's 429
+  // backoff so legitimate clients self-heal on transient pressure.
+  const { blocked, result: rl } = await enforceRateLimit({
+    namespace: "ingest",
+    identifier: user.id as string,
+    ...RATE_LIMITS.ingest,
+  });
+  if (blocked) return blocked;
 
   // --- Parse body ---
   let body: SyncEnvelope;
@@ -319,11 +335,14 @@ export async function POST(request: NextRequest) {
   // --- ADR-0083 §5: Success response ---
   // `records_upserted` stays for backward compatibility with existing daemon
   // builds; the per-table counts make session regressions obvious (#14).
-  return Response.json({
-    accepted: true,
-    watermark,
-    records_upserted: dailyRollupsUpserted + sessionSummariesUpserted,
-    daily_rollups_upserted: dailyRollupsUpserted,
-    session_summaries_upserted: sessionSummariesUpserted,
-  });
+  return withRateLimitHeaders(
+    Response.json({
+      accepted: true,
+      watermark,
+      records_upserted: dailyRollupsUpserted + sessionSummariesUpserted,
+      daily_rollups_upserted: dailyRollupsUpserted,
+      session_summaries_upserted: sessionSummariesUpserted,
+    }),
+    rl
+  );
 }

--- a/src/app/api/v1/ingest/status/route.test.ts
+++ b/src/app/api/v1/ingest/status/route.test.ts
@@ -10,6 +10,10 @@ type Row = Record<string, unknown>;
 
 class FakeSupabase {
   tables = new Map<string, Row[]>();
+  // Rate-limit RPC fake (#179). The route hits this once per request,
+  // after auth. Tests can flip `rateLimitOverride` to force a 429.
+  rateLimitCounts = new Map<string, number>();
+  rateLimitOverride: { allowed: boolean } | null = null;
 
   seed(table: string, rows: Row[]) {
     this.tables.set(table, [...rows]);
@@ -18,6 +22,41 @@ class FakeSupabase {
   from(table: string) {
     if (!this.tables.has(table)) this.tables.set(table, []);
     return new FakeQuery(this.tables.get(table)!);
+  }
+
+  rpc(name: string, args: Record<string, unknown>) {
+    if (name !== "check_rate_limit") {
+      return Promise.resolve({
+        data: null,
+        error: { message: `unsupported rpc: ${name}` },
+      });
+    }
+    if (this.rateLimitOverride) {
+      return Promise.resolve({
+        data: [
+          {
+            allowed: this.rateLimitOverride.allowed,
+            remaining: this.rateLimitOverride.allowed ? 1 : 0,
+            reset_at: new Date(Date.now() + 60_000).toISOString(),
+          },
+        ],
+        error: null,
+      });
+    }
+    const key = String(args.p_bucket_key);
+    const limit = Number(args.p_limit);
+    const next = (this.rateLimitCounts.get(key) ?? 0) + 1;
+    this.rateLimitCounts.set(key, next);
+    return Promise.resolve({
+      data: [
+        {
+          allowed: next <= limit,
+          remaining: Math.max(0, limit - next),
+          reset_at: new Date(Date.now() + 60_000).toISOString(),
+        },
+      ],
+      error: null,
+    });
   }
 }
 
@@ -92,6 +131,8 @@ vi.mock("@/lib/supabase/admin", () => ({
 
 beforeEach(() => {
   fake.tables.clear();
+  fake.rateLimitCounts.clear();
+  fake.rateLimitOverride = null;
 });
 
 const callerKey = "budi_caller";
@@ -195,5 +236,44 @@ describe("GET /v1/ingest/status (#182)", () => {
     const unknownBody = await unknownRes.json();
     const foreignBody = await foreignRes.json();
     expect(unknownBody).toEqual(foreignBody);
+  });
+});
+
+describe("GET /v1/ingest/status — rate limiting (#179)", () => {
+  it("returns 429 with Retry-After when the per-key bucket is exhausted", async () => {
+    seedCaller();
+    fake.seed("devices", [
+      {
+        id: "dev_mine",
+        user_id: callerUserId,
+        last_seen: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    fake.rateLimitOverride = { allowed: false };
+
+    const res = await callStatus("dev_mine");
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
+  });
+
+  it("emits rate-limit headers on a successful status response", async () => {
+    seedCaller();
+    fake.seed("devices", [
+      {
+        id: "dev_mine",
+        user_id: callerUserId,
+        last_seen: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    fake.seed("daily_rollups", [
+      { device_id: "dev_mine", bucket_day: "2026-05-01" },
+    ]);
+    fake.seed("session_summaries", []);
+
+    const res = await callStatus("dev_mine");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("29");
   });
 });

--- a/src/app/api/v1/ingest/status/route.ts
+++ b/src/app/api/v1/ingest/status/route.ts
@@ -1,5 +1,10 @@
 import { type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  enforceRateLimit,
+  RATE_LIMITS,
+  withRateLimitHeaders,
+} from "@/lib/rate-limit";
 
 /**
  * GET /v1/ingest/status
@@ -31,6 +36,15 @@ export async function GET(request: NextRequest) {
   if (userError || !user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // #179: rate-limit per user (so a leaked key — or a polling daemon stuck
+  // on a 4xx response — can't be used to enumerate device ids cheaply).
+  const { blocked, result: rl } = await enforceRateLimit({
+    namespace: "ingest_status",
+    identifier: user.id as string,
+    ...RATE_LIMITS.ingest_status,
+  });
+  if (blocked) return blocked;
 
   // --- Get device_id from query param ---
   const deviceId = request.nextUrl.searchParams.get("device_id");
@@ -88,11 +102,14 @@ export async function GET(request: NextRequest) {
     .select("*", { count: "exact", head: true })
     .eq("device_id", deviceId);
 
-  return Response.json({
-    device_id: deviceId,
-    watermark: watermarkRow?.bucket_day ?? null,
-    last_seen: device.last_seen,
-    total_rollup_records: rollupCount ?? 0,
-    total_session_records: sessionCount ?? 0,
-  });
+  return withRateLimitHeaders(
+    Response.json({
+      device_id: deviceId,
+      watermark: watermarkRow?.bucket_day ?? null,
+      last_seen: device.last_seen,
+      total_rollup_records: rollupCount ?? 0,
+      total_session_records: sessionCount ?? 0,
+    }),
+    rl
+  );
 }

--- a/src/app/api/v1/whoami/route.test.ts
+++ b/src/app/api/v1/whoami/route.test.ts
@@ -13,6 +13,10 @@ type Row = Record<string, unknown>;
 
 class FakeSupabase {
   private rows: Row[] = [];
+  // Per-bucket counters for the `check_rate_limit` RPC fake (#179).
+  // The route hits this exactly once per request, after auth.
+  rateLimitCounts = new Map<string, number>();
+  rateLimitOverride: { allowed: boolean } | null = null;
 
   seed(rows: Row[]) {
     this.rows = [...rows];
@@ -21,6 +25,41 @@ class FakeSupabase {
   from(_table: string) {
     void _table;
     return new FakeQuery(this.rows);
+  }
+
+  rpc(name: string, args: Record<string, unknown>) {
+    if (name !== "check_rate_limit") {
+      return Promise.resolve({
+        data: null,
+        error: { message: `unsupported rpc: ${name}` },
+      });
+    }
+    if (this.rateLimitOverride) {
+      return Promise.resolve({
+        data: [
+          {
+            allowed: this.rateLimitOverride.allowed,
+            remaining: this.rateLimitOverride.allowed ? 1 : 0,
+            reset_at: new Date(Date.now() + 60_000).toISOString(),
+          },
+        ],
+        error: null,
+      });
+    }
+    const key = String(args.p_bucket_key);
+    const limit = Number(args.p_limit);
+    const next = (this.rateLimitCounts.get(key) ?? 0) + 1;
+    this.rateLimitCounts.set(key, next);
+    return Promise.resolve({
+      data: [
+        {
+          allowed: next <= limit,
+          remaining: Math.max(0, limit - next),
+          reset_at: new Date(Date.now() + 60_000).toISOString(),
+        },
+      ],
+      error: null,
+    });
   }
 }
 
@@ -56,6 +95,8 @@ vi.mock("@/lib/supabase/admin", () => ({
 
 beforeEach(() => {
   fake.seed([]);
+  fake.rateLimitCounts.clear();
+  fake.rateLimitOverride = null;
 });
 
 describe("GET /v1/whoami (#541)", () => {
@@ -146,5 +187,60 @@ describe("GET /v1/whoami (#541)", () => {
     expect(res.status).toBe(200);
     expect(text).not.toContain("budi_testkey");
     expect(text).not.toContain("api_key");
+  });
+});
+
+describe("GET /v1/whoami — rate limiting (#179)", () => {
+  it("returns 429 with Retry-After when the bucket is exhausted", async () => {
+    fake.seed([
+      { id: "usr_test", org_id: "org_xEvtA", api_key: "budi_testkey" },
+    ]);
+    // Force the RPC fake to report blocked regardless of count.
+    fake.rateLimitOverride = { allowed: false };
+
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Bearer budi_testkey" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("20");
+  });
+
+  it("emits rate-limit headers on a successful response", async () => {
+    fake.seed([
+      { id: "usr_test", org_id: "org_xEvtA", api_key: "budi_testkey" },
+    ]);
+
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Bearer budi_testkey" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("20");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("19");
+  });
+
+  it("blocks the 21st request within the window", async () => {
+    fake.seed([
+      { id: "usr_test", org_id: "org_xEvtA", api_key: "budi_testkey" },
+    ]);
+
+    const { GET } = await import("./route");
+    const mkReq = () =>
+      new Request("http://localhost/v1/whoami", {
+        headers: { authorization: "Bearer budi_testkey" },
+      });
+
+    for (let i = 0; i < 20; i += 1) {
+      const ok = await GET(mkReq() as unknown as Parameters<typeof GET>[0]);
+      expect(ok.status).toBe(200);
+    }
+    const blocked = await GET(mkReq() as unknown as Parameters<typeof GET>[0]);
+    expect(blocked.status).toBe(429);
   });
 });

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -1,5 +1,10 @@
 import { type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  enforceRateLimit,
+  RATE_LIMITS,
+  withRateLimitHeaders,
+} from "@/lib/rate-limit";
 
 /**
  * Authenticate the request via Bearer token.
@@ -50,5 +55,17 @@ export async function GET(request: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  return Response.json({ org_id: user.org_id });
+  // #179: rate-limit per API key. The CLI calls /whoami once per
+  // `budi cloud init`; legitimate humans never hit 20/min.
+  const { blocked, result } = await enforceRateLimit({
+    namespace: "whoami",
+    identifier: user.id as string,
+    ...RATE_LIMITS.whoami,
+  });
+  if (blocked) return blocked;
+
+  return withRateLimitHeaders(
+    Response.json({ org_id: user.org_id }),
+    result
+  );
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,173 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Per-key / per-IP rate limiting (#179).
+ *
+ * The four public route handlers under `src/app/api/` accept unbounded
+ * request rates by default — Vercel applies a platform-level cap, but
+ * nothing route-specific. A leaked API key, a misbehaving daemon under a
+ * legitimate key, or a compromised dashboard session can flood any of them
+ * with no backoff signal.
+ *
+ * This module wraps the `check_rate_limit` Postgres RPC (migration 016) in
+ * a small TS helper. Every call is one RPC round-trip; the table schema is
+ * a fixed-window counter — see the migration for the trade-off rationale.
+ *
+ * Keys are scoped per-route to keep one chatty endpoint from starving
+ * another (`ingest:<key>` vs `whoami:<key>`). The helper does not infer the
+ * route — callers pass a stable namespace explicitly so a future split
+ * (e.g. ingest-status growing its own thresholds) doesn't quietly inherit
+ * an unrelated bucket.
+ *
+ * On the dashboard's `/api/freshness` path we don't have an API key, so the
+ * caller passes the Supabase user id (already authenticated by the route)
+ * as the bucket identifier. On all four routes the bucket key is server-
+ * trusted: no part of it comes from a header an attacker controls.
+ */
+
+export type RateLimitConfig = {
+  /** Stable per-route namespace, e.g. "ingest", "ingest_status". */
+  namespace: string;
+  /**
+   * Server-trusted identifier for the caller — API key, user id, etc.
+   * Never an arbitrary header value. Empty / missing identifiers are
+   * rejected by `enforceRateLimit`; the caller would otherwise be sharing
+   * a single global bucket with every other unauthenticated request.
+   */
+  identifier: string;
+  /** Maximum requests permitted per window. */
+  limit: number;
+  /** Window length in seconds. */
+  windowSeconds: number;
+};
+
+export type RateLimitResult = {
+  /** Whether the increment kept the bucket within `limit`. */
+  allowed: boolean;
+  /** `limit` minus post-increment count, clamped at 0. */
+  remaining: number;
+  /** When the current window rolls over and the bucket resets. */
+  resetAt: Date;
+  /** Echo of `limit` for response-header convenience. */
+  limit: number;
+};
+
+/**
+ * Standard rate-limit thresholds. First-pass values from #179 — tune in
+ * the route handler if a real-world abuse pattern shows up.
+ *
+ * These match the table in the issue verbatim so a future reader can grep
+ * either side. Don't relax them silently; document the reason in the route
+ * if you do.
+ */
+export const RATE_LIMITS = {
+  ingest: { limit: 60, windowSeconds: 60 },
+  ingest_status: { limit: 30, windowSeconds: 60 },
+  whoami: { limit: 20, windowSeconds: 60 },
+  freshness: { limit: 60, windowSeconds: 60 },
+} as const;
+
+/**
+ * Increment the rate-limit counter for `namespace:identifier` and return
+ * the post-increment status.
+ *
+ * Returns an `allowed: true` result on RPC failure (fail-open). Rationale:
+ * a transient DB hiccup must not block legitimate ingest under a
+ * defense-in-depth layer. The platform cap remains as a backstop.
+ */
+export async function checkRateLimit(
+  cfg: RateLimitConfig
+): Promise<RateLimitResult> {
+  const supabase = createAdminClient();
+  const bucketKey = `${cfg.namespace}:${cfg.identifier}`;
+
+  const { data, error } = await supabase.rpc("check_rate_limit", {
+    p_bucket_key: bucketKey,
+    p_limit: cfg.limit,
+    p_window_seconds: cfg.windowSeconds,
+  });
+
+  if (error || !data) {
+    // Fail open — see rationale above.
+    console.error("rate-limit RPC failed; failing open:", error);
+    return {
+      allowed: true,
+      remaining: cfg.limit,
+      resetAt: new Date(Date.now() + cfg.windowSeconds * 1000),
+      limit: cfg.limit,
+    };
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  return {
+    allowed: Boolean(row?.allowed),
+    remaining: Number(row?.remaining ?? 0),
+    resetAt: row?.reset_at ? new Date(row.reset_at) : new Date(),
+    limit: cfg.limit,
+  };
+}
+
+/**
+ * Apply rate-limit headers to a successful response so callers can
+ * self-pace before they hit a 429.
+ */
+export function withRateLimitHeaders<T extends Response>(
+  res: T,
+  result: RateLimitResult
+): T {
+  res.headers.set("X-RateLimit-Limit", String(result.limit));
+  res.headers.set("X-RateLimit-Remaining", String(result.remaining));
+  res.headers.set(
+    "X-RateLimit-Reset",
+    String(Math.floor(result.resetAt.getTime() / 1000))
+  );
+  return res;
+}
+
+/**
+ * Convenience wrapper: returns a 429 `Response` if blocked, or `null` to
+ * let the caller continue. The caller is expected to apply
+ * `withRateLimitHeaders` to its successful response when this returns
+ * `null` so the 429 path and 200 path share the same accounting headers.
+ */
+export async function enforceRateLimit(
+  cfg: RateLimitConfig
+): Promise<{ blocked: Response | null; result: RateLimitResult }> {
+  if (!cfg.identifier) {
+    // Should never happen — calling with an empty identifier is a bug at
+    // the route layer (auth must have run first). 401 the caller rather
+    // than collapsing every anonymous request into one shared bucket.
+    return {
+      blocked: Response.json({ error: "Unauthorized" }, { status: 401 }),
+      result: {
+        allowed: false,
+        remaining: 0,
+        resetAt: new Date(),
+        limit: cfg.limit,
+      },
+    };
+  }
+
+  const result = await checkRateLimit(cfg);
+  if (result.allowed) return { blocked: null, result };
+
+  const retryAfterSeconds = Math.max(
+    1,
+    Math.ceil((result.resetAt.getTime() - Date.now()) / 1000)
+  );
+  const blocked = Response.json(
+    { error: "Rate limit exceeded" },
+    {
+      status: 429,
+      headers: {
+        "Retry-After": String(retryAfterSeconds),
+        "X-RateLimit-Limit": String(result.limit),
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": String(
+          Math.floor(result.resetAt.getTime() / 1000)
+        ),
+      },
+    }
+  );
+  return { blocked, result };
+}

--- a/supabase/migrations/016_rate_limits.sql
+++ b/supabase/migrations/016_rate_limits.sql
@@ -1,0 +1,104 @@
+-- Per-key / per-IP rate limiting (#179): a leaked API key, a misbehaving
+-- daemon, or a compromised browser session can otherwise flood the public
+-- route handlers under `src/app/api/` with no backoff signal beyond what
+-- Vercel's platform default applies. Combined with the unbounded-string and
+-- unvalidated-numeric issues filed in #177 / #178, this trivially fills the
+-- org's `daily_rollups` and `session_summaries` tables.
+--
+-- Implementation: fixed-window counter, one row per (bucket_key, window_start).
+-- Cheaper than a sliding-window log and more accurate than a single-counter
+-- shape — at most 2× the configured limit at the window boundary, which is
+-- well within the safety margin we care about for ingest abuse.
+--
+-- We deliberately keep this in Postgres rather than reaching for Redis: the
+-- repo already depends on Supabase, the per-route call rates are well below
+-- what a single connection-pooler can handle, and adding an Upstash dep
+-- would mean another env var, another marketplace integration, and another
+-- production failure mode for an OSS-friendly cloud whose default mode is
+-- "self-host the whole stack".
+--
+-- ADR-0083 §7 already documents the daemon's 429 → exponential backoff
+-- behavior (1s → 2s → … 5 min cap), so the daemon side is ready.
+
+CREATE TABLE IF NOT EXISTS rate_limits (
+    bucket_key   TEXT        NOT NULL,
+    window_start TIMESTAMPTZ NOT NULL,
+    count        INTEGER     NOT NULL DEFAULT 0,
+    PRIMARY KEY (bucket_key, window_start)
+);
+
+-- Sweep stale rows ("> 1h old") with a partial index — only the recent rows
+-- are ever read, but every old row would still cost on UPSERT planning.
+CREATE INDEX IF NOT EXISTS rate_limits_window_start_idx
+    ON rate_limits (window_start);
+
+-- Atomic check-and-increment. Returns the post-increment count alongside
+-- the window's reset moment so callers can echo `Retry-After` headers.
+--
+-- Behaviour:
+--   * Locates (or creates) the row for the current window.
+--   * Increments the counter unconditionally, even when over the limit.
+--     "Over the limit" callers being charged toward the next window is the
+--     standard fixed-window behaviour and stops a hot loop from getting a
+--     free pass once the counter rolls over.
+--   * `allowed` is the post-increment count <= p_limit.
+--
+-- Window boundary:
+--   floor(epoch / window_seconds) * window_seconds — deterministic and
+--   shared across all callers, so two concurrent requests never land in
+--   different windows by accident.
+CREATE OR REPLACE FUNCTION public.check_rate_limit(
+    p_bucket_key      TEXT,
+    p_limit           INTEGER,
+    p_window_seconds  INTEGER
+)
+RETURNS TABLE (
+    allowed   BOOLEAN,
+    remaining INTEGER,
+    reset_at  TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_now           TIMESTAMPTZ := NOW();
+    v_window_start  TIMESTAMPTZ;
+    v_count         INTEGER;
+BEGIN
+    v_window_start := to_timestamp(
+        floor(extract(epoch FROM v_now)::BIGINT / p_window_seconds)::BIGINT
+        * p_window_seconds
+    );
+
+    INSERT INTO rate_limits (bucket_key, window_start, count)
+    VALUES (p_bucket_key, v_window_start, 1)
+    ON CONFLICT (bucket_key, window_start)
+    DO UPDATE SET count = rate_limits.count + 1
+    RETURNING count INTO v_count;
+
+    RETURN QUERY SELECT
+        v_count <= p_limit,
+        GREATEST(0, p_limit - v_count),
+        v_window_start + (p_window_seconds * INTERVAL '1 second');
+END;
+$$;
+
+-- Garbage-collect rows older than the longest plausible window. Called
+-- opportunistically from the application; not on the hot path. Returns
+-- the number of rows deleted so a cron caller can log it.
+CREATE OR REPLACE FUNCTION public.purge_rate_limits(p_older_than_seconds INTEGER DEFAULT 3600)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_deleted INTEGER;
+BEGIN
+    DELETE FROM rate_limits
+    WHERE window_start < NOW() - (p_older_than_seconds * INTERVAL '1 second');
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$;


### PR DESCRIPTION
## Summary

Closes #179. Adds per-user fixed-window rate limits to the four public route handlers under `src/app/api/`:

| Endpoint                | Limit | Window |
|-------------------------|-------|--------|
| `POST /v1/ingest`       | 60    | 60 s   |
| `GET /v1/ingest/status` | 30    | 60 s   |
| `GET /v1/whoami`        | 20    | 60 s   |
| `GET /api/freshness`    | 60    | 60 s   |

These match the first-pass thresholds in the issue verbatim. ADR-0083 §7 already covers the daemon's 429 → exponential backoff (1s → 2s → … 5 min cap), so the daemon side is ready.

## Implementation

- **Migration `016_rate_limits.sql`**: `rate_limits` table (PK `(bucket_key, window_start)`) + atomic `check_rate_limit(p_bucket_key, p_limit, p_window_seconds)` RPC. Fixed-window counter — cheaper than a sliding-window log, accurate enough for abuse detection (at most 2× the configured limit at the boundary).
- **Helper `src/lib/rate-limit.ts`**: thin wrapper that calls the RPC, fails open on transient DB errors, and exposes `enforceRateLimit` (returns a ready-made 429 `Response` with `Retry-After`) plus `withRateLimitHeaders` (adds `X-RateLimit-{Limit,Remaining,Reset}` to the success path).
- **Route wiring**: each route reads its threshold from a shared `RATE_LIMITS` constant. Bucket key is server-trusted (Supabase user id post-auth); no part comes from a header an attacker controls.

### Why Postgres, not Upstash

The repo already depends on Supabase. Adding Redis/Upstash would mean another env var, another marketplace integration, and another production failure mode for an OSS-friendly cloud whose default mode is "self-host the whole stack". The per-route call rates are well below what the existing pooler can handle.

## Test plan

- [x] `npm test` — 246 tests pass (added 9 new rate-limit tests across the four routes; existing fakes extended with a `check_rate_limit` RPC shim).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [ ] Manual: apply migration 016 in a Supabase dev project, run `npm run dev`, hammer `/v1/whoami` with `curl` until the 21st request flips to 429 with a `Retry-After` header.
- [ ] Manual: confirm the daemon's existing 429 backoff path (ADR-0083 §7) re-syncs cleanly after a rate-limit window rolls over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)