### PR TITLE
fix(ingest): validate numeric metric ranges (#178)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -781,3 +781,217 @@ describe("POST /v1/ingest — device_id squatting protections (#181)", () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe("POST /v1/ingest — numeric metric range guards (#178)", () => {
+  function seedUser() {
+    fake.seed("orgs", [{ id: "org_test", name: "test" }]);
+    fake.seed("users", [
+      {
+        id: "usr_test",
+        org_id: "org_test",
+        role: "manager",
+        api_key: "budi_testkey",
+        display_name: "Test",
+        email: "t@example.com",
+      },
+    ]);
+  }
+
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      // JSON.stringify drops NaN / Infinity to `null`, which our validator
+      // catches anyway — but to exercise the *runtime* guard (not just the
+      // wire-format guard) we also test via the row-builder unit cases below.
+      body: JSON.stringify(body),
+    });
+  }
+
+  const baseRollup = {
+    bucket_day: "2026-04-14",
+    role: "assistant",
+    provider: "claude_code",
+    model: "claude-sonnet-4-5",
+    repo_id: "repo_x",
+    git_branch: "refs/heads/main",
+    ticket: null,
+    message_count: 1,
+    input_tokens: 1,
+    output_tokens: 1,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    cost_cents: 1,
+  };
+
+  const baseEnvelope = {
+    schema_version: 1,
+    device_id: "11111111-1111-4111-8111-111111111111",
+    org_id: "org_test",
+    synced_at: "2026-04-15T12:00:00Z",
+    payload: {
+      daily_rollups: [baseRollup],
+      session_summaries: [],
+    },
+  };
+
+  it("rejects a rollup with negative cost_cents with 422", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        payload: {
+          daily_rollups: [{ ...baseRollup, cost_cents: -1 }],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/daily_rollups\[0\]\.cost_cents/);
+    // No row landed in either table — the envelope was rejected outright.
+    expect(fake.rows("daily_rollups")).toHaveLength(0);
+  });
+
+  it("rejects a rollup with non-finite token counts (Infinity)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    // JSON can't carry Infinity literally; build the body string manually so
+    // JSON.parse sees the bare token and the validator runs against the
+    // resulting `Infinity` numeric value.
+    const raw = JSON.stringify({
+      ...baseEnvelope,
+      payload: {
+        daily_rollups: [{ ...baseRollup, input_tokens: 0 }],
+        session_summaries: [],
+      },
+    }).replace('"input_tokens":0', '"input_tokens":1e999');
+
+    const req = new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      body: raw,
+    });
+
+    const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/input_tokens/);
+    expect(fake.rows("daily_rollups")).toHaveLength(0);
+  });
+
+  it("rejects a session summary with a negative total_cost_cents", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        payload: {
+          daily_rollups: [],
+          session_summaries: [
+            {
+              session_id: "s1",
+              provider: "cursor",
+              started_at: "2026-04-14T10:00:00Z",
+              ended_at: "2026-04-14T11:00:00Z",
+              duration_ms: 1,
+              repo_id: null,
+              git_branch: null,
+              ticket: null,
+              message_count: 1,
+              total_input_tokens: 1,
+              total_output_tokens: 1,
+              total_cost_cents: -50,
+            },
+          ],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/session_summaries\[0\]\.total_cost_cents/);
+    expect(fake.rows("session_summaries")).toHaveLength(0);
+  });
+
+  it("caps over-large token counts in stored rollups (defense-in-depth)", async () => {
+    // Direct unit test against the row-builder rather than the route, so we
+    // don't have to fight the route's envelope validator (which would 422
+    // anything implausible). This proves the cap runs even if a future caller
+    // ever skips validation — the database never sees > METRIC_CAPS values.
+    const { buildRollupRows, METRIC_CAPS } = await import("./rows");
+
+    const huge = Number.MAX_SAFE_INTEGER;
+    const rows = buildRollupRows("dev_x", "2026-04-15T12:00:00Z", [
+      { ...baseRollup, input_tokens: huge, cost_cents: huge },
+    ]);
+    expect(rows[0].input_tokens).toBe(METRIC_CAPS.input_tokens);
+    expect(rows[0].cost_cents).toBe(METRIC_CAPS.cost_cents);
+  });
+
+  it("coerces NaN / negative metrics to 0 in the row-builder", async () => {
+    const { buildRollupRows, buildSessionRows } = await import("./rows");
+
+    const rollupRows = buildRollupRows("dev_x", "2026-04-15T12:00:00Z", [
+      {
+        ...baseRollup,
+        message_count: Number.NaN,
+        input_tokens: -1,
+        output_tokens: -Infinity,
+      },
+    ]);
+    expect(rollupRows[0].message_count).toBe(0);
+    expect(rollupRows[0].input_tokens).toBe(0);
+    expect(rollupRows[0].output_tokens).toBe(0);
+
+    const sessionRows = buildSessionRows("dev_x", "2026-04-15T12:00:00Z", [
+      {
+        session_id: "s1",
+        provider: "cursor",
+        message_count: Number.NaN,
+        total_input_tokens: -1,
+        total_output_tokens: 0,
+        total_cost_cents: Number.NaN,
+      },
+    ]);
+    expect(sessionRows[0].message_count).toBe(0);
+    expect(sessionRows[0].total_input_tokens).toBe(0);
+    expect(sessionRows[0].total_cost_cents).toBe(0);
+  });
+
+  it("accepts valid metrics at the upper plausible end", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        payload: {
+          daily_rollups: [
+            {
+              ...baseRollup,
+              input_tokens: 1_000_000,
+              output_tokens: 500_000,
+              cost_cents: 12_345,
+            },
+          ],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    expect(fake.rows("daily_rollups")).toHaveLength(1);
+  });
+});

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -3,6 +3,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import {
   buildRollupRows,
   buildSessionRows,
+  validateIngestMetrics,
   type IngestDailyRollup,
   type IngestSessionSummary,
 } from "@/app/api/v1/ingest/rows";
