### PR TITLE
fix(charts): drop redundant <title> on bar y-axis tick (#205)

### DIFF
--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -217,9 +217,9 @@ describe("CostBarChart", () => {
       const truncTickNodes = Array.from(walk(truncRendered));
       const titleNode = truncTickNodes.find((n) => n.type === "title");
       expect(titleNode).toBeDefined();
-      expect(
-        (titleNode!.props as { children: string }).children
-      ).toBe("really-long-surface-name-that-will-truncate");
+      expect((titleNode!.props as { children: string }).children).toBe(
+        "really-long-surface-name-that-will-truncate"
+      );
     } finally {
       isCompact = false;
     }

--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { ReactElement } from "react";
-import { Bar, BarChart, LabelList } from "recharts";
+import { Bar, BarChart, LabelList, YAxis } from "recharts";
 import { fmtCost, fmtNum } from "@/lib/format";
 
 // CostBarChart now calls `useMediaQuery` to shrink the y-axis column on
@@ -147,6 +147,79 @@ describe("CostBarChart", () => {
         "haiku-4-5",
         "opus-4-7",
       ]);
+    } finally {
+      isCompact = false;
+    }
+  });
+
+  it("omits the redundant <title> when the visible label already shows the full name (#205)", () => {
+    // The y-axis tick used to always render <title>{original} alongside the
+    // visible label. When original === visible, accessibility-tree / page-text
+    // scrapes concatenated both and produced duplicates like "UnknownUnknown".
+    const tree = CostBarChart({
+      data: [{ label: "Unknown", cost_cents: 185983, tokens: 0 }],
+      emptyLabel: "unused",
+    });
+    const nodes = Array.from(walk(tree));
+    const yAxis = nodes.find((n) => n.type === YAxis);
+    expect(yAxis).toBeDefined();
+    const tick = (
+      yAxis!.props as {
+        tick: (args: {
+          x: number;
+          y: number;
+          payload: { value: string };
+          index: number;
+        }) => ReactElement;
+      }
+    ).tick;
+    const rendered = tick({
+      x: 0,
+      y: 0,
+      payload: { value: "Unknown" },
+      index: 0,
+    });
+    const tickNodes = Array.from(walk(rendered));
+    // No <title> child means the label can't be doubled by the a11y tree.
+    expect(tickNodes.find((n) => n.type === "title")).toBeUndefined();
+
+    // Truncated rows still need <title> to expose the full original name.
+    isCompact = true;
+    try {
+      const truncTree = CostBarChart({
+        data: [
+          {
+            label: "really-long-surface-name-that-will-truncate",
+            cost_cents: 100,
+            tokens: 0,
+          },
+        ],
+        emptyLabel: "unused",
+      });
+      const truncNodes = Array.from(walk(truncTree));
+      const truncYAxis = truncNodes.find((n) => n.type === YAxis);
+      const truncTick = (
+        truncYAxis!.props as {
+          tick: (args: {
+            x: number;
+            y: number;
+            payload: { value: string };
+            index: number;
+          }) => ReactElement;
+        }
+      ).tick;
+      const truncRendered = truncTick({
+        x: 0,
+        y: 0,
+        payload: { value: "really-long-surface-name-that-will-truncate" },
+        index: 0,
+      });
+      const truncTickNodes = Array.from(walk(truncRendered));
+      const titleNode = truncTickNodes.find((n) => n.type === "title");
+      expect(titleNode).toBeDefined();
+      expect(
+        (titleNode!.props as { children: string }).children
+      ).toBe("really-long-surface-name-that-will-truncate");
     } finally {
       isCompact = false;
     }

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -141,6 +141,12 @@ export function CostBarChart({
           interval={0}
           tick={({ x, y, payload, index }) => {
             const original = rows[index]?.label ?? payload.value;
+            const visible = truncateLabel(payload.value, labelMaxLen);
+            // Only attach a <title> when it carries info beyond the visible
+            // label — otherwise SVG accessibility-tree readers concatenate
+            // the two and labels render duplicated (e.g. "UnknownUnknown") in
+            // page-text scrapes (#205).
+            const needsTitle = visible !== original;
             return (
               <g transform={`translate(${x},${y})`}>
                 <text
@@ -151,8 +157,8 @@ export function CostBarChart({
                   fill="#71717a"
                   fontSize={12}
                 >
-                  <title>{original}</title>
-                  {truncateLabel(payload.value, labelMaxLen)}
+                  {needsTitle ? <title>{original}</title> : null}
+                  {visible}
                 </text>
               </g>
             );


### PR DESCRIPTION
## Summary

- The `CostBarChart` y-axis tick rendered `<title>{original}` alongside the visible label unconditionally. When `original === visible` (no truncation, no shared-prefix stripping), the SVG accessibility tree / page-text scrapes concatenated the two siblings and produced duplicates — the symptom in #205 was the Overview "Spend by Surface" bar reading `UnknownUnknown`.
- Render `<title>` only when it carries info beyond the visible text. Truncated rows (mobile, long labels) and prefix-stripped rows (e.g. `claude-sonnet-4-5` after stripping `claude_code / claude-`) still get the full original via `<title>` for screen readers; unchanged labels no longer double.

## Test plan

- [x] `npx vitest run src/components/charts/cost-bar-chart.test.tsx` — new test asserts no `<title>` is emitted for an unchanged label and that truncated labels still expose the full original via `<title>`.
- [x] `npx vitest run` — full suite, 272 tests pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [ ] Manual: open `/dashboard`, inspect the "Spend by Surface" bar — visible label appears once; hover still surfaces the full name when truncated. Same component drives `/dashboard/models`, `/dashboard/repos`, `/dashboard/team`, `/dashboard/devices` — same fix applies, no behavior change for already-distinct labels.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)