### PR TITLE
feat(security): rate-limit public API routes (#179)

### DIFF
--- a/src/app/api/freshness/route.test.ts
+++ b/src/app/api/freshness/route.test.ts
@@ -16,6 +16,20 @@ const dal = vi.hoisted(() => ({
 
 vi.mock("@/lib/dal", () => dal);
 
+// #179: route now consults the limiter — bypass it in this suite, which
+// tests the auth/freshness contract, not rate-limit behavior (covered in
+// src/lib/rate-limit.test.ts).
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: async () => ({ success: true, retryAfterSeconds: 0 }),
+  rateLimitResponse: () => new Response(null, { status: 429 }),
+  clientIp: () => "127.0.0.1",
+  hashKey: (k: string) => k,
+}));
+
+function makeRequest() {
+  return new Request("http://localhost/api/freshness");
+}
+
 beforeEach(() => {
   dal.getCurrentUser.mockReset();
   dal.getSyncFreshness.mockReset();
@@ -32,7 +46,9 @@ describe("GET /api/freshness (#133)", () => {
     });
 
     const { GET } = await import("./route");
-    const res = await GET();
+    const res = await GET(
+      makeRequest() as unknown as Parameters<typeof GET>[0]
+    );
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toBe("no-store");
     expect(await res.json()).toEqual({
@@ -47,7 +63,9 @@ describe("GET /api/freshness (#133)", () => {
     dal.getCurrentUser.mockResolvedValue(null);
 
     const { GET } = await import("./route");
-    const res = await GET();
+    const res = await GET(
+      makeRequest() as unknown as Parameters<typeof GET>[0]
+    );
     expect(res.status).toBe(401);
     expect(dal.getSyncFreshness).not.toHaveBeenCalled();
   });

--- a/src/app/api/freshness/route.ts
+++ b/src/app/api/freshness/route.ts
@@ -1,7 +1,13 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getCurrentUser, getSyncFreshness } from "@/lib/dal";
+import { clientIp, rateLimit, rateLimitResponse } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
+
+// #179: freshness is polled by the dashboard header badge. The current poll
+// cadence is comfortably under 60/min; the cap exists to bound a compromised
+// browser session abusing the endpoint as a side-channel.
+const RATE_LIMIT = { limit: 60, windowSeconds: 60 } as const;
 
 /**
  * GET /api/freshness
@@ -12,11 +18,32 @@ export const dynamic = "force-dynamic";
  * `renderedRollupAt` and triggers `router.refresh()` only when the daemon
  * has pushed something new (#133).
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  // --- Pre-auth IP rate limit (#179) ---
+  const ipLimit = await rateLimit(
+    `freshness:ip:${clientIp(request)}`,
+    RATE_LIMIT
+  );
+  if (!ipLimit.success) {
+    return rateLimitResponse(ipLimit.retryAfterSeconds);
+  }
+
   const user = await getCurrentUser();
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // --- Per-user rate limit (#179) ---
+  // Once the Supabase session is resolved, switch to a per-user bucket so two
+  // tabs from the same NAT don't share a single IP cap.
+  const userLimit = await rateLimit(
+    `freshness:user:${user.id}`,
+    RATE_LIMIT
+  );
+  if (!userLimit.success) {
+    return rateLimitResponse(userLimit.retryAfterSeconds);
+  }
+
   const freshness = await getSyncFreshness(user);
   // No-store: this endpoint exists precisely to detect new uploads, so any
   // CDN/Next caching here would defeat the point.

--- a/src/app/api/freshness/route.ts
+++ b/src/app/api/freshness/route.ts
@@ -36,10 +36,7 @@ export async function GET(request: NextRequest) {
   // --- Per-user rate limit (#179) ---
   // Once the Supabase session is resolved, switch to a per-user bucket so two
   // tabs from the same NAT don't share a single IP cap.
-  const userLimit = await rateLimit(
-    `freshness:user:${user.id}`,
-    RATE_LIMIT
-  );
+  const userLimit = await rateLimit(`freshness:user:${user.id}`, RATE_LIMIT);
   if (!userLimit.success) {
     return rateLimitResponse(userLimit.retryAfterSeconds);
   }

--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -37,6 +37,15 @@ class FakeSupabase {
    * — extend if a future ingest test calls another breakdown.
    */
   rpc(name: string, args: Record<string, unknown>) {
+    // #179: route now calls rate_limit_check on every request — return a
+    // permissive stub so existing assertions keep exercising the handler
+    // body rather than the 429 short-circuit.
+    if (name === "rate_limit_check") {
+      return Promise.resolve({
+        data: [{ allowed: true, current_count: 1, retry_after_seconds: 60 }],
+        error: null,
+      });
+    }
     if (name !== "dashboard_overview_stats") {
       return Promise.resolve({
         data: null,

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -1,6 +1,12 @@
 import { type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
+  clientIp,
+  hashKey,
+  rateLimit,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
+import {
   buildRollupRows,
   buildSessionRows,
   validateIngestMetrics,
@@ -10,6 +16,12 @@ import {
 
 // ADR-0083 §7: Max body size 1 MiB
 const MAX_BODY_BYTES = 1024 * 1024;
+
+// #179: per-key/per-IP rate limit. Daemon ships hourly by default
+// (ADR-0083 §7) plus retries, so 60/min comfortably covers a healthy fleet
+// while still catching a runaway loop. Bumping this requires re-checking
+// the daily_rollups insert pressure, not just a one-line edit.
+const RATE_LIMIT = { limit: 60, windowSeconds: 60 } as const;
 
 const CURRENT_SCHEMA_VERSION = 1;
 
@@ -142,15 +154,29 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // --- Pre-auth IP rate limit (#179) ---
+  // Apply before the API-key lookup so a brute-force scan against `users.api_key`
+  // can't spend our DB budget. A legitimate daemon hits this from a single IP
+  // and stays well under the cap.
+  const ipLimit = await rateLimit(`ingest:ip:${clientIp(request)}`, RATE_LIMIT);
+  if (!ipLimit.success) return rateLimitResponse(ipLimit.retryAfterSeconds);
+
   // --- Auth ---
   const supabase = createAdminClient();
-  const user = await authenticateApiKey(
-    supabase,
-    request.headers.get("authorization")
-  );
+  const authHeader = request.headers.get("authorization");
+  const user = await authenticateApiKey(supabase, authHeader);
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // --- Per-key rate limit (#179) ---
+  // Authoritative limit for the authenticated path. Bucketed on a hash of the
+  // key so the raw secret never lands in `rate_limits` rows.
+  const keyLimit = await rateLimit(
+    `ingest:key:${hashKey(authHeader!.slice(7))}`,
+    RATE_LIMIT
+  );
+  if (!keyLimit.success) return rateLimitResponse(keyLimit.retryAfterSeconds);
 
   // --- Parse body ---
   let body: SyncEnvelope;

--- a/src/app/api/v1/ingest/status/route.test.ts
+++ b/src/app/api/v1/ingest/status/route.test.ts
@@ -19,6 +19,18 @@ class FakeSupabase {
     if (!this.tables.has(table)) this.tables.set(table, []);
     return new FakeQuery(this.tables.get(table)!);
   }
+
+  // #179: route handler hits `rate_limit_check` before/after auth. Return
+  // permissive results — these tests cover the 401-vs-404 distinction, not
+  // the limiter, which is exercised in src/lib/rate-limit.test.ts.
+  async rpc(_name: string, _args: unknown) {
+    void _name;
+    void _args;
+    return {
+      data: [{ allowed: true, current_count: 1, retry_after_seconds: 60 }],
+      error: null,
+    };
+  }
 }
 
 class FakeQuery {

--- a/src/app/api/v1/ingest/status/route.ts
+++ b/src/app/api/v1/ingest/status/route.ts
@@ -1,5 +1,15 @@
 import { type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  clientIp,
+  hashKey,
+  rateLimit,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
+
+// #179: status endpoint runs three Supabase queries per call and echoes
+// `last_seen` / record counts, so cap polling well below the ingest rate.
+const RATE_LIMIT = { limit: 30, windowSeconds: 60 } as const;
 
 /**
  * GET /v1/ingest/status
@@ -11,6 +21,13 @@ import { createAdminClient } from "@/lib/supabase/admin";
 export async function GET(request: NextRequest) {
   const supabase = createAdminClient();
 
+  // --- Pre-auth IP rate limit (#179) ---
+  const ipLimit = await rateLimit(
+    `ingest_status:ip:${clientIp(request)}`,
+    RATE_LIMIT
+  );
+  if (!ipLimit.success) return rateLimitResponse(ipLimit.retryAfterSeconds);
+
   // --- Auth ---
   const authHeader = request.headers.get("authorization");
   if (!authHeader?.startsWith("Bearer ")) {
@@ -21,6 +38,13 @@ export async function GET(request: NextRequest) {
   if (!apiKey.startsWith("budi_")) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // --- Per-key rate limit (#179) ---
+  const keyLimit = await rateLimit(
+    `ingest_status:key:${hashKey(apiKey)}`,
+    RATE_LIMIT
+  );
+  if (!keyLimit.success) return rateLimitResponse(keyLimit.retryAfterSeconds);
 
   const { data: user, error: userError } = await supabase
     .from("users")

--- a/src/app/api/v1/whoami/route.test.ts
+++ b/src/app/api/v1/whoami/route.test.ts
@@ -22,6 +22,18 @@ class FakeSupabase {
     void _table;
     return new FakeQuery(this.rows);
   }
+
+  // #179: route handler now consults `rate_limit_check` before/after auth.
+  // Tests don't exercise the limiter — return "allowed" so the rest of the
+  // handler can run.
+  async rpc(_name: string, _args: unknown) {
+    void _name;
+    void _args;
+    return {
+      data: [{ allowed: true, current_count: 1, retry_after_seconds: 60 }],
+      error: null,
+    };
+  }
 }
 
 class FakeQuery {

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -1,5 +1,16 @@
 import { type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  clientIp,
+  hashKey,
+  rateLimit,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
+
+// #179: whoami is the auto-bootstrap endpoint for `budi cloud init` — one
+// hit per CLI invocation. 20/min/key is well above any legitimate usage and
+// chokes off a brute-force scan against the api_key column.
+const RATE_LIMIT = { limit: 20, windowSeconds: 60 } as const;
 
 /**
  * Authenticate the request via Bearer token.
@@ -41,14 +52,26 @@ async function authenticateApiKey(
  * No request body; all identity data derives from the key.
  */
 export async function GET(request: NextRequest) {
-  const supabase = createAdminClient();
-  const user = await authenticateApiKey(
-    supabase,
-    request.headers.get("authorization")
+  // --- Pre-auth IP rate limit (#179) ---
+  const ipLimit = await rateLimit(
+    `whoami:ip:${clientIp(request)}`,
+    RATE_LIMIT
   );
+  if (!ipLimit.success) return rateLimitResponse(ipLimit.retryAfterSeconds);
+
+  const supabase = createAdminClient();
+  const authHeader = request.headers.get("authorization");
+  const user = await authenticateApiKey(supabase, authHeader);
   if (!user) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // --- Per-key rate limit (#179) ---
+  const keyLimit = await rateLimit(
+    `whoami:key:${hashKey(authHeader!.slice(7))}`,
+    RATE_LIMIT
+  );
+  if (!keyLimit.success) return rateLimitResponse(keyLimit.retryAfterSeconds);
 
   return Response.json({ org_id: user.org_id });
 }

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -53,10 +53,7 @@ async function authenticateApiKey(
  */
 export async function GET(request: NextRequest) {
   // --- Pre-auth IP rate limit (#179) ---
-  const ipLimit = await rateLimit(
-    `whoami:ip:${clientIp(request)}`,
-    RATE_LIMIT
-  );
+  const ipLimit = await rateLimit(`whoami:ip:${clientIp(request)}`, RATE_LIMIT);
   if (!ipLimit.success) return rateLimitResponse(ipLimit.retryAfterSeconds);
 
   const supabase = createAdminClient();

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #179: rate-limit unit tests. The Postgres counter itself is exercised in
+ * the migration (017), so here we verify the JS wrapper:
+ *   - delegates atomically to the `rate_limit_check` RPC
+ *   - propagates the `allowed` flag and `retry_after_seconds` value
+ *   - fails open when the RPC errors (so a limiter outage doesn't pause the
+ *     fleet via 429 → ADR-0083 §7 daemon backoff)
+ *   - never lands a raw API key in the bucket id
+ */
+
+type RpcArgs = {
+  p_bucket: string;
+  p_limit: number;
+  p_window_seconds: number;
+};
+
+type RpcResult = {
+  data: Array<{
+    allowed: boolean;
+    current_count: number;
+    retry_after_seconds: number;
+  }> | null;
+  error: unknown;
+};
+
+let lastRpc: { name: string; args: RpcArgs } | null = null;
+let nextRpcResult: RpcResult = {
+  data: [{ allowed: true, current_count: 1, retry_after_seconds: 60 }],
+  error: null,
+};
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    rpc: (name: string, args: RpcArgs) => {
+      lastRpc = { name, args };
+      return Promise.resolve(nextRpcResult);
+    },
+  }),
+}));
+
+beforeEach(() => {
+  lastRpc = null;
+  nextRpcResult = {
+    data: [{ allowed: true, current_count: 1, retry_after_seconds: 60 }],
+    error: null,
+  };
+});
+
+describe("rateLimit", () => {
+  it("calls rate_limit_check with the bucket and config", async () => {
+    const { rateLimit } = await import("./rate-limit");
+    const result = await rateLimit("ingest:key:abc123", {
+      limit: 60,
+      windowSeconds: 60,
+    });
+
+    expect(lastRpc?.name).toBe("rate_limit_check");
+    expect(lastRpc?.args).toEqual({
+      p_bucket: "ingest:key:abc123",
+      p_limit: 60,
+      p_window_seconds: 60,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("returns success=false when the RPC reports the cap is exceeded", async () => {
+    nextRpcResult = {
+      data: [{ allowed: false, current_count: 61, retry_after_seconds: 42 }],
+      error: null,
+    };
+    const { rateLimit } = await import("./rate-limit");
+    const result = await rateLimit("ingest:ip:1.2.3.4", {
+      limit: 60,
+      windowSeconds: 60,
+    });
+    expect(result.success).toBe(false);
+    expect(result.retryAfterSeconds).toBe(42);
+  });
+
+  it("fails open when the RPC errors so a limiter outage does not pause ingest", async () => {
+    nextRpcResult = { data: null, error: new Error("rpc unreachable") };
+    const { rateLimit } = await import("./rate-limit");
+    const result = await rateLimit("ingest:ip:1.2.3.4", {
+      limit: 60,
+      windowSeconds: 60,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("fails open on an empty result row (defensive)", async () => {
+    nextRpcResult = { data: [], error: null };
+    const { rateLimit } = await import("./rate-limit");
+    const result = await rateLimit("freshness:user:xyz", {
+      limit: 60,
+      windowSeconds: 60,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("rateLimitResponse", () => {
+  it("returns a 429 with Retry-After at least 1 second", async () => {
+    const { rateLimitResponse } = await import("./rate-limit");
+    const res = rateLimitResponse(0);
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("1");
+  });
+
+  it("propagates the retry_after value when above the floor", async () => {
+    const { rateLimitResponse } = await import("./rate-limit");
+    const res = rateLimitResponse(42);
+    expect(res.headers.get("retry-after")).toBe("42");
+  });
+});
+
+describe("hashKey", () => {
+  it("produces a deterministic 16-hex-char hash that is not the input", async () => {
+    const { hashKey } = await import("./rate-limit");
+    const a = hashKey("budi_secret_token");
+    const b = hashKey("budi_secret_token");
+    expect(a).toBe(b);
+    expect(a).toHaveLength(16);
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(a).not.toContain("secret");
+    expect(a).not.toContain("budi_");
+  });
+});
+
+describe("clientIp", () => {
+  it("prefers the leftmost x-forwarded-for entry", async () => {
+    const { clientIp } = await import("./rate-limit");
+    const req = {
+      headers: new Headers({
+        "x-forwarded-for": "203.0.113.7, 10.0.0.1",
+        "x-real-ip": "10.0.0.1",
+      }),
+    };
+    expect(clientIp(req as never)).toBe("203.0.113.7");
+  });
+
+  it("falls back to x-real-ip", async () => {
+    const { clientIp } = await import("./rate-limit");
+    const req = {
+      headers: new Headers({ "x-real-ip": "198.51.100.4" }),
+    };
+    expect(clientIp(req as never)).toBe("198.51.100.4");
+  });
+
+  it("returns 'unknown' when no proxy headers are set", async () => {
+    const { clientIp } = await import("./rate-limit");
+    const req = { headers: new Headers() };
+    expect(clientIp(req as never)).toBe("unknown");
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,106 @@
+import { createHash } from "node:crypto";
+import { type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * Per-route rate-limit configuration. Thresholds match the first-pass table
+ * from issue #179; tune by editing the route's `RATE_LIMIT` constant rather
+ * than threading new args through `rateLimit()` so the limit lives next to
+ * the handler that enforces it.
+ */
+export type RateLimitConfig = {
+  /** Max requests permitted in the window. */
+  limit: number;
+  /** Window length in seconds. */
+  windowSeconds: number;
+};
+
+export type RateLimitResult = {
+  /** True if the caller is under the limit. */
+  success: boolean;
+  /** Seconds until the window rolls over. Stamped into `Retry-After`. */
+  retryAfterSeconds: number;
+};
+
+/**
+ * Atomically increment the counter for `bucket` and return whether the caller
+ * is still under the configured limit. Backed by `rate_limit_check` (migration
+ * 017): a single UPSERT keeps the read-and-increment atomic across instances.
+ *
+ * Fail-open: if the RPC fails (network, schema drift, etc.) the request is
+ * allowed through and the error is logged. Rate limiting is defense in depth
+ * — auth, payload caps, schema validation, and per-org device caps all still
+ * apply — so a brief limiter outage should not pause every daemon in the
+ * fleet via 429 → ADR-0083 §7 backoff.
+ */
+export async function rateLimit(
+  bucket: string,
+  config: RateLimitConfig
+): Promise<RateLimitResult> {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.rpc("rate_limit_check", {
+    p_bucket: bucket,
+    p_limit: config.limit,
+    p_window_seconds: config.windowSeconds,
+  });
+
+  if (error || !data || !Array.isArray(data) || data.length === 0) {
+    if (error) console.error("rate_limit_check RPC failed:", error);
+    return { success: true, retryAfterSeconds: 0 };
+  }
+
+  const row = data[0] as {
+    allowed: boolean;
+    current_count: number;
+    retry_after_seconds: number;
+  };
+  return {
+    success: row.allowed,
+    retryAfterSeconds: row.retry_after_seconds,
+  };
+}
+
+/**
+ * Build a 429 response with the headers ADR-0083 §7 asks the daemon to
+ * inspect. Use the same shape on every rate-limited route so clients see a
+ * uniform contract.
+ */
+export function rateLimitResponse(retryAfterSeconds: number): Response {
+  return Response.json(
+    { error: "Rate limit exceeded" },
+    {
+      status: 429,
+      headers: { "Retry-After": String(Math.max(1, retryAfterSeconds)) },
+    }
+  );
+}
+
+/**
+ * Best-effort client IP extraction. Vercel sets `x-forwarded-for` and
+ * `x-real-ip`; the leftmost entry of `x-forwarded-for` is the client. Falls
+ * back to `"unknown"` so a missing header still produces a deterministic
+ * bucket (one shared bucket across opaque clients is preferable to no limit
+ * at all when the proxy didn't tag the request).
+ */
+export function clientIp(request: NextRequest): string {
+  const xff = request.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const xri = request.headers.get("x-real-ip");
+  if (xri) return xri.trim();
+  return "unknown";
+}
+
+/**
+ * Hash a Bearer-style API key into a short, stable bucket suffix so the raw
+ * key never appears as a row id in `rate_limits`. The full SHA-256 is
+ * truncated to 16 hex chars — collisions among ~10^9 keys are still
+ * astronomically rare for the tiny set in flight at once, and the bucket
+ * scope (`route + key-hash`) means a collision would only let two specific
+ * keys share a counter for one window.
+ */
+export function hashKey(apiKey: string): string {
+  return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}

--- a/supabase/migrations/017_rate_limits.sql
+++ b/supabase/migrations/017_rate_limits.sql
@@ -75,5 +75,14 @@ END;
 $$;
 
 -- Only the service role calls the RPC (admin client). Lock everyone else out.
+-- The CI dry-run runs on vanilla Postgres without the Supabase-provisioned
+-- `service_role` (mirrors the `auth.uid()` shim above), so guard the GRANT
+-- so we still validate syntax on every PR.
 REVOKE ALL ON FUNCTION rate_limit_check(TEXT, INTEGER, INTEGER) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION rate_limit_check(TEXT, INTEGER, INTEGER) TO service_role;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION rate_limit_check(TEXT, INTEGER, INTEGER) TO service_role';
+    END IF;
+END
+$$;

--- a/supabase/migrations/017_rate_limits.sql
+++ b/supabase/migrations/017_rate_limits.sql
@@ -1,0 +1,79 @@
+-- #179: Postgres-backed fixed-window rate limiter for the public API routes
+-- (`/v1/ingest`, `/v1/ingest/status`, `/v1/whoami`, `/api/freshness`). The
+-- counter lives in Postgres rather than Redis so the cloud doesn't grow a new
+-- runtime dependency just for this — see issue #179 for the trade-off
+-- discussion. ADR-0083 §7 already specs daemon backoff on 429, so the daemon
+-- side handles the response gracefully.
+--
+-- The RPC is wrapped in a single UPSERT so the read-and-increment is atomic
+-- across the Vercel Fluid Compute fleet — no per-instance drift.
+--
+-- Stale rows (one per unique bucket id seen in the last window) are not
+-- explicitly pruned: at the volumes this dashboard sees, a few thousand rows
+-- worth of bookkeeping is cheaper than running a cron. If the table grows
+-- past expectations, add a daily `DELETE FROM rate_limits WHERE
+-- window_start < NOW() - INTERVAL '1 day'` job.
+
+CREATE TABLE rate_limits (
+    bucket          TEXT        PRIMARY KEY,
+    window_start    TIMESTAMPTZ NOT NULL,
+    count           INTEGER     NOT NULL
+);
+
+-- Restrict direct table access to the service-role admin client. Anon and
+-- authenticated PostgREST roles must never read or mutate this table; the
+-- only sanctioned mutation path is `rate_limit_check` below.
+ALTER TABLE rate_limits ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION rate_limit_check(
+    p_bucket            TEXT,
+    p_limit             INTEGER,
+    p_window_seconds    INTEGER
+)
+RETURNS TABLE(
+    allowed                 BOOLEAN,
+    current_count           INTEGER,
+    retry_after_seconds     INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_now           TIMESTAMPTZ := NOW();
+    v_count         INTEGER;
+    v_window_start  TIMESTAMPTZ;
+    v_window_end    TIMESTAMPTZ;
+BEGIN
+    -- Fixed-window counter: when the prior window has elapsed, reset to 1;
+    -- otherwise increment in place. Doing both branches in a single UPSERT
+    -- keeps it atomic — two concurrent calls for the same bucket cannot
+    -- both observe `count = limit` and both pass.
+    INSERT INTO rate_limits (bucket, window_start, count)
+    VALUES (p_bucket, v_now, 1)
+    ON CONFLICT (bucket) DO UPDATE
+        SET count = CASE
+                WHEN rate_limits.window_start + (p_window_seconds || ' seconds')::INTERVAL < v_now
+                    THEN 1
+                ELSE rate_limits.count + 1
+            END,
+            window_start = CASE
+                WHEN rate_limits.window_start + (p_window_seconds || ' seconds')::INTERVAL < v_now
+                    THEN v_now
+                ELSE rate_limits.window_start
+            END
+    RETURNING rate_limits.count, rate_limits.window_start
+        INTO v_count, v_window_start;
+
+    v_window_end := v_window_start + (p_window_seconds || ' seconds')::INTERVAL;
+
+    allowed := v_count <= p_limit;
+    current_count := v_count;
+    retry_after_seconds := GREATEST(0, CEIL(EXTRACT(EPOCH FROM (v_window_end - v_now)))::INTEGER);
+    RETURN NEXT;
+END;
+$$;
+
+-- Only the service role calls the RPC (admin client). Lock everyone else out.
+REVOKE ALL ON FUNCTION rate_limit_check(TEXT, INTEGER, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION rate_limit_check(TEXT, INTEGER, INTEGER) TO service_role;


### PR DESCRIPTION
## Summary

Closes #179. Adds a Postgres-backed fixed-window rate limiter and applies it to every public route under `src/app/api/`.

- New migration `017_rate_limits.sql` — `rate_limits` table + `rate_limit_check(p_bucket, p_limit, p_window_seconds)` PL/pgSQL RPC. The read-and-increment is done in a single atomic UPSERT so concurrent calls can't both observe the count under the cap.
- New `src/lib/rate-limit.ts` — thin wrapper around the RPC plus `clientIp()`, `hashKey()`, and a uniform 429 builder that stamps `Retry-After` (which the daemon already inspects per ADR-0083 §7).
- Routes wired up with the thresholds from #179:

  | Endpoint                  | Limit         | Window |
  | ------------------------- | ------------- | ------ |
  | `POST /v1/ingest`         | 60 requests   | 60 s   |
  | `GET /v1/ingest/status`   | 30 requests   | 60 s   |
  | `GET /v1/whoami`          | 20 requests   | 60 s   |
  | `GET /api/freshness`      | 60 requests   | 60 s   |

Each handler increments a per-IP counter **before** the API-key lookup so a brute-force scan against `users.api_key` can't spend our DB budget, then increments a per-key/per-user counter post-auth. Buckets are scoped by route + IP / keyhash so a leaked key in one route can't exhaust limits for unrelated routes or callers. Raw API keys are SHA-256 hashed before becoming a bucket id, so they never land in `rate_limits`.

## Design notes

- **Why Postgres, not Upstash Redis?** The repo has no Redis dep today and option 3 in the issue was explicitly called out as fine for the volumes here. Postgres-backed is correct across the Vercel Fluid Compute fleet (no per-instance drift) and adds zero new infra.
- **Fail-open on limiter outage.** The RPC wrapper returns `success: true` if the RPC itself errors. Rate limiting is defense in depth — auth, payload caps (#177), metric validation (#178), and per-org device caps (#181) all still apply — so a brief limiter outage should not pause every daemon in the fleet via the 429 → ADR-0083 §7 backoff path.
- **Cleanup.** `rate_limits` is left to grow. At expected volumes this is negligible; the migration documents the cutover query if a daily cleanup ever becomes worthwhile.

## Test plan

- [x] `npm test` — added `src/lib/rate-limit.test.ts` (RPC delegation, fail-open, hashKey privacy, IP extraction, 429 shape). Updated existing route tests so their `FakeSupabase` returns a permissive `rate_limit_check` stub.
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Migration 017 applied to Supabase via the standard CI flow on merge.