@@ -112,6 +113,14 @@ function validateEnvelope(body: SyncEnvelope): string | null {
   if (!Array.isArray(body.payload.session_summaries)) {
     return "payload.session_summaries must be an array";
   }
+  // #178: reject the whole envelope on non-finite or negative numeric metrics
+  // so a misbehaving daemon pauses (ADR-0083 §7) instead of silently
+  // poisoning every aggregate that touches the row for the 90-day window.
+  const metricError = validateIngestMetrics(
+    body.payload.daily_rollups,
+    body.payload.session_summaries
+  );
+  if (metricError) return metricError;
   return null;
 }
 

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -54,6 +54,102 @@ function normalizeVitalMetric(raw: unknown): number | null {
   return Number.isFinite(raw) ? raw : null;
 }
 
+/**
+ * Per-field upper bounds for the headline metric columns (#178).
+ *
+ * Token columns are BIGINT (`001_ingest_schema.sql`) but a single rollup row
+ * representing more than 10 billion tokens is almost certainly a bug — real
+ * heavy-user rollups land in the millions. Capping silently here prevents a
+ * single corrupt envelope from poisoning the auto-ranged dashboard charts for
+ * the full 90-day retention window, while a strict validator (see
+ * `validateIngestMetrics`) rejects obviously malformed inputs (NaN/-Inf) with
+ * 422 so the daemon backs off instead of looping.
+ *
+ * `cost_cents` is `NUMERIC(12,4)` (max ≈ 1e8 before overflow), so its cap is
+ * tighter than the suggested 1e9 in #178 — a single rollup row at $1M of cost
+ * is already well past the bug horizon.
+ */
+export const METRIC_CAPS = {
+  message_count: 1e7,
+  input_tokens: 1e10,
+  output_tokens: 1e10,
+  cache_creation_tokens: 1e10,
+  cache_read_tokens: 1e10,
+  cost_cents: 1e8,
+  total_input_tokens: 1e10,
+  total_output_tokens: 1e10,
+  total_cost_cents: 1e8,
+} as const;
+
+/**
+ * Returns true iff `raw` is a finite, non-negative `number`. Used to gate
+ * the headline metric columns at the envelope-validation layer (#178) so a
+ * NaN/-Infinity/negative value triggers a 422 — that's the daemon-pause
+ * signal documented in ADR-0083 §7 — rather than landing as a silent zero.
+ */
+export function isValidNonNegativeNumber(raw: unknown): raw is number {
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 0;
+}
+
+/**
+ * Coerce a numeric metric to `[0, max]`. Defense-in-depth alongside
+ * `validateIngestMetrics`: if the validator misses a path or a future
+ * non-validated field is added, this still floors the value into a sane
+ * range before it reaches the database.
+ */
+function safeNonNegativeNumber(raw: unknown, max: number): number {
+  if (!isValidNonNegativeNumber(raw)) return 0;
+  return Math.min(raw, max);
+}
+
+const ROLLUP_METRIC_FIELDS = [
+  "message_count",
+  "input_tokens",
+  "output_tokens",
+  "cache_creation_tokens",
+  "cache_read_tokens",
+  "cost_cents",
+] as const satisfies ReadonlyArray<keyof IngestDailyRollup>;
+
+const SESSION_METRIC_FIELDS = [
+  "message_count",
+  "total_input_tokens",
+  "total_output_tokens",
+  "total_cost_cents",
+] as const satisfies ReadonlyArray<keyof IngestSessionSummary>;
+
+/**
+ * Walks the envelope's rollups and session summaries, returning a 422-style
+ * error message on the first non-finite or negative numeric metric.
+ *
+ * Per #178: cost and token counts drive every dashboard card and are summed
+ * across the 90-day retention window. A single bad row (NaN, -1, Infinity)
+ * silently corrupts every aggregate that touches it. Reject loudly so the
+ * daemon pauses (ADR-0083 §7) instead of spraying garbage on retry.
+ */
+export function validateIngestMetrics(
+  rollups: IngestDailyRollup[],
+  sessions: IngestSessionSummary[]
+): string | null {
+  for (let i = 0; i < rollups.length; i++) {
+    const r = rollups[i];
+    for (const f of ROLLUP_METRIC_FIELDS) {
+      if (!isValidNonNegativeNumber(r[f])) {
+        return `daily_rollups[${i}].${f} must be a finite, non-negative number`;
+      }
+    }
+  }
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i];
+    for (const f of SESSION_METRIC_FIELDS) {
+      if (!isValidNonNegativeNumber(s[f])) {
+        return `session_summaries[${i}].${f} must be a finite, non-negative number`;
+      }
+    }
+  }
+  return null;
+}
+
 // Cap on the stored surface tag so a malformed envelope can't store an
 // unbounded string and the dashboard's chip dropdown stays readable. Real
 // daemon-side values are short (`vscode`, `jetbrains`, …); 64 is comfortably
