### PR TITLE
feat(dashboard): finish Surface UX — column placement + Models card (#203)

### DIFF
--- a/src/app/dashboard/models/page.test.tsx
+++ b/src/app/dashboard/models/page.test.tsx
@@ -21,6 +21,7 @@ vi.mock("next/navigation", () => ({
 const dal = {
   getCurrentUser: vi.fn(),
   getCostByModel: vi.fn(),
+  getCostBySurface: vi.fn(),
   getModelActivityByDay: vi.fn(),
   getEarliestActivity: vi.fn(),
   getOrgMembers: vi.fn(),
@@ -75,6 +76,21 @@ beforeEach(() => {
   dal.getOrgMembers.mockReset().mockResolvedValue([]);
   // #187 surface filter chip — populates from known surfaces in the org.
   dal.getKnownSurfaces.mockReset().mockResolvedValue(["cursor", "vscode"]);
+  // #203 Cost-by-Surface card — mirrors the Overview chart on the Models page.
+  dal.getCostBySurface.mockReset().mockResolvedValue([
+    {
+      surface: "vscode",
+      cost_cents: 700_00,
+      input_tokens: 500_000,
+      output_tokens: 150_000,
+    },
+    {
+      surface: "cursor",
+      cost_cents: 300_00,
+      input_tokens: 250_000,
+      output_tokens: 100_000,
+    },
+  ]);
 });
 
 async function render(searchParams: Record<string, string> = {}) {
@@ -147,5 +163,38 @@ describe("dashboard/models /page", () => {
       const scope = lastCall![lastCall!.length - 1];
       expect(scope).toMatchObject({ surfaces: ["vscode"] });
     }
+  });
+
+  it("surface chart: renders the 'Cost by Surface' card and pulls per-surface costs from the DAL (#203)", async () => {
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Cost by Surface");
+    expect(dal.getCostBySurface).toHaveBeenCalled();
+    // The chart receives bars as a prop array (not visible in extractText) —
+    // the DAL-call assertion above catches a regression that drops the data
+    // pipeline upstream of the chart.
+  });
+
+  it("surface chart: 'tokens' unit relabels the card to 'Tokens by Surface' (#203)", async () => {
+    const node = await render({ units: "tokens" });
+    const text = extractText(node);
+    expect(text).toContain("Tokens by Surface");
+    expect(text).not.toContain("Cost by Surface");
+  });
+
+  it("surface chart: single-surface org renders an empty-state copy that names the next-state condition (#203)", async () => {
+    dal.getKnownSurfaces.mockResolvedValue(["vscode"]);
+    dal.getCostBySurface.mockResolvedValue([
+      {
+        surface: "vscode",
+        cost_cents: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+      },
+    ]);
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Cost by Surface");
+    expect(text).toContain("Single-surface org");
   });
 });

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import {
   getCurrentUser,
   getCostByModel,
+  getCostBySurface,
   getModelActivityByDay,
   getEarliestActivity,
   getOrgMembers,
@@ -16,7 +17,7 @@ import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { SurfaceFilter } from "@/components/surface-filter";
-import { parseSurfaceParam } from "@/lib/surface";
+import { formatSurface, parseSurfaceParam } from "@/lib/surface";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { ModelCountChart } from "@/components/charts/model-count-chart";
 import { CostPerModelChart } from "@/components/charts/cost-per-model-chart";
@@ -46,12 +47,16 @@ export default async function ModelsPage({
       : null;
   const tz = await getViewerTimeZone();
   const range = dateRangeFromDays(params.days, earliestActivity, tz);
-  const [models, modelActivity, members, knownSurfaces] = await Promise.all([
-    getCostByModel(user, range, scope),
-    getModelActivityByDay(user, range, scope),
-    user.role === "manager" ? getOrgMembers(user.org_id) : Promise.resolve([]),
-    getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
-  ]);
+  const [models, modelActivity, members, knownSurfaces, surfaceShare] =
+    await Promise.all([
+      getCostByModel(user, range, scope),
+      getModelActivityByDay(user, range, scope),
+      user.role === "manager"
+        ? getOrgMembers(user.org_id)
+        : Promise.resolve([]),
+      getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
+      getCostBySurface(user, range, scope),
+    ]);
 
   const isTokens = unit === "tokens";
   const valueWord = isTokens ? "Tokens" : "Cost";
@@ -194,6 +199,27 @@ export default async function ModelsPage({
               </div>
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{`${valueWord} by Surface`}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CostBarChart
+            data={surfaceShare.map((s) => ({
+              label: formatSurface(s.surface),
+              cost_cents: s.cost_cents,
+              tokens: s.input_tokens + s.output_tokens,
+            }))}
+            emptyLabel={
+              knownSurfaces.length <= 1
+                ? "Single-surface org — break out per-surface spend after a second IDE / CLI starts syncing."
+                : `No surface ${valueWord.toLowerCase()} data for this period`
+            }
+            unit={unit}
+          />
         </CardContent>
       </Card>
 

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -177,14 +177,14 @@ export default async function SessionsPage({
                       <th className="pr-3 pb-2 font-medium whitespace-nowrap">
                         Provider
                       </th>
-                      <th className="pr-3 pb-2 font-medium whitespace-nowrap">
-                        Model
-                      </th>
                       {showSurfaceColumn && (
                         <th className="pr-3 pb-2 font-medium whitespace-nowrap">
                           Surface
                         </th>
                       )}
+                      <th className="pr-3 pb-2 font-medium whitespace-nowrap">
+                        Model
+                      </th>
                       <th className="pr-3 pb-2 font-medium whitespace-nowrap">
                         Started
                       </th>
@@ -236,19 +236,6 @@ export default async function SessionsPage({
                               {formatProvider(s.provider)}
                             </Link>
                           </td>
-                          <td
-                            className="text-zinc-400"
-                            title={s.main_model ?? undefined}
-                          >
-                            <Link
-                              href={href}
-                              className="block max-w-[16ch] truncate py-2 pr-3"
-                            >
-                              {s.main_model
-                                ? formatModelName(s.main_model)
-                                : "-"}
-                            </Link>
-                          </td>
                           {showSurfaceColumn && (
                             <td
                               className="text-zinc-400"
@@ -263,6 +250,19 @@ export default async function SessionsPage({
                               </Link>
                             </td>
                           )}
+                          <td
+                            className="text-zinc-400"
+                            title={s.main_model ?? undefined}
+                          >
+                            <Link
+                              href={href}
+                              className="block max-w-[16ch] truncate py-2 pr-3"
+                            >
+                              {s.main_model
+                                ? formatModelName(s.main_model)
+                                : "-"}
+                            </Link>
+                          </td>
                           <td className="text-zinc-400">
                             <Link href={href} className="block py-2 pr-3">
                               {formatTimestamp(s.started_at)}


### PR DESCRIPTION
## Summary

- **Sessions list** — move the Surface column to sit between Provider and Model so the row reads Member → Provider → Surface → Model → …, the order spelled out in #203 acceptance.
- **Models page** — add a Cost-by-Surface card mirroring the existing Overview "Spend by Surface" chart, so a manager investigating the per-model breakdown can also see per-surface spend without bouncing back to /dashboard.
- Reuses `getCostBySurface`, `CostBarChart`, and the single-surface empty-state copy so the Overview and Models cards stay in lockstep.

Closes #203.

## Test plan

- [x] `npm test` — full vitest suite (275/275)
- [x] `npm run lint`
- [x] `npm run build`
- [x] Sessions list multi-surface column-order test
- [x] New Models-page tests: card renders, DAL is called, units toggle relabels card, single-surface empty-state copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)