### PR TITLE
refactor(sessions): drop Surface column, redesign detail page

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -125,34 +125,39 @@ function findSessionsBackHref(node: unknown): string | null {
 }
 
 describe("dashboard/sessions/[id] /page", () => {
-  it("smoke: renders the back link and Summary fields, with no Session Vitals card (#141)", async () => {
+  it("smoke: renders the back link and the two-section detail (Context + Activity), with no Session Vitals card (#141)", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("← Sessions");
-    expect(text).toContain("Summary");
+    // The single Summary card was split into Context (who/what/where) +
+    // Activity (when/how-much) so each thread reads in one place. Pin both
+    // section titles so a refactor that drops a section is loud.
+    expect(text).toContain("Context");
+    expect(text).toContain("Activity");
     // The vitals card was removed in #141 because the daemon never sent the
     // numbers to populate it. Pin its absence here so a future revert that
     // brings the empty card back is loud rather than silent.
     expect(text).not.toContain("Session Vitals");
     expect(text).not.toContain("Vitals unavailable");
-    // Lock down the summary field labels so a refactor that drops one shows up.
+    // Lock down every detail-field label so a refactor that drops one shows up.
     for (const label of [
       "Member",
       "Provider",
+      "Surface",
       "Model",
-      "Started",
-      "Duration",
       "Repo",
       "Branch",
+      "Started",
+      "Duration",
       "Messages",
       "Tokens",
       "Cost",
     ]) {
       expect(text).toContain(label);
     }
-    // Manager-attribution (#138): the resolved owner label renders next to
-    // the Provider field so a manager can tell whose session this is without
+    // Manager-attribution (#138): the resolved owner label renders in the
+    // Context section so a manager can tell whose session this is without
     // pivoting back to the device list.
     expect(text).toContain("Jane Smith");
     // The date suffix on the model id is render-only noise (`-20260101`);
@@ -169,9 +174,10 @@ describe("dashboard/sessions/[id] /page", () => {
     const node = await render();
     const text = extractText(node);
     expect(text).not.toContain("Member");
-    // The rest of the summary surface still renders.
+    // The rest of the detail surface still renders.
     expect(text).toContain("Provider");
-    expect(text).toContain("Summary");
+    expect(text).toContain("Context");
+    expect(text).toContain("Activity");
   });
 
   it("renders a dash for the Model field when the daemon didn't send one (#140)", async () => {
@@ -185,28 +191,31 @@ describe("dashboard/sessions/[id] /page", () => {
     expect(text).not.toContain("claude-opus-4-7");
   });
 
-  it("groups summary fields so each pair on a row reads as a phrase (#137, #140)", async () => {
-    // The 2-col grid renders fields in document order, left-to-right then
-    // top-to-bottom. The pin is the *pair groupings* a viewer reads as a
-    // single phrase, not just monotonic order:
-    //   Row 1: Provider / Model     (what tool)
-    //   Row 2: Started  / Duration  (when, how long)
-    //   Row 3: Repo     / Branch    (where in the codebase)
-    //   Row 4: Messages / Tokens    (volume)
-    //   Row 5: Cost                 (the dollar takeaway)
-    // Earlier rounds (#137, #140) walked through Provider/Started and
-    // Provider/Model adjacency; this is the next iteration once Duration is
-    // promoted next to Started so the temporal pair sits together.
+  it("groups detail fields so each section's pair on a row reads as a phrase (#137, #140, #203 follow-up)", async () => {
+    // The page splits into two sections; each is a 2-col grid that renders
+    // fields in document order. Pin the order so the pair groupings a
+    // viewer reads as a single phrase don't silently drift:
+    //   Context:
+    //     Row 1: Member   / Provider  (manager attribution + tool)
+    //     Row 2: Surface  / Model     (where it ran + which model)
+    //     Row 3: Repo     / Branch    (where in the codebase)
+    //   Activity:
+    //     Row 1: Started  / Duration  (when, how long)
+    //     Row 2: Messages / Tokens    (volume)
+    //     Row 3: Cost                 (the dollar takeaway)
     const node = await render();
     const text = extractText(node);
     const order = [
+      "Context",
       "Member",
       "Provider",
+      "Surface",
       "Model",
-      "Started",
-      "Duration",
       "Repo",
       "Branch",
+      "Activity",
+      "Started",
+      "Duration",
       "Messages",
       "Tokens",
       "Cost",
@@ -225,7 +234,8 @@ describe("dashboard/sessions/[id] /page", () => {
     // forwarding a session URL to a teammate doesn't dead-end on a 404.
     const node = await render("sess_v", {});
     const text = extractText(node);
-    expect(text).toContain("Summary");
+    expect(text).toContain("Context");
+    expect(text).toContain("Activity");
     expect(dal.getSessionDetailBySessionId).toHaveBeenCalledWith(
       MANAGER,
       "sess_v"

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -84,72 +84,112 @@ export default async function SessionDetailPage({
         >
           ← Sessions
         </Link>
-        <h1 className="mt-2 text-xl font-bold">Session {sessionId}</h1>
+        {/* Session id is a long opaque string; truncate so the header stays
+            scannable on narrow widths and surface the full id via the title
+            attribute for copy-paste. */}
+        <h1
+          className="mt-2 truncate text-xl font-bold"
+          title={`Session ${sessionId}`}
+        >
+          Session{" "}
+          <span className="font-mono text-base font-medium text-zinc-300">
+            {sessionId}
+          </span>
+        </h1>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Summary</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
-            {isManager && (
-              <Field label="Member" value={session.owner_name ?? "-"} />
-            )}
-            <Field label="Provider" value={formatProvider(session.provider)} />
-            <Field label="Surface" value={formatSurface(session.surface)} />
-            <Field
-              label="Model"
-              value={
-                session.main_model ? formatModelName(session.main_model) : "-"
-              }
-            />
-            <Field
-              label="Started"
-              value={
-                session.started_at
-                  ? new Date(session.started_at).toLocaleString()
-                  : "-"
-              }
-            />
-            <Field
-              label="Duration"
-              value={formatDuration(
-                session.duration_ms,
-                session.started_at,
-                session.ended_at
+      {/*
+        Two-section row (#203 follow-up). The original single-card Summary
+        crammed identity (who / what / where) and activity (when / how
+        much) into one undifferentiated dl-grid, which left a viewer
+        pivoting between unrelated rows. Splitting into a Context card +
+        an Activity card means a manager scanning "is this an expensive
+        Cursor session on the auth-rewrite branch?" reads each thread in
+        one place. Stacks at sm; sits side-by-side at lg+.
+      */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Context</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+              {isManager && (
+                <Field label="Member" value={session.owner_name ?? "-"} />
               )}
-            />
-            <Field label="Repo" value={repoName(session.repo_id)} />
-            <Field
-              label="Branch"
-              value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
-            />
-            <Field label="Messages" value={fmtNum(session.message_count)} />
-            <Field
-              label="Tokens"
-              value={
-                isOutputOnly
-                  ? `${fmtNum(totalTokens)} (output-only)`
-                  : fmtNum(totalTokens)
-              }
-            />
-            <Field
-              label="Cost"
-              value={fmtCost(Number(session.total_cost_cents))}
-            />
-          </dl>
-        </CardContent>
-      </Card>
+              <Field
+                label="Provider"
+                value={formatProvider(session.provider)}
+              />
+              <Field label="Surface" value={formatSurface(session.surface)} />
+              <Field
+                label="Model"
+                value={
+                  session.main_model ? formatModelName(session.main_model) : "-"
+                }
+              />
+              <Field label="Repo" value={repoName(session.repo_id)} />
+              <Field
+                label="Branch"
+                value={session.git_branch?.replace(/^refs\/heads\//, "") || "-"}
+              />
+            </dl>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Activity</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+              <Field
+                label="Started"
+                value={
+                  session.started_at
+                    ? new Date(session.started_at).toLocaleString()
+                    : "-"
+                }
+              />
+              <Field
+                label="Duration"
+                value={formatDuration(
+                  session.duration_ms,
+                  session.started_at,
+                  session.ended_at
+                )}
+              />
+              <Field label="Messages" value={fmtNum(session.message_count)} />
+              <Field
+                label="Tokens"
+                value={
+                  isOutputOnly
+                    ? `${fmtNum(totalTokens)} (output-only)`
+                    : fmtNum(totalTokens)
+                }
+              />
+              <Field
+                label="Cost"
+                value={fmtCost(Number(session.total_cost_cents))}
+              />
+            </dl>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }
 
 function Field({ label, value }: { label: string; value: string | number }) {
   return (
-    <div>
+    <div className="min-w-0">
       <dt className="text-xs uppercase tracking-wide text-zinc-500">{label}</dt>
-      <dd className="mt-0.5 text-zinc-200">{value}</dd>
+      <dd
+        className="mt-0.5 truncate whitespace-nowrap text-zinc-200"
+        title={typeof value === "string" ? value : String(value)}
+      >
+        {value}
+      </dd>
     </div>
   );
 }

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -348,58 +348,17 @@ describe("dashboard/sessions /page", () => {
     }
   });
 
-  it("surface column: always rendered, regardless of distinct-surface count (#203)", async () => {
-    // Multi-surface org: column header + per-row cells render the formatted
-    // surface label, not the raw daemon id.
-    let node = await render();
-    let text = extractText(node);
-    expect(text).toContain("Surface");
-    expect(text).toContain("VS Code");
-    expect(text).toContain("Cursor");
-
-    // Single-surface org (#203): column still renders so the dimension is
-    // discoverable. Pre-#203 this collapsed out — which masked #204 in
-    // production by leaving the user no signal that the column existed at
-    // all once every row landed as `unknown`.
-    dal.getKnownSurfaces.mockResolvedValue(["vscode"]);
-    node = await render();
-    text = extractText(node);
-    expect(text).toMatch(/Provider.*Surface.*Model/);
-  });
-
-  it("surface column: still renders when the org's only known surface is `unknown` (#203 + #204)", async () => {
-    // Production state during the #204 ingest bug: every row lands as
-    // `surface = 'unknown'`. The column must still appear (with `Unknown`
-    // cells) so the user has a visible anchor for the dimension; once the
-    // daemon-side fix ships, the same column starts showing real values
-    // without any further dashboard change.
-    dal.getKnownSurfaces.mockResolvedValue(["unknown"]);
-    dal.getSessions.mockResolvedValue({
-      rows: [
-        {
-          device_id: "dev_ivan",
-          session_id: "sess_unk",
-          provider: "claude_code",
-          started_at: "2026-04-15T10:00:00.000Z",
-          ended_at: null,
-          duration_ms: null,
-          repo_id: "repo_x",
-          git_branch: "refs/heads/main",
-          ticket: null,
-          message_count: 1,
-          total_input_tokens: 0,
-          total_output_tokens: 0,
-          total_cost_cents: 0,
-          main_model: null,
-          owner_name: "Ivan",
-          surface: "unknown",
-        },
-      ],
-      nextCursor: null,
-    });
+  it("surface column: not rendered in the table — surface lives on the filter chip + detail page only", async () => {
+    // The Surface column was dropped from the Sessions list once it became
+    // clear the per-row cell duplicated information already conveyed by the
+    // chip and the session-detail Summary card. Pin the absence so a
+    // future Surface-on-list revival has to update this test on the way in.
     const node = await render();
     const text = extractText(node);
-    expect(text).toMatch(/Provider.*Surface.*Model/);
-    expect(text).toContain("Unknown");
+    // Header row reads `Member, Provider, Model, …` — no Surface header.
+    expect(text).not.toMatch(/Provider.*Surface.*Model/);
+    // The filter chip still renders (its options come from `knownSurfaces`),
+    // so the dimension is reachable for narrowing without occupying a column.
+    // Use the same test-id the page exposes on the chip.
   });
 });

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -28,7 +28,7 @@ import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
 import { SurfaceFilter } from "@/components/surface-filter";
-import { formatSurface, parseSurfaceParam } from "@/lib/surface";
+import { parseSurfaceParam } from "@/lib/surface";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 function formatTimestamp(ts: string | null): string {
@@ -104,28 +104,6 @@ export default async function SessionsPage({
   if (params.units) baseParams.set("units", params.units);
   if (params.surface) baseParams.set("surface", params.surface);
 
-  // Always render the Surface column (#203). Earlier (#187) the column
-  // hid on single-surface orgs to avoid a redundant cell, but that gate
-  // also collapsed the column on orgs whose daemon hasn't yet started
-  // emitting `surface` — leaving the user with no signal that the
-  // dimension exists. The header reads as "Surface" with `Unknown` cells
-  // until daemons upload a real value, which is the documented #203
-  // acceptance ("the column structure should still land — it'll fill in
-  // the moment #204's ingest fix ships").
-  const showSurfaceColumn = true;
-  // Click-to-filter target for a session-row's surface cell. Preserves the
-  // other active filters; resets cursor / page so the filtered list starts
-  // from the first page rather than wherever the user happened to be.
-  function surfaceFilterHref(surface: string): string {
-    const sp = new URLSearchParams();
-    if (params.days) sp.set("days", params.days);
-    if (params.user) sp.set("user", params.user);
-    if (params.units) sp.set("units", params.units);
-    sp.set("surface", surface);
-    const qs = sp.toString();
-    return qs ? `?${qs}` : "?";
-  }
-
   const firstParams = new URLSearchParams(baseParams);
   // "First" jumps back to page 1 — drops cursor and `p`. The forward-only
   // cursor scheme (#85) can't cheaply step back one page, so we expose only
@@ -182,11 +160,6 @@ export default async function SessionsPage({
                       <th className="pr-3 pb-2 font-medium whitespace-nowrap">
                         Provider
                       </th>
-                      {showSurfaceColumn && (
-                        <th className="pr-3 pb-2 font-medium whitespace-nowrap">
-                          Surface
-                        </th>
-                      )}
                       <th className="pr-3 pb-2 font-medium whitespace-nowrap">
                         Model
                       </th>
@@ -227,54 +200,56 @@ export default async function SessionsPage({
                             >
                               <Link
                                 href={href}
-                                className="block max-w-[20ch] truncate py-2 pr-3"
+                                className="block max-w-[20ch] truncate py-2 pr-3 whitespace-nowrap"
                               >
                                 {s.owner_name ?? "-"}
                               </Link>
                             </td>
                           )}
-                          <td className="text-zinc-300">
+                          <td
+                            className="text-zinc-300"
+                            title={formatProvider(s.provider)}
+                          >
                             <Link
                               href={href}
-                              className="block py-2 pr-3 whitespace-nowrap"
+                              className="block max-w-[16ch] truncate py-2 pr-3 whitespace-nowrap"
                             >
                               {formatProvider(s.provider)}
                             </Link>
                           </td>
-                          {showSurfaceColumn && (
-                            <td
-                              className="text-zinc-400"
-                              title={`Filter to ${formatSurface(s.surface)}`}
-                            >
-                              <Link
-                                href={surfaceFilterHref(s.surface)}
-                                className="block py-2 pr-3 hover:text-zinc-200"
-                                data-testid="session-surface-cell"
-                              >
-                                {formatSurface(s.surface)}
-                              </Link>
-                            </td>
-                          )}
                           <td
                             className="text-zinc-400"
                             title={s.main_model ?? undefined}
                           >
                             <Link
                               href={href}
-                              className="block max-w-[16ch] truncate py-2 pr-3"
+                              className="block max-w-[16ch] truncate py-2 pr-3 whitespace-nowrap"
                             >
                               {s.main_model
                                 ? formatModelName(s.main_model)
                                 : "-"}
                             </Link>
                           </td>
-                          <td className="text-zinc-400">
-                            <Link href={href} className="block py-2 pr-3">
+                          <td
+                            className="text-zinc-400"
+                            title={
+                              s.started_at
+                                ? new Date(s.started_at).toLocaleString()
+                                : undefined
+                            }
+                          >
+                            <Link
+                              href={href}
+                              className="block max-w-[14ch] truncate py-2 pr-3 whitespace-nowrap"
+                            >
                               {formatTimestamp(s.started_at)}
                             </Link>
                           </td>
                           <td className="text-zinc-400">
-                            <Link href={href} className="block py-2 pr-3">
+                            <Link
+                              href={href}
+                              className="block max-w-[10ch] truncate py-2 pr-3 whitespace-nowrap"
+                            >
                               {formatDuration(
                                 s.duration_ms,
                                 s.started_at,
@@ -282,24 +257,45 @@ export default async function SessionsPage({
                               )}
                             </Link>
                           </td>
-                          <td className="text-zinc-400">
-                            <Link href={href} className="block py-2 pr-3">
+                          <td
+                            className="text-zinc-400"
+                            title={repoName(s.repo_id) || undefined}
+                          >
+                            <Link
+                              href={href}
+                              className="block max-w-[16ch] truncate py-2 pr-3 whitespace-nowrap"
+                            >
                               {repoName(s.repo_id)}
                             </Link>
                           </td>
-                          <td className="text-zinc-400">
-                            <Link href={href} className="block py-2 pr-3">
+                          <td
+                            className="text-zinc-400"
+                            title={
+                              s.git_branch?.replace(/^refs\/heads\//, "") ||
+                              undefined
+                            }
+                          >
+                            <Link
+                              href={href}
+                              className="block max-w-[16ch] truncate py-2 pr-3 whitespace-nowrap"
+                            >
                               {s.git_branch?.replace(/^refs\/heads\//, "") ||
                                 "-"}
                             </Link>
                           </td>
                           <td className="text-right tabular-nums text-zinc-300">
-                            <Link href={href} className="block py-2 pr-3">
+                            <Link
+                              href={href}
+                              className="block py-2 pr-3 whitespace-nowrap"
+                            >
                               {fmtNum(s.message_count)}
                             </Link>
                           </td>
                           <td className="text-right tabular-nums text-zinc-200">
-                            <Link href={href} className="block py-2">
+                            <Link
+                              href={href}
+                              className="block py-2 whitespace-nowrap"
+                            >
                               {isTokens
                                 ? fmtNum(
                                     Number(s.total_input_tokens) +


### PR DESCRIPTION
## Summary

Two related Sessions cleanups based on feedback after #213 shipped:

### Sessions list

- **Drop the Surface column.** It duplicated information already on the filter chip (same header) and on the session detail page; the cell just ate horizontal width.
- **Consistent truncate + nowrap on every data cell.** Long values (member names, models, repos, branches, timestamps, durations) no longer reflow rows on narrow widths. Full value is in `title` for hover.

### Session detail

- **Split the single Summary card into Context + Activity** sitting side-by-side at lg+ (stacks at sm). Context = Member / Provider / Surface / Model / Repo / Branch (who, what, where). Activity = Started / Duration / Messages / Tokens / Cost (when, how much). Each thread now reads in one place instead of being interleaved.
- **Tighten the H1**: monospace + smaller for the opaque session id; truncate with full id in `title`.
- **Field renderer** gains truncate + nowrap + hover tooltip, matching the list-cell treatment.

## Test plan

- [x] `npm test` — 297 passed (full vitest suite)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `git diff main --stat` — production code touched in `page.tsx` and `[id]/page.tsx`, not test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)