@@ -124,12 +220,32 @@ export function buildRollupRows(
     repo_id: r.repo_id,
     git_branch: r.git_branch,
     ticket: r.ticket ?? null,
-    message_count: r.message_count,
-    input_tokens: r.input_tokens,
-    output_tokens: r.output_tokens,
-    cache_creation_tokens: r.cache_creation_tokens,
-    cache_read_tokens: r.cache_read_tokens,
-    cost_cents: r.cost_cents,
+    // #178: every numeric metric is coerced to a finite, non-negative value
+    // capped per `METRIC_CAPS` before storage. The route's
+    // `validateIngestMetrics` already rejects bad inputs with 422; the
+    // coercion here is defense-in-depth so a future ingest path that forgets
+    // to validate still can't corrupt the dashboard's auto-ranging.
+    message_count: safeNonNegativeNumber(
+      r.message_count,
+      METRIC_CAPS.message_count
+    ),
+    input_tokens: safeNonNegativeNumber(
+      r.input_tokens,
+      METRIC_CAPS.input_tokens
+    ),
+    output_tokens: safeNonNegativeNumber(
+      r.output_tokens,
+      METRIC_CAPS.output_tokens
+    ),
+    cache_creation_tokens: safeNonNegativeNumber(
+      r.cache_creation_tokens,
+      METRIC_CAPS.cache_creation_tokens
+    ),
+    cache_read_tokens: safeNonNegativeNumber(
+      r.cache_read_tokens,
+      METRIC_CAPS.cache_read_tokens
+    ),
+    cost_cents: safeNonNegativeNumber(r.cost_cents, METRIC_CAPS.cost_cents),
     surface: normalizeSurface(r.surface),
     synced_at: syncedAt,
   }));
