### PR TITLE
feat(sessions): add Surface column + filter (#203)

### DIFF
--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -348,7 +348,7 @@ describe("dashboard/sessions /page", () => {
     }
   });
 
-  it("surface column: rendered when the org has 2+ surfaces, hidden when only one (#187)", async () => {
+  it("surface column: always rendered, regardless of distinct-surface count (#203)", async () => {
     // Multi-surface org: column header + per-row cells render the formatted
     // surface label, not the raw daemon id.
     let node = await render();
@@ -357,15 +357,49 @@ describe("dashboard/sessions /page", () => {
     expect(text).toContain("VS Code");
     expect(text).toContain("Cursor");
 
-    // Single-surface org: column collapses out so every row doesn't repeat
-    // the same value.
+    // Single-surface org (#203): column still renders so the dimension is
+    // discoverable. Pre-#203 this collapsed out — which masked #204 in
+    // production by leaving the user no signal that the column existed at
+    // all once every row landed as `unknown`.
     dal.getKnownSurfaces.mockResolvedValue(["vscode"]);
     node = await render();
     text = extractText(node);
-    // Surface table-header text is gone (the `Provider` / `Model` / `Started`
-    // headers still render, so a contains-check on them isn't useful here).
-    // Use a regex tied to the cell column-header position to avoid matching
-    // unrelated copy.
-    expect(text).not.toMatch(/Provider.*Model.*Surface/);
+    expect(text).toMatch(/Provider.*Surface.*Model/);
+  });
+
+  it("surface column: still renders when the org's only known surface is `unknown` (#203 + #204)", async () => {
+    // Production state during the #204 ingest bug: every row lands as
+    // `surface = 'unknown'`. The column must still appear (with `Unknown`
+    // cells) so the user has a visible anchor for the dimension; once the
+    // daemon-side fix ships, the same column starts showing real values
+    // without any further dashboard change.
+    dal.getKnownSurfaces.mockResolvedValue(["unknown"]);
+    dal.getSessions.mockResolvedValue({
+      rows: [
+        {
+          device_id: "dev_ivan",
+          session_id: "sess_unk",
+          provider: "claude_code",
+          started_at: "2026-04-15T10:00:00.000Z",
+          ended_at: null,
+          duration_ms: null,
+          repo_id: "repo_x",
+          git_branch: "refs/heads/main",
+          ticket: null,
+          message_count: 1,
+          total_input_tokens: 0,
+          total_output_tokens: 0,
+          total_cost_cents: 0,
+          main_model: null,
+          owner_name: "Ivan",
+          surface: "unknown",
+        },
+      ],
+      nextCursor: null,
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toMatch(/Provider.*Surface.*Model/);
+    expect(text).toContain("Unknown");
   });
 });

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -104,10 +104,15 @@ export default async function SessionsPage({
   if (params.units) baseParams.set("units", params.units);
   if (params.surface) baseParams.set("surface", params.surface);
 
-  // Hide the Surface column on single-surface orgs — every row would carry
-  // the same value, which is just visual noise. Once a second surface
-  // appears the column starts rendering automatically (acceptance for #187).
-  const showSurfaceColumn = knownSurfaces.length > 1;
+  // Always render the Surface column (#203). Earlier (#187) the column
+  // hid on single-surface orgs to avoid a redundant cell, but that gate
+  // also collapsed the column on orgs whose daemon hasn't yet started
+  // emitting `surface` — leaving the user with no signal that the
+  // dimension exists. The header reads as "Surface" with `Unknown` cells
+  // until daemons upload a real value, which is the documented #203
+  // acceptance ("the column structure should still land — it'll fill in
+  // the moment #204's ingest fix ships").
+  const showSurfaceColumn = true;
   // Click-to-filter target for a session-row's surface cell. Preserves the
   // other active filters; resets cursor / page so the filtered list starts
   // from the first page rather than wherever the user happened to be.

--- a/src/components/surface-filter.tsx
+++ b/src/components/surface-filter.tsx
@@ -17,14 +17,18 @@ const ALL_SURFACE_LABEL = "All surfaces";
  * multi-select UIs can ship without a wire-shape change. For v1 the chip
  * surfaces a single-select dropdown.
  *
- * Hidden when `surfaces` has 0 or 1 entries — a chip that can only filter
- * to "everything" or "the only thing" adds noise.
+ * Hidden only when `surfaces` is empty — i.e. the org has no rollups yet,
+ * so a dropdown that would only offer "All surfaces" carries zero signal.
+ * Once any surface is known (even just `unknown` from pre-bump daemons)
+ * the chip renders so the dimension is discoverable: #203 explicitly asks
+ * the filter to land alongside Teammate / time-range / $/Tokens
+ * regardless of the number of distinct surfaces in the data.
  */
 export function SurfaceFilter({ surfaces }: { surfaces: string[] }) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  if (surfaces.length < 2) return null;
+  if (surfaces.length === 0) return null;
 
   const raw = searchParams.get("surface");
   const parsed = parseSurfaceParam(raw);


### PR DESCRIPTION
## Summary

Closes #203. The reopen comment flagged that the Sessions list still has no Surface column and no Surface filter chip on `app.getbudi.dev`. The column existed in code (`page.tsx`) but was gated on `knownSurfaces.length > 1`; the same gate hid the `<SurfaceFilter>` chip. In production the daemon's surface upload path is broken (#204), so every row lands with `surface = 'unknown'` → `knownSurfaces == ['unknown']` (length 1) → both column and chip collapse out, leaving the user no signal that the dimension exists.

The fix is to drop the gate. Per the #203 reopen comment ("the column structure should still land — it'll fill in the moment #204's ingest fix ships"):

- `src/app/dashboard/sessions/page.tsx` — `showSurfaceColumn = true` unconditionally. The header reads "Surface" and cells render `Unknown` until daemons start uploading real values.
- `src/components/surface-filter.tsx` — render whenever `surfaces` is non-empty (was: `>= 2`). A totally-empty org still hides the chip, but any rollup data → chip renders.

## Test plan

- [x] `npm test` — 293 passed (full vitest suite). The `#187 single-surface hide` test was rewritten to pin the new always-on shape; added a regression that pins the `unknown`-only edge case (column + cell still render).
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `git diff main --stat` — production code touched in `page.tsx` and `surface-filter.tsx`, not test-only.

## Live verification

After deploy, navigate to `https://app.getbudi.dev/dashboard/sessions`.

```js
[...document.querySelectorAll('thead th, table th')].map(t => t.textContent.trim())
```

PASS if the array includes `"Surface"`.

```js
!!document.querySelector('[data-testid="surface-filter"]')
```

PASS if `true` — the filter chip is in the header row.

Note: until #204 (daemon-side surface upload) ships, every cell will read `Unknown`. That's expected — the column structure is what this PR lands. Once the daemon fix ships the same column starts showing real values without any further dashboard change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)