### PR TITLE
test(sessions): pin multi-provider Sessions visibility (#202)

### DIFF
--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -270,6 +270,88 @@ describe("dashboard/sessions /page", () => {
     expect(lastCall![2]).toMatchObject({ surfaces: ["vscode"] });
   });
 
+  it("multi-provider: lists rows for every provider the daemon ships, not only claude_code (#202)", async () => {
+    // The daemon's 8.4.2 release surfaced sessions for `copilot_chat`,
+    // `cursor`, `codex`, and `copilot_cli` alongside `claude_code`. The
+    // Sessions list contract is provider-agnostic — pin that the table
+    // renders one row per provider with each row's actual display label,
+    // so a future change can't silently re-collapse the list to one
+    // provider without tripping this assertion.
+    const baseRow = {
+      device_id: "dev_ivan",
+      ended_at: null,
+      duration_ms: null,
+      repo_id: "repo_x",
+      git_branch: "refs/heads/main",
+      ticket: null,
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost_cents: 0,
+      main_model: null,
+      owner_name: "Ivan",
+      surface: "vscode",
+    };
+    dal.getSessions.mockResolvedValue({
+      rows: [
+        {
+          ...baseRow,
+          session_id: "sess_cc",
+          provider: "claude_code",
+          started_at: "2026-04-15T14:00:00.000Z",
+        },
+        {
+          ...baseRow,
+          session_id: "sess_copilot",
+          provider: "copilot_chat",
+          started_at: "2026-04-15T13:00:00.000Z",
+        },
+        {
+          ...baseRow,
+          session_id: "sess_cursor",
+          provider: "cursor",
+          started_at: "2026-04-15T12:00:00.000Z",
+          surface: "cursor",
+        },
+        {
+          ...baseRow,
+          session_id: "sess_codex",
+          provider: "codex",
+          started_at: "2026-04-15T11:00:00.000Z",
+          surface: "terminal",
+        },
+        {
+          ...baseRow,
+          session_id: "sess_copilot_cli",
+          provider: "copilot_cli",
+          started_at: "2026-04-15T10:00:00.000Z",
+          surface: "terminal",
+        },
+      ],
+      nextCursor: null,
+    });
+    const node = await render();
+    const text = extractText(node);
+    // Each provider lands on the list with its display label, never the
+    // raw snake_case wire value.
+    for (const label of [
+      "Claude Code",
+      "Copilot Chat",
+      "Cursor",
+      "Codex",
+      "Copilot CLI",
+    ]) {
+      expect(text).toContain(label);
+    }
+    for (const wire of [
+      "claude_code",
+      "copilot_chat",
+      "copilot_cli",
+    ]) {
+      expect(text).not.toContain(wire);
+    }
+  });
+
   it("surface column: rendered when the org has 2+ surfaces, hidden when only one (#187)", async () => {
     // Multi-surface org: column header + per-row cells render the formatted
     // surface label, not the raw daemon id.

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -343,11 +343,7 @@ describe("dashboard/sessions /page", () => {
     ]) {
       expect(text).toContain(label);
     }
-    for (const wire of [
-      "claude_code",
-      "copilot_chat",
-      "copilot_cli",
-    ]) {
+    for (const wire of ["claude_code", "copilot_chat", "copilot_cli"]) {
       expect(text).not.toContain(wire);
     }
   });

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -1923,7 +1923,13 @@ describe("getSessions multi-provider visibility (#202)", () => {
     // to a hardcoded "claude_code" label.
     const ids = page.rows.map((r) => r.session_id).sort();
     expect(ids).toEqual(
-      ["sess_cc", "sess_codex", "sess_copilot", "sess_copilot_cli", "sess_cursor"].sort()
+      [
+        "sess_cc",
+        "sess_codex",
+        "sess_copilot",
+        "sess_copilot_cli",
+        "sess_cursor",
+      ].sort()
     );
   });
 

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -1837,3 +1837,109 @@ describe("getSessions cursor pagination (#85)", () => {
     expect(page.rows.map((r) => r.session_id)).toEqual(["sess_jane"]);
   });
 });
