### PR TITLE
fix(security): validate Sessions cursor + quote PostgREST .or() values

### DIFF
--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1026,8 +1026,16 @@ export async function getSessions(
     // Composite tuple compare: (started_at, session_id) < cursor.
     // PostgREST has no native row-constructor compare, so we expand to the
     // logically-equivalent disjunction.
+    //
+    // Both values are wrapped in PostgREST's quoted-literal syntax — without
+    // the quoting, a `session_id` containing filter-tree metacharacters (`,`,
+    // `(`, `)`) would inject extra top-level conditions into the disjunction,
+    // breaking the cursor invariant. Decoding already rejects those shapes
+    // (#176), but we quote here too so a direct DAL caller can't bypass it.
+    const startedAt = postgrestQuoteLiteral(cursor.startedAt);
+    const sessionId = postgrestQuoteLiteral(cursor.sessionId);
     query = query.or(
-      `started_at.lt.${cursor.startedAt},and(started_at.eq.${cursor.startedAt},session_id.lt.${cursor.sessionId})`
+      `started_at.lt.${startedAt},and(started_at.eq.${startedAt},session_id.lt.${sessionId})`
     );
   }
 
@@ -1273,6 +1281,18 @@ export async function getOrgMembers(orgId: string) {
 }
 
 // --- Helpers ---
