### PR TITLE
fix(dashboard): clarify Sessions pagination labels (#197)

### DIFF
--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -174,10 +174,73 @@ describe("dashboard/sessions /page", () => {
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("No sessions found");
-    // The "← Newest" / "Older →" labels live in the pagination nav — neither
+    // The "« First" / "Next ›" labels live in the pagination nav — neither
     // should render when there are no rows + no next cursor.
+    expect(text).not.toContain("First");
+    expect(text).not.toContain("Next");
+  });
+
+  it("pagination labels: forward-only cursor scheme exposes only « First and Next › (#197)", async () => {
+    // Page 1 with more pages available: only Next renders. The earlier copy
+    // ("← Newest") read as a back-by-one button and confused users (#197).
+    dal.getSessions.mockResolvedValueOnce({
+      rows: [
+        {
+          device_id: "dev_ivan",
+          session_id: "sess_a",
+          provider: "claude_code",
+          started_at: "2026-04-15T10:00:00.000Z",
+          ended_at: "2026-04-15T11:00:00.000Z",
+          duration_ms: 3_600_000,
+          repo_id: "repo_x",
+          git_branch: "refs/heads/main",
+          ticket: null,
+          message_count: 12,
+          total_input_tokens: 2000,
+          total_output_tokens: 800,
+          total_cost_cents: 250,
+          main_model: "claude-opus-4-7-20260101",
+          owner_name: "Ivan",
+          surface: "vscode",
+        },
+      ],
+      nextCursor: { startedAt: "2026-04-15T10:00:00.000Z", sessionId: "sess_a" },
+    });
+    let text = extractText(await render());
+    expect(text).toContain("Next");
+    expect(text).not.toContain("First");
+    // The retired labels must not creep back in.
     expect(text).not.toContain("Newest");
     expect(text).not.toContain("Older");
+
+    // Page 2+ with no further pages: only « First renders. Next is hidden
+    // because `nextCursor` is null.
+    dal.getSessions.mockResolvedValueOnce({
+      rows: [
+        {
+          device_id: "dev_ivan",
+          session_id: "sess_b",
+          provider: "claude_code",
+          started_at: "2026-04-15T09:00:00.000Z",
+          ended_at: "2026-04-15T09:30:00.000Z",
+          duration_ms: 1_800_000,
+          repo_id: "repo_x",
+          git_branch: "refs/heads/main",
+          ticket: null,
+          message_count: 4,
+          total_input_tokens: 200,
+          total_output_tokens: 80,
+          total_cost_cents: 30,
+          main_model: null,
+          owner_name: "Ivan",
+          surface: "vscode",
+        },
+      ],
+      nextCursor: null,
+    });
+    text = extractText(await render({ p: "2" }));
+    expect(text).toContain("First");
+    expect(text).not.toContain("Next");
   });
 
   it("loading: composes a Suspense boundary around the filter cluster so the table can stream", async () => {

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -204,7 +204,10 @@ describe("dashboard/sessions /page", () => {
           surface: "vscode",
         },
       ],
-      nextCursor: { startedAt: "2026-04-15T10:00:00.000Z", sessionId: "sess_a" },
+      nextCursor: {
+        startedAt: "2026-04-15T10:00:00.000Z",
+        sessionId: "sess_a",
+      },
     });
     let text = extractText(await render());
     expect(text).toContain("Next");

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -91,8 +91,8 @@ export default async function SessionsPage({
 
   const startIndex = (page - 1) * SESSIONS_PAGE_SIZE + 1;
   const endIndex = startIndex + sessions.length - 1;
-  const hasOlder = nextCursor !== null;
-  const hasNewer = page > 1;
+  const hasNext = nextCursor !== null;
+  const hasFirst = page > 1;
 
   // Preserve the period, unit, and user-filter params across page boundaries
   // (#85 acceptance: "Period selector + user filter both preserved across
@@ -121,14 +121,19 @@ export default async function SessionsPage({
     return qs ? `?${qs}` : "?";
   }
 
-  const newerParams = new URLSearchParams(baseParams);
-  // "Newer" returns to the first page — drops cursor and `p`. Browser back
-  // remains the way to walk one page at a time, per the cursor scheme in #85.
+  const firstParams = new URLSearchParams(baseParams);
+  // "First" jumps back to page 1 — drops cursor and `p`. The forward-only
+  // cursor scheme (#85) can't cheaply step back one page, so we expose only
+  // the affordances that actually work: « First and Next ›. The absence of
+  // a per-page Prev is signalled by the labels themselves (#197) — earlier
+  // copy ("← Newest") read as "previous page" and surprised users who had
+  // paged forward several times. Browser back still walks one page at a
+  // time for users who need it.
 
-  const olderParams = new URLSearchParams(baseParams);
+  const nextParams = new URLSearchParams(baseParams);
   if (nextCursor) {
-    olderParams.set("cursor", encodeSessionsCursor(nextCursor));
-    olderParams.set("p", String(page + 1));
+    nextParams.set("cursor", encodeSessionsCursor(nextCursor));
+    nextParams.set("p", String(page + 1));
   }
 
   return (
@@ -150,7 +155,7 @@ export default async function SessionsPage({
           <CardTitle>
             {sessions.length === 0
               ? "Recent Sessions"
-              : `Recent Sessions (showing ${startIndex.toLocaleString()}–${endIndex.toLocaleString()}${hasOlder ? "+" : ""})`}
+              : `Recent Sessions (showing ${startIndex.toLocaleString()}–${endIndex.toLocaleString()}${hasNext ? "+" : ""})`}
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -283,30 +288,32 @@ export default async function SessionsPage({
             </div>
           )}
 
-          {(hasOlder || hasNewer) && (
+          {(hasNext || hasFirst) && (
             <nav
               aria-label="Sessions pagination"
               className="mt-4 flex items-center justify-between gap-3 border-t border-white/5 pt-3 text-sm"
             >
               <div>
-                {hasNewer ? (
+                {hasFirst ? (
                   <Link
-                    href={buildHref(newerParams)}
+                    href={buildHref(firstParams)}
+                    aria-label="Jump to first page"
                     className="rounded-md px-3 py-1.5 font-medium text-zinc-300 transition-colors hover:bg-white/5 hover:text-white"
                   >
-                    ← Newest
+                    « First
                   </Link>
                 ) : (
                   <span aria-hidden="true" />
                 )}
               </div>
               <div>
-                {hasOlder && (
+                {hasNext && (
                   <Link
-                    href={buildHref(olderParams)}
+                    href={buildHref(nextParams)}
+                    aria-label="Next page"
                     className="rounded-md px-3 py-1.5 font-medium text-zinc-300 transition-colors hover:bg-white/5 hover:text-white"
                   >
-                    Older →
+                    Next ›
                   </Link>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- Closes #197.
- The Sessions pagination back-affordance was labeled `← Newest` but actually jumped straight to page 1 — visually it read as a back-by-one button, which surprised users who had paged forward several times.
- Forward-only cursor pagination (#85) can't cheaply step back one page without stack-encoding visited cursors, which the issue scopes out. Instead, signal the absence of a per-page Prev through the labels themselves: `« First` (clearly "jump to first page") + `Next ›` (paired with First as a coherent forward-only scheme).
- Renamed local symbols accordingly (`hasNewer`/`newerParams` → `hasFirst`/`firstParams`, `hasOlder`/`olderParams` → `hasNext`/`nextParams`) so the code matches the UI vocabulary.
- Added a regression test pinning that page 1 with more pages renders only `Next ›`, page 2+ with no further pages renders only `« First`, and the retired `Newest`/`Older` copy doesn't creep back in.

## Test plan
- [x] `pnpm vitest run src/app/dashboard/sessions` — all session page tests pass (21/21).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [ ] Manual: load `/dashboard/sessions`, click `Next ›` a few times, confirm `« First` jumps back to page 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)