### PR TITLE
docs: align CLAUDE.md stub and complete sibling list in SOUL.md/README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
-@AGENTS.md
+# CLAUDE.md
+
+Canonical AI-agent repository guidance lives in `SOUL.md`.
+
+This file is kept only as a compatibility pointer for tools that still look for `CLAUDE.md`.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Required GitHub Actions secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`
 
 - **[budi](https://github.com/siropkin/budi)** — Rust daemon + CLI (pushes data via cloud sync)
 - **[budi-cursor](https://github.com/siropkin/budi-cursor)** — VS Code/Cursor extension
+- **[budi-jetbrains](https://github.com/siropkin/budi-jetbrains)** — JetBrains IDE plugin
+- **[homebrew-budi](https://github.com/siropkin/homebrew-budi)** — Homebrew tap for `brew install siropkin/budi/budi`
+- **[getbudi.dev](https://github.com/siropkin/getbudi.dev)** — Public marketing landing page
 
 ## License
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -10,12 +10,14 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ## Product boundaries
 
-| Product         | Repo                                                              | Role                                                                                     |
-| --------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| **budi-core**   | [`siropkin/budi`](https://github.com/siropkin/budi)               | Rust daemon + CLI. Owns SQLite, pushes aggregates to this service.                       |
-| **budi-cursor** | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor) | VS Code/Cursor extension. Unrelated to the cloud.                                        |
-| **budi-cloud**  | **this repo** (`siropkin/budi-cloud`)                             | Cloud dashboard + ingest API.                                                            |
-| **getbudi.dev** | [`siropkin/getbudi.dev`](https://github.com/siropkin/getbudi.dev) | Public marketing landing page. Different subdomain (`getbudi.dev` vs `app.getbudi.dev`). |
+| Product             | Repo                                                                      | Role                                                                                     |
+| ------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **budi-core**       | [`siropkin/budi`](https://github.com/siropkin/budi)                       | Rust daemon + CLI. Owns SQLite, pushes aggregates to this service.                       |
+| **budi-cursor**     | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor)         | VS Code/Cursor extension. Unrelated to the cloud.                                        |
+| **budi-jetbrains**  | [`siropkin/budi-jetbrains`](https://github.com/siropkin/budi-jetbrains)   | JetBrains IDE plugin. Sibling surface to `budi-cursor`.                                  |
+| **budi-cloud**      | **this repo** (`siropkin/budi-cloud`)                                     | Cloud dashboard + ingest API.                                                            |
+| **homebrew-budi**   | [`siropkin/homebrew-budi`](https://github.com/siropkin/homebrew-budi)     | Homebrew tap for `brew install siropkin/budi/budi`.                                      |
+| **getbudi.dev**     | [`siropkin/getbudi.dev`](https://github.com/siropkin/getbudi.dev)         | Public marketing landing page. Different subdomain (`getbudi.dev` vs `app.getbudi.dev`). |
 
 Extraction boundaries are defined in [ADR-0086](https://github.com/siropkin/budi/blob/main/docs/adr/0086-extraction-boundaries.md) in the main repo. The privacy contract is [ADR-0083](https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md). Read both before touching the ingest path.
 

--- a/SOUL.md
+++ b/SOUL.md
@@ -10,14 +10,14 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 ## Product boundaries
 
-| Product             | Repo                                                                      | Role                                                                                     |
-| ------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| **budi-core**       | [`siropkin/budi`](https://github.com/siropkin/budi)                       | Rust daemon + CLI. Owns SQLite, pushes aggregates to this service.                       |
-| **budi-cursor**     | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor)         | VS Code/Cursor extension. Unrelated to the cloud.                                        |
-| **budi-jetbrains**  | [`siropkin/budi-jetbrains`](https://github.com/siropkin/budi-jetbrains)   | JetBrains IDE plugin. Sibling surface to `budi-cursor`.                                  |
-| **budi-cloud**      | **this repo** (`siropkin/budi-cloud`)                                     | Cloud dashboard + ingest API.                                                            |
-| **homebrew-budi**   | [`siropkin/homebrew-budi`](https://github.com/siropkin/homebrew-budi)     | Homebrew tap for `brew install siropkin/budi/budi`.                                      |
-| **getbudi.dev**     | [`siropkin/getbudi.dev`](https://github.com/siropkin/getbudi.dev)         | Public marketing landing page. Different subdomain (`getbudi.dev` vs `app.getbudi.dev`). |
+| Product            | Repo                                                                    | Role                                                                                     |
+| ------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **budi-core**      | [`siropkin/budi`](https://github.com/siropkin/budi)                     | Rust daemon + CLI. Owns SQLite, pushes aggregates to this service.                       |
+| **budi-cursor**    | [`siropkin/budi-cursor`](https://github.com/siropkin/budi-cursor)       | VS Code/Cursor extension. Unrelated to the cloud.                                        |
+| **budi-jetbrains** | [`siropkin/budi-jetbrains`](https://github.com/siropkin/budi-jetbrains) | JetBrains IDE plugin. Sibling surface to `budi-cursor`.                                  |
+| **budi-cloud**     | **this repo** (`siropkin/budi-cloud`)                                   | Cloud dashboard + ingest API.                                                            |
+| **homebrew-budi**  | [`siropkin/homebrew-budi`](https://github.com/siropkin/homebrew-budi)   | Homebrew tap for `brew install siropkin/budi/budi`.                                      |
+| **getbudi.dev**    | [`siropkin/getbudi.dev`](https://github.com/siropkin/getbudi.dev)       | Public marketing landing page. Different subdomain (`getbudi.dev` vs `app.getbudi.dev`). |
 
 Extraction boundaries are defined in [ADR-0086](https://github.com/siropkin/budi/blob/main/docs/adr/0086-extraction-boundaries.md) in the main repo. The privacy contract is [ADR-0083](https://github.com/siropkin/budi/blob/main/docs/adr/0083-cloud-ingest-identity-and-privacy-contract.md). Read both before touching the ingest path.
 


### PR DESCRIPTION
## Summary

- Replace `CLAUDE.md`'s `@AGENTS.md` include with the shared text stub used by the other 5 sibling repos so all ecosystem repos ship an identical compatibility pointer.
- Extend `SOUL.md` product boundaries table to list all six repos (adds `budi-jetbrains` and `homebrew-budi`).
- Extend `README.md` Ecosystem section to list all five sibling repos (adds `budi-jetbrains`, `homebrew-budi`, `getbudi.dev`) so it matches the SOUL.md table.

Closes #219

## Test plan

- [x] `CLAUDE.md` matches the standard text-stub shape used by sibling repos
- [x] `SOUL.md` Product boundaries lists all six repos
- [x] `README.md` Ecosystem lists all five sibling repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)