### PR TITLE
fix(dashboard): normalize Sessions cursor timestamps to canonical Z form (#195)

### DIFF
--- a/src/lib/sessions-cursor.test.ts
+++ b/src/lib/sessions-cursor.test.ts
@@ -104,6 +104,39 @@ describe("decodeSessionsCursor (#176)", () => {
     }
   });
 
+  it("normalizes PostgREST `+00:00` timestamps to the `Z` form on encode (#195)", () => {
+    // PostgREST returns `timestamptz` in `+00:00` form; `Date.toISOString()`
+    // only emits `Z`. Without encode-side normalization the cursor failed its
+    // own round-trip check and pagination silently fell back to first page.
+    const postgrestShape = "2026-05-08T02:02:02.469+00:00";
+    const canonical = "2026-05-08T02:02:02.469Z";
+    const decoded = decodeSessionsCursor(
+      encodeSessionsCursor({
+        startedAt: postgrestShape,
+        sessionId: "sess_0001",
+      })
+    );
+    expect(decoded).toEqual({
+      startedAt: canonical,
+      sessionId: "sess_0001",
+    });
+  });
+
+  it("normalizes other valid offset forms on encode", () => {
+    // Sanity-check the normalization isn't only `+00:00`-specific: any
+    // parseable instant should round-trip into the canonical UTC `Z` form.
+    const inputs: Array<[string, string]> = [
+      ["2026-05-08T07:30:00.000+05:30", "2026-05-08T02:00:00.000Z"],
+      ["2026-05-08T02:02:02+00:00", "2026-05-08T02:02:02.000Z"],
+    ];
+    for (const [input, expected] of inputs) {
+      const decoded = decodeSessionsCursor(
+        encodeSessionsCursor({ startedAt: input, sessionId: "sess_x" })
+      );
+      expect(decoded).toEqual({ startedAt: expected, sessionId: "sess_x" });
+    }
+  });
+
   it("rejects oversized cursor fields", () => {
     // Defense against a megabyte-long cursor blowing up the downstream
     // .or() string. 256 chars is well above any real daemon-emitted id.

--- a/src/lib/sessions-cursor.ts
+++ b/src/lib/sessions-cursor.ts
@@ -11,8 +11,30 @@ import type { SessionsCursor } from "@/lib/dal";
  * 500ing — same defensive posture as the user filter in #80.
  */
 export function encodeSessionsCursor(cursor: SessionsCursor): string {
-  const json = JSON.stringify(cursor);
+  const json = JSON.stringify({
+    startedAt: normalizeIsoInstant(cursor.startedAt),
+    sessionId: cursor.sessionId,
+  });
   return base64UrlEncode(json);
+}
+
+/**
+ * PostgREST returns `timestamptz` columns in the `+00:00` offset form
+ * (e.g. `2026-05-08T02:02:02.469+00:00`), but `Date.prototype.toISOString()`
+ * only ever emits the `Z` form. The decoder validates `startedAt` by
+ * round-tripping through `toISOString()` (#176), so without normalization
+ * here every real cursor produced from `tail.started_at` failed to round-trip
+ * and the page silently fell back to "first page" (#195). We normalize once
+ * at encode time so the encoded cursor is always in the canonical `Z` shape
+ * the decoder expects, regardless of what the daemon / PostgREST emits.
+ *
+ * If the value isn't parseable we leave it alone — the decoder will reject
+ * it, which is the correct behavior for non-instant input.
+ */
+function normalizeIsoInstant(value: string): string {
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) return value;
+  return new Date(ms).toISOString();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Closes #195. `decodeSessionsCursor()` validates `startedAt` by round-tripping through `toISOString()`, which only emits the `Z` suffix. PostgREST returns `started_at` in `+00:00` offset form, so every real cursor produced from `tail.started_at` failed the round-trip check, `decodeSessionsCursor()` returned `null`, and the page silently fell back to first-page rows while the title still said "201–250+".
- Fix normalizes `startedAt` once in `encodeSessionsCursor()` so the encoded cursor is always in the canonical `Z` shape the decoder expects, regardless of what the daemon / PostgREST emits. Decoder contract stays strict — important for the #176 injection-defense posture.
- Regression test pins the exact PostgREST shape from the bug report plus a non-UTC offset for sanity.

## Test plan
- [x] `npm test` (267 passed, including 2 new cases in `sessions-cursor.test.ts`)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Manual verification on dashboard: navigate "Older →" on `/dashboard/sessions` and confirm rows actually advance past page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)