@@ -163,10 +279,25 @@ export function buildSessionRows(
     repo_id: s.repo_id ?? null,
     git_branch: s.git_branch ?? null,
     ticket: s.ticket ?? null,
-    message_count: s.message_count,
-    total_input_tokens: s.total_input_tokens,
-    total_output_tokens: s.total_output_tokens,
-    total_cost_cents: s.total_cost_cents,
+    // #178: see the matching note in `buildRollupRows` — coerce + cap the
+    // headline session metrics so a malformed value can't poison the
+    // dashboard's session-level aggregates.
+    message_count: safeNonNegativeNumber(
+      s.message_count,
+      METRIC_CAPS.message_count
+    ),
+    total_input_tokens: safeNonNegativeNumber(
+      s.total_input_tokens,
+      METRIC_CAPS.total_input_tokens
+    ),
+    total_output_tokens: safeNonNegativeNumber(
+      s.total_output_tokens,
+      METRIC_CAPS.total_output_tokens
+    ),
+    total_cost_cents: safeNonNegativeNumber(
+      s.total_cost_cents,
+      METRIC_CAPS.total_cost_cents
+    ),
     main_model: s.primary_model ?? null,
     // Vitals (#99). Each field is normalized independently so a daemon that
     // emits e.g. only the overall state (or only some vitals) still lands the

--- a/supabase/migrations/016_metric_range_checks.sql
+++ b/supabase/migrations/016_metric_range_checks.sql
@@ -1,0 +1,38 @@
+-- #178: floor the headline metric columns at the database so a future ingest
+-- path that forgets to call `validateIngestMetrics` / the row-builder caps
+-- still can't land negative cost or token counts. The application already
+-- rejects non-finite + negative inputs with 422 (ADR-0083 §7 daemon-pause
+-- signal) and coerces over-large values into `METRIC_CAPS`; these CHECKs are
+-- the last line of defense against silent dashboard corruption over the
+-- 90-day retention window.
+--
+-- Only `>= 0` is enforced here, not the upper caps. The caps live in TypeScript
+-- (`METRIC_CAPS` in `rows.ts`) where they can evolve without a migration —
+-- the column types (BIGINT for tokens, NUMERIC(12,4) for cost_cents) already
+-- bound the upper end at the storage layer. Adding upper-bound CHECKs that
+-- duplicate the application caps would just create a second source of truth
+-- to keep in sync.
+
+ALTER TABLE daily_rollups
+    ADD CONSTRAINT daily_rollups_message_count_nonneg
+        CHECK (message_count >= 0),
+    ADD CONSTRAINT daily_rollups_input_tokens_nonneg
+        CHECK (input_tokens >= 0),
+    ADD CONSTRAINT daily_rollups_output_tokens_nonneg
+        CHECK (output_tokens >= 0),
+    ADD CONSTRAINT daily_rollups_cache_creation_tokens_nonneg
+        CHECK (cache_creation_tokens >= 0),
+    ADD CONSTRAINT daily_rollups_cache_read_tokens_nonneg
+        CHECK (cache_read_tokens >= 0),
+    ADD CONSTRAINT daily_rollups_cost_cents_nonneg
+        CHECK (cost_cents >= 0);
+
+ALTER TABLE session_summaries
+    ADD CONSTRAINT session_summaries_message_count_nonneg
+        CHECK (message_count >= 0),
+    ADD CONSTRAINT session_summaries_total_input_tokens_nonneg
+        CHECK (total_input_tokens >= 0),
+    ADD CONSTRAINT session_summaries_total_output_tokens_nonneg
+        CHECK (total_output_tokens >= 0),
+    ADD CONSTRAINT session_summaries_total_cost_cents_nonneg
+        CHECK (total_cost_cents >= 0);


### PR DESCRIPTION
## Summary

Closes #178. `POST /v1/ingest` previously passed every numeric metric (`cost_cents`, `message_count`, token counts on rollups + session totals) straight through to Supabase with no finite/range checks. A misbehaving daemon — or one running a leaked key — could land negative cost (under-counting Overview) or `Number.MAX_SAFE_INTEGER` (breaking auto-ranged charts) and corrupt every aggregate for the 90-day window.

- **Reject loud:** `validateIngestMetrics` walks both rollup and session arrays and returns a 422 with the offending field's path on the first non-finite or negative metric. Per ADR-0083 §7 the daemon pauses on 422, so this is the right "stop syncing garbage" signal.
- **Defense-in-depth:** `buildRollupRows` / `buildSessionRows` now coerce each metric through `safeNonNegativeNumber(raw, METRIC_CAPS[field])`. A future ingest path that forgets to validate still can't store a negative or implausibly large value. Caps live in TS so they can evolve without a migration; column types already bound the upper end at storage.
- **Database floor:** migration `016_metric_range_checks.sql` adds non-negative `CHECK` constraints on every affected column.
- **Cap rationale:** `1e10` for token counts (10B/row is well past any realistic heavy user); `1e8` for `cost_cents` to fit `NUMERIC(12,4)` — tighter than the issue's suggested `1e9` because the column type already overflows above ≈`1e8`.

## Test plan

- [x] `npx vitest run src/app/api/v1/ingest/route.test.ts` — 18/18 pass, including new cases:
  - rejects negative `cost_cents` with 422 (no row inserted)
  - rejects `Infinity` (`1e999`) `input_tokens` with 422
  - rejects negative `total_cost_cents` on a session summary
  - row-builder caps `Number.MAX_SAFE_INTEGER` to `METRIC_CAPS`
  - row-builder coerces `NaN` / `-1` / `-Infinity` to `0`
  - accepts realistic upper-end values
- [x] Full suite green: `npx vitest run` — 243/243 pass.
- [x] `npx tsc --noEmit` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)