### PR TITLE
fix(dashboard): keep Provider column on a single line (#196)

### DIFF
--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -171,7 +171,9 @@ export default async function SessionsPage({
                     {isManager && (
                       <th className="pr-3 pb-2 font-medium">Member</th>
                     )}
-                    <th className="pr-3 pb-2 font-medium">Provider</th>
+                    <th className="pr-3 pb-2 font-medium whitespace-nowrap">
+                      Provider
+                    </th>
                     <th className="pr-3 pb-2 font-medium">Model</th>
                     {showSurfaceColumn && (
                       <th className="pr-3 pb-2 font-medium">Surface</th>
@@ -212,7 +214,10 @@ export default async function SessionsPage({
                           </td>
                         )}
                         <td className="text-zinc-300">
-                          <Link href={href} className="block py-2 pr-3">
+                          <Link
+                            href={href}
+                            className="block py-2 pr-3 whitespace-nowrap"
+                          >
                             {formatProvider(s.provider)}
                           </Link>
                         </td>


### PR DESCRIPTION
## Summary
- Add `whitespace-nowrap` to the Provider `<th>` and cell `<Link>` on `/dashboard/sessions`.
- Prevents multi-word labels (e.g. "Claude Code", "Copilot Chat") from wrapping to two lines and creating jagged row heights when the column is squeezed by long values in neighboring columns.
- Provider-agnostic — works for any future label produced by `formatProvider()`.

Fixes #196

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] Visually confirm on `/dashboard/sessions` that "Claude Code" / "Copilot Chat" render on one line across pages with varied column widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)