+
+describe("getSessions multi-provider visibility (#202)", () => {
+  // Pre-#202 the daemon's 8.4.2 release surfaced a regression: copilot_chat /
+  // cursor / codex / copilot_cli sessions landed in the cloud but never showed
+  // up in the Sessions list. The list path is provider-agnostic by contract;
+  // pin the behavior so a future filter-tightening can't silently re-collapse
+  // the list to one provider.
+  const wideRange = utcRange("2026-01-01", "2026-12-31");
+
+  const manager = {
+    id: "usr_ivan",
+    org_id: "org_team",
+    role: "manager" as const,
+    api_key: "budi_i",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+
+  function seedMixedProviders() {
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [{ ...manager }]);
+    fake.seed("devices", [{ id: "dev_ivan", user_id: "usr_ivan" }]);
+    const base = {
+      device_id: "dev_ivan",
+      ended_at: null,
+      duration_ms: null,
+      repo_id: "repo_x",
+      git_branch: "refs/heads/main",
+      ticket: null,
+      message_count: 1,
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cost_cents: 0,
+    } as const;
+    fake.seed("session_summaries", [
+      {
+        ...base,
+        session_id: "sess_cc",
+        provider: "claude_code",
+        started_at: "2026-04-15T10:00:00.000Z",
+        surface: "terminal",
+      },
+      {
+        ...base,
+        session_id: "sess_copilot",
+        provider: "copilot_chat",
+        started_at: "2026-04-15T11:00:00.000Z",
+        surface: "vscode",
+      },
+      {
+        ...base,
+        session_id: "sess_cursor",
+        provider: "cursor",
+        started_at: "2026-04-15T12:00:00.000Z",
+        surface: "cursor",
+      },
+      {
+        ...base,
+        session_id: "sess_codex",
+        provider: "codex",
+        started_at: "2026-04-15T13:00:00.000Z",
+        surface: "terminal",
+      },
+      {
+        ...base,
+        session_id: "sess_copilot_cli",
+        provider: "copilot_cli",
+        started_at: "2026-04-15T14:00:00.000Z",
+        surface: "terminal",
+      },
+    ]);
+  }
+
+  it("lists sessions for every provider the daemon uploads, not only claude_code", async () => {
+    seedMixedProviders();
+    const { getSessions } = await loadDal();
+    const page = await getSessions(manager, wideRange);
+
+    const providers = page.rows.map((r) => r.provider).sort();
+    expect(providers).toEqual(
+      ["claude_code", "copilot_chat", "copilot_cli", "codex", "cursor"].sort()
+    );
+    // Each row carries the provider the daemon uploaded — no row collapses
+    // to a hardcoded "claude_code" label.
+    const ids = page.rows.map((r) => r.session_id).sort();
+    expect(ids).toEqual(
+      ["sess_cc", "sess_codex", "sess_copilot", "sess_copilot_cli", "sess_cursor"].sort()
+    );
+  });
+
+  it("getSessionDetail loads a non-claude_code session by (device, session_id)", async () => {
+    seedMixedProviders();
+    const { getSessionDetail } = await loadDal();
+
+    for (const sid of [
+      "sess_copilot",
+      "sess_cursor",
+      "sess_codex",
+      "sess_copilot_cli",
+    ]) {
+      const detail = await getSessionDetail(manager, "dev_ivan", sid);
+      expect(detail, `expected detail for ${sid}`).not.toBeNull();
+      expect(detail?.session_id).toBe(sid);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #202. The Sessions list and detail paths are provider-agnostic by contract, but the only existing coverage seeded `claude_code` rows — a regression that re-collapses the list to a single provider would have shipped silently.

After investigating the symptoms in #202, the current `main` already handles every provider the daemon uploads (`claude_code`, `copilot_chat`, `cursor`, `codex`, `copilot_cli`):

- `getSessions` / `getSessionDetail` apply only `device_id` + `started_at` range filters; no provider gate.
- `formatProvider` renders each canonical key as its display label and falls back to the raw value for unknown keys (so a future provider lights up without a code change).
- The detail page already round-trips `provider` from the DAL row, including `copilot_chat` (`page.test.tsx#renders the canonical provider key`).

This PR adds two regression tests pinning the behavior so a future filter-tightening can't silently re-collapse the Sessions surface to one provider:

- **DAL** (`src/lib/dal.test.ts`): seeds 5 sessions across every supported provider on the same device; asserts `getSessions` lists all of them and `getSessionDetail` resolves each non-`claude_code` ID.
- **Page** (`src/app/dashboard/sessions/page.test.tsx`): mocks the DAL with one row per provider; asserts the list renders the display label for each (`Claude Code`, `Copilot Chat`, `Cursor`, `Codex`, `Copilot CLI`) and never leaks the snake_case wire value.

No production code changes.

## Test plan

- [x] `npm test` — 273 passed (271 prior + 2 new + 1 page-level multi-provider)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Verify on `app.getbudi.dev` after deploy that copilot_chat / cursor sessions land in the Sessions list once the daemon-side 8.4.2 sync completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)