### PR TITLE
fix(ingest): cap user-controlled string fields (#177)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -979,6 +979,123 @@ describe("POST /v1/ingest — numeric metric range guards (#178)", () => {
     expect(sessionRows[0].total_cost_cents).toBe(0);
   });
 
+  it("truncates over-long string fields on rollups (#177)", async () => {
+    const { buildRollupRows, STRING_CAPS } = await import("./rows");
+
+    const huge = "A".repeat(50_000);
+    const rows = buildRollupRows("dev_x", "2026-04-15T12:00:00Z", [
+      {
+        ...baseRollup,
+        role: huge,
+        provider: huge,
+        model: huge,
+        repo_id: huge,
+        git_branch: huge,
+        ticket: huge,
+      },
+    ]);
+
+    expect(rows[0].role.length).toBe(STRING_CAPS.role);
+    expect(rows[0].provider.length).toBe(STRING_CAPS.provider);
+    expect(rows[0].model.length).toBe(STRING_CAPS.model);
+    expect(rows[0].repo_id.length).toBe(STRING_CAPS.repo_id);
+    expect(rows[0].git_branch.length).toBe(STRING_CAPS.git_branch);
+    expect((rows[0].ticket as string).length).toBe(STRING_CAPS.ticket);
+  });
+
+  it("truncates over-long string fields on session summaries (#177)", async () => {
+    const { buildSessionRows, STRING_CAPS } = await import("./rows");
+
+    const huge = "B".repeat(50_000);
+    const rows = buildSessionRows("dev_x", "2026-04-15T12:00:00Z", [
+      {
+        session_id: huge,
+        provider: huge,
+        repo_id: huge,
+        git_branch: huge,
+        ticket: huge,
+        primary_model: huge,
+        message_count: 1,
+        total_input_tokens: 1,
+        total_output_tokens: 1,
+        total_cost_cents: 1,
+      },
+    ]);
+
+    expect(rows[0].session_id.length).toBe(STRING_CAPS.session_id);
+    expect(rows[0].provider.length).toBe(STRING_CAPS.provider);
+    expect((rows[0].repo_id as string).length).toBe(STRING_CAPS.repo_id);
+    expect((rows[0].git_branch as string).length).toBe(STRING_CAPS.git_branch);
+    expect((rows[0].ticket as string).length).toBe(STRING_CAPS.ticket);
+    expect((rows[0].main_model as string).length).toBe(STRING_CAPS.model);
+  });
+
+  it("preserves null on nullable string columns when the envelope omits them (#177)", async () => {
+    const { buildRollupRows, buildSessionRows } = await import("./rows");
+
+    const rollup = buildRollupRows("dev_x", "2026-04-15T12:00:00Z", [
+      { ...baseRollup, ticket: null },
+    ]);
+    expect(rollup[0].ticket).toBeNull();
+
+    const session = buildSessionRows("dev_x", "2026-04-15T12:00:00Z", [
+      {
+        session_id: "s1",
+        provider: "cursor",
+        message_count: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost_cents: 0,
+      },
+    ]);
+    expect(session[0].repo_id).toBeNull();
+    expect(session[0].git_branch).toBeNull();
+    expect(session[0].ticket).toBeNull();
+    expect(session[0].main_model).toBeNull();
+  });
+
+  it("end-to-end: 50 KiB strings on every session field land truncated (#177)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+    const { STRING_CAPS } = await import("./rows");
+
+    const huge = "X".repeat(50_000);
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        payload: {
+          daily_rollups: [],
+          session_summaries: [
+            {
+              session_id: huge,
+              provider: huge,
+              started_at: "2026-04-14T10:00:00Z",
+              ended_at: "2026-04-14T11:00:00Z",
+              duration_ms: 1,
+              repo_id: huge,
+              git_branch: huge,
+              ticket: huge,
+              message_count: 1,
+              total_input_tokens: 1,
+              total_output_tokens: 1,
+              total_cost_cents: 1,
+              primary_model: huge,
+            },
+          ],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const [stored] = fake.rows("session_summaries");
+    expect((stored.session_id as string).length).toBe(STRING_CAPS.session_id);
+    expect((stored.provider as string).length).toBe(STRING_CAPS.provider);
+    expect((stored.repo_id as string).length).toBe(STRING_CAPS.repo_id);
+    expect((stored.git_branch as string).length).toBe(STRING_CAPS.git_branch);
+    expect((stored.ticket as string).length).toBe(STRING_CAPS.ticket);
+    expect((stored.main_model as string).length).toBe(STRING_CAPS.model);
+  });
+
   it("accepts valid metrics at the upper plausible end", async () => {
     seedUser();
     const { POST } = await import("./route");

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -157,6 +157,41 @@ export function validateIngestMetrics(
 const MAX_SURFACE_LENGTH = 64;
 
 /**
+ * Per-field upper bounds for the user-controlled string columns ingest writes
+ * (#177). The label cap on `devices.label` (128) lives in `route.ts` and
+ * documents the same intent: a malformed or compromised envelope must not
+ * land hundreds of KiB on a single column, slowing every dashboard query
+ * for the 90-day retention window and overflowing the rendered table cells.
+ *
+ * The numbers track the worst plausible real-world value, not the worst
+ * theoretical one — branch names occasionally embed long ticket slugs but
+ * never approach 256 chars; session ids are typically UUIDs or short
+ * tool-emitted strings well under 128. Migration 018 mirrors these caps as
+ * column-level CHECK constraints so a future ingest path that forgets to
+ * call the row-builder still can't bypass them.
+ */
+export const STRING_CAPS = {
+  session_id: 128,
+  provider: 64,
+  model: 128,
+  role: 32,
+  repo_id: 128,
+  git_branch: 256,
+  ticket: 64,
+} as const;
+
+/**
+ * Truncate a string to `max` chars. Non-string inputs (null, undefined,
+ * numbers, …) pass through unchanged so the existing NOT NULL / type
+ * mismatch error paths still trip — this cap is purely defense-in-depth
+ * against unbounded length, not a coercion layer.
+ */
+function capString<T>(raw: T, max: number): T {
+  if (typeof raw === "string") return raw.slice(0, max) as T;
+  return raw;
+}
+
+/**
  * Normalize the envelope's `surface` value. The cloud column is `NOT NULL
  * DEFAULT 'unknown'` (014), so we coalesce missing / invalid / empty inputs
  * to that literal rather than letting the daemon's omission collapse the
@@ -214,12 +249,14 @@ export function buildRollupRows(
   return rollups.map((r) => ({
     device_id: deviceId,
     bucket_day: r.bucket_day,
-    role: r.role,
-    provider: r.provider,
-    model: r.model,
-    repo_id: r.repo_id,
-    git_branch: r.git_branch,
-    ticket: r.ticket ?? null,
+    // #177: cap every user-controlled string column so a malformed daemon
+    // (or a leaked API key) can't land hundreds of KiB on a single field.
+    role: capString(r.role, STRING_CAPS.role),
+    provider: capString(r.provider, STRING_CAPS.provider),
+    model: capString(r.model, STRING_CAPS.model),
+    repo_id: capString(r.repo_id, STRING_CAPS.repo_id),
+    git_branch: capString(r.git_branch, STRING_CAPS.git_branch),
+    ticket: capString(r.ticket ?? null, STRING_CAPS.ticket),
     // #178: every numeric metric is coerced to a finite, non-negative value
     // capped per `METRIC_CAPS` before storage. The route's
     // `validateIngestMetrics` already rejects bad inputs with 422; the
@@ -271,14 +308,16 @@ export function buildSessionRows(
 ) {
   return sessions.map((s) => ({
     device_id: deviceId,
-    session_id: s.session_id,
-    provider: s.provider,
+    // #177: matches `buildRollupRows` — every user-controlled string is
+    // length-capped before storage. See STRING_CAPS for the per-field bounds.
+    session_id: capString(s.session_id, STRING_CAPS.session_id),
+    provider: capString(s.provider, STRING_CAPS.provider),
     started_at: s.started_at ?? s.ended_at ?? syncedAt,
     ended_at: s.ended_at ?? null,
     duration_ms: s.duration_ms ?? null,
-    repo_id: s.repo_id ?? null,
-    git_branch: s.git_branch ?? null,
-    ticket: s.ticket ?? null,
+    repo_id: capString(s.repo_id ?? null, STRING_CAPS.repo_id),
+    git_branch: capString(s.git_branch ?? null, STRING_CAPS.git_branch),
+    ticket: capString(s.ticket ?? null, STRING_CAPS.ticket),
     // #178: see the matching note in `buildRollupRows` — coerce + cap the
     // headline session metrics so a malformed value can't poison the
     // dashboard's session-level aggregates.
@@ -298,7 +337,7 @@ export function buildSessionRows(
       s.total_cost_cents,
       METRIC_CAPS.total_cost_cents
     ),
-    main_model: s.primary_model ?? null,
+    main_model: capString(s.primary_model ?? null, STRING_CAPS.model),
     // Vitals (#99). Each field is normalized independently so a daemon that
     // emits e.g. only the overall state (or only some vitals) still lands the
     // partial signal — the dashboard already renders missing slots as a

--- a/supabase/migrations/018_string_length_checks.sql
+++ b/supabase/migrations/018_string_length_checks.sql
@@ -1,0 +1,41 @@
+-- #177: floor user-controlled string columns at the database so a future
+-- ingest path that forgets to call the row-builder (`buildRollupRows` /
+-- `buildSessionRows`) still can't land unbounded strings on a single column.
+-- The application already truncates inputs in `STRING_CAPS` (`rows.ts`); these
+-- CHECKs are the last line of defense against the same dashboard-wide damage
+-- 016 guards against on the numeric side: a single bad row that bloats
+-- storage and slows every aggregate query for the 90-day retention window.
+--
+-- Bounds match `STRING_CAPS` exactly. If a future change relaxes a TypeScript
+-- cap the migration must be relaxed in lockstep — the same trade-off ADR-0083
+-- §7 documents for the metric range checks. Nullable columns admit NULL
+-- explicitly so existing rows where the daemon legitimately omitted the
+-- field (e.g. `ticket`) keep validating.
+
+ALTER TABLE daily_rollups
+    ADD CONSTRAINT daily_rollups_role_length
+        CHECK (length(role) <= 32),
+    ADD CONSTRAINT daily_rollups_provider_length
+        CHECK (length(provider) <= 64),
+    ADD CONSTRAINT daily_rollups_model_length
+        CHECK (length(model) <= 128),
+    ADD CONSTRAINT daily_rollups_repo_id_length
+        CHECK (length(repo_id) <= 128),
+    ADD CONSTRAINT daily_rollups_git_branch_length
+        CHECK (length(git_branch) <= 256),
+    ADD CONSTRAINT daily_rollups_ticket_length
+        CHECK (ticket IS NULL OR length(ticket) <= 64);
+
+ALTER TABLE session_summaries
+    ADD CONSTRAINT session_summaries_session_id_length
+        CHECK (length(session_id) <= 128),
+    ADD CONSTRAINT session_summaries_provider_length
+        CHECK (length(provider) <= 64),
+    ADD CONSTRAINT session_summaries_repo_id_length
+        CHECK (repo_id IS NULL OR length(repo_id) <= 128),
+    ADD CONSTRAINT session_summaries_git_branch_length
+        CHECK (git_branch IS NULL OR length(git_branch) <= 256),
+    ADD CONSTRAINT session_summaries_ticket_length
+        CHECK (ticket IS NULL OR length(ticket) <= 64),
+    ADD CONSTRAINT session_summaries_main_model_length
+        CHECK (main_model IS NULL OR length(main_model) <= 128);


### PR DESCRIPTION
## Summary

Closes #177.

`POST /v1/ingest` only capped `label` (devices) at 128 chars. Every other user-controlled string written by the route — `session_id`, `provider`, `model`, `role`, `repo_id`, `git_branch`, `ticket`, `primary_model` — was passed through unchanged, so a single envelope under the 1 MiB body cap could land hundreds of KiB on one column. That bloats `session_summaries` / `daily_rollups` storage, slows every aggregate query for the 90-day retention window, and overflows the dashboard's table cells.

- Add `STRING_CAPS` next to the existing `METRIC_CAPS` in `src/app/api/v1/ingest/rows.ts` with per-field bounds (session_id 128, provider 64, model 128, role 32, repo_id 128, git_branch 256, ticket 64).
- Truncate via a `capString` helper in `buildRollupRows` / `buildSessionRows`. Non-string inputs pass through unchanged so the existing NOT NULL / type-mismatch error paths still trip.
- Mirror the bounds as column-level CHECK constraints in `supabase/migrations/018_string_length_checks.sql` — same defense-in-depth pattern as 016 on the numeric side.
- Add unit + end-to-end tests that ship 50 KB strings on each field and assert they land truncated.

## Test plan

- [x] `npm test` — 257 tests pass (24 files)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] New tests cover: per-field rollup truncation, per-field session truncation, nullable fields stay null when omitted, end-to-end 50 KiB envelope is accepted and stored truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)