+
+/**
+ * Wrap a value in PostgREST's quoted-literal syntax (`"..."`). Escapes
+ * embedded `\` and `"` per PostgREST's docs so the filter tree always parses
+ * as a single leaf — never as a stray delimiter that opens a new branch in
+ * the parent expression. Used by `getSessions` when expanding a composite
+ * `(started_at, session_id) < cursor` compare into a `.or()` disjunction.
+ */
+function postgrestQuoteLiteral(value: string): string {
+  const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
 
 /**
  * Get device IDs visible to the current user.

--- a/src/lib/sessions-cursor.test.ts
+++ b/src/lib/sessions-cursor.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  decodeSessionsCursor,
+  encodeSessionsCursor,
+} from "@/lib/sessions-cursor";
+
+/**
+ * Pins the validation contract added in #176. The Sessions cursor flows from
+ * a hand-editable URL parameter into a PostgREST `.or()` filter; without
+ * strict decoding, a crafted `session_id` containing PostgREST filter-tree
+ * metacharacters (`,`, `(`, `)`) injects extra top-level conditions into the
+ * disjunction. The decoder is the first line of defense — anything off-shape
+ * collapses to `null` so the page silently falls back to "first page" rather
+ * than 500ing or returning rows from outside the intended page.
+ */
+describe("decodeSessionsCursor (#176)", () => {
+  it("round-trips a well-formed cursor", () => {
+    const original = {
+      startedAt: "2026-04-15T10:00:00.000Z",
+      sessionId: "sess_0001",
+    };
+    const decoded = decodeSessionsCursor(encodeSessionsCursor(original));
+    expect(decoded).toEqual(original);
+  });
+
+  it("returns null for an empty / missing cursor", () => {
+    expect(decodeSessionsCursor(null)).toBeNull();
+    expect(decodeSessionsCursor(undefined)).toBeNull();
+    expect(decodeSessionsCursor("")).toBeNull();
+  });
+
+  it("returns null when base64url decode or JSON parse fails", () => {
+    expect(decodeSessionsCursor("not-base64-or-json")).toBeNull();
+    expect(decodeSessionsCursor(toBase64Url("not json"))).toBeNull();
+  });
+
+  it("returns null when fields are the wrong shape", () => {
+    expect(decodeSessionsCursor(toBase64Url(JSON.stringify({})))).toBeNull();
+    expect(
+      decodeSessionsCursor(
+        toBase64Url(JSON.stringify({ startedAt: 123, sessionId: "x" }))
+      )
+    ).toBeNull();
+    expect(
+      decodeSessionsCursor(
+        toBase64Url(JSON.stringify({ startedAt: "x", sessionId: null }))
+      )
+    ).toBeNull();
+  });
+
+  it("rejects startedAt values that aren't a real ISO-8601 instant", () => {
+    for (const startedAt of [
+      "not-a-date",
+      "2026-13-45T99:99:99.000Z",
+      "2026", // Date.parse accepts this; we don't.
+      "April 15", // Same — round-trip rejects.
+      "2026-04-15", // Date-only, no time component.
+      "2026-04-15T10:00:00Z", // No milliseconds → toISOString won't match.
+    ]) {
+      const raw = toBase64Url(
+        JSON.stringify({ startedAt, sessionId: "sess_0001" })
+      );
+      expect(decodeSessionsCursor(raw)).toBeNull();
+    }
+  });
+
+  it("rejects sessionId containing PostgREST filter metacharacters", () => {
+    // The bug report's exact crafted shape: a `,` lifts the trailing fragment
+    // up to a top-level term in the .or() disjunction, breaking the cursor
+    // invariant. Same risk for `(` and `)` opening / closing a nested group.
+    const startedAt = "2026-01-01T00:00:00.000Z";
+    for (const sessionId of [
+      "x,y",
+      "x)or(true",
+      "a),or(started_at.gt.1900-01-01,and(true",
+      "x(",
+      "x)",
+      "(",
+      ")",
+      ",",
+    ]) {
+      const raw = toBase64Url(JSON.stringify({ startedAt, sessionId }));
+      expect(decodeSessionsCursor(raw)).toBeNull();
+    }
+  });
+
+  it("accepts sessionIds with non-metacharacter punctuation", () => {
+    // A real daemon may emit hyphens / underscores / dots / colons in the id
+    // (e.g. UUIDs, timestamped ids). None of these break the .or() filter
+    // tree, so they round-trip cleanly.
+    for (const sessionId of [
+      "sess_0001",
+      "8c5b2f3a-1b1c-4f2a-9b9a-2e9c6f7d4a3b",
+      "claude_code:2026-04-15T10:00:00",
+      "sess.with.dots",
+      "sess-with-dashes",
+    ]) {
+      const original = {
+        startedAt: "2026-04-15T10:00:00.000Z",
+        sessionId,
+      };
+      const decoded = decodeSessionsCursor(encodeSessionsCursor(original));
+      expect(decoded).toEqual(original);
+    }
+  });
+
+  it("rejects oversized cursor fields", () => {
+    // Defense against a megabyte-long cursor blowing up the downstream
+    // .or() string. 256 chars is well above any real daemon-emitted id.
+    const big = "a".repeat(257);
+    expect(
+      decodeSessionsCursor(
+        toBase64Url(
+          JSON.stringify({
+            startedAt: "2026-04-15T10:00:00.000Z",
+            sessionId: big,
+          })
+        )
+      )
+    ).toBeNull();
+    expect(
+      decodeSessionsCursor(
+        toBase64Url(
+          JSON.stringify({
+            startedAt: big,
+            sessionId: "sess_0001",
+          })
+        )
+      )
+    ).toBeNull();
+  });
+});
+
+function toBase64Url(s: string): string {
+  return Buffer.from(s, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}

--- a/src/lib/sessions-cursor.ts
+++ b/src/lib/sessions-cursor.ts
@@ -15,6 +15,26 @@ export function encodeSessionsCursor(cursor: SessionsCursor): string {
   return base64UrlEncode(json);
 }
 
+/**
+ * Defense-in-depth caps for #176. The cursor value flows into a PostgREST
+ * `.or()` filter that historically built the expression via string
+ * interpolation (`getSessions`). Even though the DAL now quotes/escapes
+ * cursor values before interpolation, decoding still validates here so a
+ * crafted URL falls back cleanly to "first page" instead of producing a 500
+ * deeper in the query path.
+ *
+ * - `startedAt` must round-trip through `Date` and reproduce the same string,
+ *   pinning it to a real ISO-8601 instant (e.g. `2026-04-15T10:00:00.000Z`).
+ *   This rejects free-form strings the cursor was never meant to carry.
+ * - `sessionId` must not contain `,` `(` `)` — the PostgREST filter-tree
+ *   delimiters that drove the original injection report. Real daemons emit
+ *   opaque token-shaped ids; these characters never legitimately appear.
+ * - Both are length-capped so a megabyte-long cursor can't blow up the
+ *   downstream `.or()` string.
+ */
+const MAX_CURSOR_FIELD_LEN = 256;
+const SESSION_ID_DISALLOWED = /[,()]/;
+
 export function decodeSessionsCursor(
   raw: string | null | undefined
 ): SessionsCursor | null {
@@ -23,15 +43,34 @@ export function decodeSessionsCursor(
     const json = base64UrlDecode(raw);
     const parsed = JSON.parse(json) as Partial<SessionsCursor>;
     if (
-      typeof parsed.startedAt === "string" &&
-      typeof parsed.sessionId === "string"
+      typeof parsed.startedAt !== "string" ||
+      typeof parsed.sessionId !== "string"
     ) {
-      return { startedAt: parsed.startedAt, sessionId: parsed.sessionId };
+      return null;
     }
-    return null;
+    if (
+      parsed.startedAt.length > MAX_CURSOR_FIELD_LEN ||
+      parsed.sessionId.length > MAX_CURSOR_FIELD_LEN
+    ) {
+      return null;
+    }
+    if (!isIsoInstant(parsed.startedAt)) return null;
+    if (SESSION_ID_DISALLOWED.test(parsed.sessionId)) return null;
+    return { startedAt: parsed.startedAt, sessionId: parsed.sessionId };
   } catch {
     return null;
   }
+}
+
+/**
+ * `Date.parse` happily accepts plenty of strings the cursor should not carry
+ * (`"2026"`, `"April 15"`, …). Round-tripping through `toISOString()` is the
+ * cheapest way to require an actual UTC instant the daemon would emit.
+ */
+function isIsoInstant(value: string): boolean {
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) return false;
+  return new Date(ms).toISOString() === value;
 }
 
 function base64UrlEncode(s: string): string {


### PR DESCRIPTION
## Summary

- `decodeSessionsCursor` now strictly validates the cursor — `startedAt` must round-trip as a real ISO-8601 instant, `sessionId` is length-capped and rejected if it contains the PostgREST filter-tree metacharacters `,`, `(`, `)`. Off-shape cursors fall back to "first page" instead of 500ing.
- `getSessions` wraps the cursor values in PostgREST's quoted-literal syntax (escaping `\` and `"`) before interpolating into `.or()`, so a direct DAL caller bypassing the decoder still can't inject a delimiter.

The original `query.or(\`started_at.lt.${'$'}{cursor.startedAt},and(...session_id.lt.${'$'}{cursor.sessionId})\`)` shape is gone — the values now flow through `postgrestQuoteLiteral` and the decoder is the gatekeeper for any URL-supplied cursor.

Closes #176.

## Test plan

- [x] `npm test` — all 25 files / 265 tests pass, including 7 new cases in `src/lib/sessions-cursor.test.ts` that feed every PostgREST metacharacter into `sessionId` and assert decode returns `null`.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)