### PR TITLE
chore(dashboard): drop user-facing ADR-0083 links (#220)

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -216,16 +216,7 @@ export default async function ReposPage({
             <span className="text-zinc-400">(no repo)</span> aggregates spend
             from sessions whose directory didn&rsquo;t map to a known git
             remote. Your local Budi&rsquo;s privacy layer strips the repo
-            identifier in that case; see{" "}
-            <a
-              className="underline decoration-dotted underline-offset-2 hover:text-zinc-300"
-              href="https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md"
-              target="_blank"
-              rel="noreferrer"
-            >
-              ADR-0083
-            </a>
-            .
+            identifier in that case.
           </p>
         </CardContent>
       </Card>

--- a/src/components/sync-freshness.tsx
+++ b/src/components/sync-freshness.tsx
@@ -271,14 +271,6 @@ function StalledBadge({
               .
             </li>
           </ol>
-          <a
-            className="text-zinc-400 underline decoration-dotted underline-offset-2 hover:text-zinc-200"
-            href="https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md"
-            target="_blank"
-            rel="noreferrer"
-          >
-            ADR-0083 — cloud sync contract
-          </a>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Removes the two `<a href=".../docs/adr/0083-...">` anchors in the dashboard UI (Repos page "(no repo)" explainer + `sync-freshness` stalled-sync panel).
- Rephrases the surrounding copy so the Repos paragraph stands on its own; the stalled-sync panel ends cleanly with the troubleshooting list.
- Comment-level ADR references in source (out of scope per the ticket) are untouched.

Closes #220.

## Test plan
- [x] `grep -rn 'docs/adr' src/` → 0 hits
- [x] `npx vitest run src/app/dashboard/repos/page.test.tsx src/components/sync-freshness.test.tsx` → all pass
- [x] `npx tsc --noEmit` → clean
- [x] `npx eslint` on touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)