### PR TITLE
feat(sessions): add cost-percentile distribution strip (#217)

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -40,8 +40,7 @@ const dal = {
 // `@/lib/dal`; spread the real exports so that helper resolves while the
 // async DAL entry points stay mockable per-test.
 vi.mock("@/lib/dal", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/lib/dal")>("@/lib/dal");
+  const actual = await vi.importActual<typeof import("@/lib/dal")>("@/lib/dal");
   return {
     ...actual,
     getCurrentUser: dal.getCurrentUser,
@@ -151,7 +150,11 @@ function findStripProps(node: unknown): {
     seen.add(n as object);
     const el = n as {
       type?: unknown;
-      props?: { children?: unknown; distribution?: unknown; currentCostCents?: unknown };
+      props?: {
+        children?: unknown;
+        distribution?: unknown;
+        currentCostCents?: unknown;
+      };
     };
     const t = el.type as { name?: string } | undefined;
     if (

--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -33,8 +33,25 @@ const dal = {
   getSessionDetail: vi.fn(),
   getSessionDetailBySessionId: vi.fn(),
   getDeviceSessionsForDay: vi.fn(),
+  getEarliestActivity: vi.fn(),
+  getSessionCostDistribution: vi.fn(),
 };
-vi.mock("@/lib/dal", () => dal);
+// The strip component imports `sessionCostBucketIndex` directly from
+// `@/lib/dal`; spread the real exports so that helper resolves while the
+// async DAL entry points stay mockable per-test.
+vi.mock("@/lib/dal", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/dal")>("@/lib/dal");
+  return {
+    ...actual,
+    getCurrentUser: dal.getCurrentUser,
+    getSessionDetail: dal.getSessionDetail,
+    getSessionDetailBySessionId: dal.getSessionDetailBySessionId,
+    getDeviceSessionsForDay: dal.getDeviceSessionsForDay,
+    getEarliestActivity: dal.getEarliestActivity,
+    getSessionCostDistribution: dal.getSessionCostDistribution,
+  };
+});
 vi.mock("@/lib/viewer-timezone", () => ({
   getViewerTimeZone: async () => "UTC",
 }));
@@ -84,6 +101,14 @@ beforeEach(() => {
   // Default: single-session day so the timeline is hidden in baseline
   // smoke tests. Suites that exercise the timeline override per-case.
   dal.getDeviceSessionsForDay.mockReset().mockResolvedValue([SESSION]);
+  dal.getEarliestActivity.mockReset().mockResolvedValue(null);
+  // Default: empty cost distribution so the cost-vs-team strip is hidden in
+  // baseline smoke tests (matches the < 10 sessions empty state from #217).
+  dal.getSessionCostDistribution.mockReset().mockResolvedValue({
+    buckets: [],
+    total_sessions: 0,
+    max_cost_cents: 0,
+  });
 });
 
 async function render(
@@ -95,6 +120,53 @@ async function render(
     params: Promise.resolve({ id }),
     searchParams: Promise.resolve(searchParams),
   });
+}
+
+/**
+ * Walk the rendered tree for the cost-distribution strip element and pull its
+ * props out. The strip is a function component, so its body never executes
+ * inside the page-test pipeline — we capture the props the page handed it
+ * (distribution + current cost) and verify the wiring without poking at the
+ * strip's rendered output. Render-side coverage lives in the strip's own
+ * test file (`session-cost-distribution-strip.test.tsx`).
+ */
+function findStripProps(node: unknown): {
+  distribution: unknown;
+  currentCostCents: unknown;
+} | null {
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): {
+    distribution: unknown;
+    currentCostCents: unknown;
+  } | null {
+    if (!n || typeof n !== "object") return null;
+    if (Array.isArray(n)) {
+      for (const c of n) {
+        const f = walk(c);
+        if (f) return f;
+      }
+      return null;
+    }
+    if (seen.has(n as object)) return null;
+    seen.add(n as object);
+    const el = n as {
+      type?: unknown;
+      props?: { children?: unknown; distribution?: unknown; currentCostCents?: unknown };
+    };
+    const t = el.type as { name?: string } | undefined;
+    if (
+      t &&
+      typeof t === "function" &&
+      (t as { name?: string }).name === "SessionCostDistributionStrip"
+    ) {
+      return {
+        distribution: el.props?.distribution,
+        currentCostCents: el.props?.currentCostCents,
+      };
+    }
+    return walk(el.props?.children);
+  }
+  return walk(node);
 }
 
 /**
@@ -311,6 +383,48 @@ describe("dashboard/sessions/[id] /page", () => {
     const text = extractText(node);
     expect(text).toContain("Copilot Chat");
     expect(text).not.toContain("copilot_chat");
+  });
+
+  it("queries the cost distribution and feeds it into the strip with the current session's cost (#217)", async () => {
+    // The strip itself owns the render-side contract (see its own tests).
+    // At the page level we pin the wiring: the DAL is called with the
+    // viewer's user, and the strip element receives the current session's
+    // `total_cost_cents` so the highlighted bucket can resolve correctly.
+    const distribution = {
+      buckets: Array.from({ length: 20 }, (_, i) => ({
+        lower_cents: i * 100,
+        upper_cents: (i + 1) * 100,
+        count: i === 5 ? 8 : 1,
+      })),
+      total_sessions: 27,
+      max_cost_cents: 2000,
+    };
+    dal.getSessionCostDistribution.mockResolvedValue(distribution);
+    const node = await render();
+    expect(dal.getSessionCostDistribution).toHaveBeenCalledTimes(1);
+    expect(dal.getSessionCostDistribution).toHaveBeenCalledWith(
+      MANAGER,
+      expect.objectContaining({ from: expect.any(String) })
+    );
+    const stripProps = findStripProps(node);
+    expect(stripProps).not.toBeNull();
+    expect(stripProps!.distribution).toBe(distribution);
+    expect(stripProps!.currentCostCents).toBe(250);
+  });
+
+  it("round-trips `?days=` from the URL into the cost-distribution range (#217)", async () => {
+    // When the viewer arrived from a filtered Sessions list (?days=7), the
+    // percentile must be computed against the same window so the call-out
+    // doesn't disagree with what the list page showed.
+    await render("sess_v", { device: "dev_ivan", days: "7" });
+    const range = dal.getSessionCostDistribution.mock.calls[0]?.[1] as {
+      from: string;
+      to: string;
+    };
+    // 7-day rolling window: from = to - 7 days.
+    const fromMs = new Date(`${range.from}T00:00:00Z`).getTime();
+    const toMs = new Date(`${range.to}T00:00:00Z`).getTime();
+    expect((toMs - fromMs) / 86_400_000).toBe(7);
   });
 
   it("annotates output-only sessions so a `0` input-token count reads as a known May-2026+ Copilot Chat state, not missing data (#168)", async () => {

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -3,9 +3,14 @@ import Link from "next/link";
 import {
   getCurrentUser,
   getDeviceSessionsForDay,
+  getEarliestActivity,
+  getSessionCostDistribution,
   getSessionDetail,
   getSessionDetailBySessionId,
 } from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { SessionCostDistributionStrip } from "@/components/session-cost-distribution-strip";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import {
   fmtCost,
@@ -96,6 +101,29 @@ export default async function SessionDetailPage({
         viewerTz
       )
     : [];
+
+  // Cost-percentile distribution strip (#217). Compares the current session's
+  // cost against every other session the viewer can see in the same period —
+  // round-tripped from the list page's `?days=` when present so a manager
+  // arriving from the filtered Sessions table sees the percentile against the
+  // same window. We default to 30d (rather than the dashboard's 7d default)
+  // because a small team frequently has < 10 sessions in a 7-day window and
+  // the strip would self-hide; 30d trades a slightly broader baseline for a
+  // meaningful percentile in the common case.
+  const distributionDays = sp.days ?? "30";
+  const earliestActivity =
+    distributionDays === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user)
+      : null;
+  const distributionRange = dateRangeFromDays(
+    distributionDays,
+    earliestActivity,
+    viewerTz
+  );
+  const costDistribution = await getSessionCostDistribution(
+    user,
+    distributionRange
+  );
 
   return (
     <div className="space-y-6">
@@ -198,6 +226,11 @@ export default async function SessionDetailPage({
           </CardContent>
         </Card>
       </div>
+
+      <SessionCostDistributionStrip
+        distribution={costDistribution}
+        currentCostCents={Number(session.total_cost_cents)}
+      />
 
       {sessionLocalDate ? (
         <DeviceDayTimeline

--- a/src/components/session-cost-distribution-strip.test.tsx
+++ b/src/components/session-cost-distribution-strip.test.tsx
@@ -172,8 +172,7 @@ describe("SessionCostDistributionStrip (#217)", () => {
     counts[0] = 5;
     counts[19] = 95;
     const buckets = bucketsWithCounts(counts);
-    const targetCost =
-      (buckets[0]!.lower_cents + buckets[0]!.upper_cents) / 2;
+    const targetCost = (buckets[0]!.lower_cents + buckets[0]!.upper_cents) / 2;
     const node = SessionCostDistributionStrip({
       distribution: {
         buckets,

--- a/src/components/session-cost-distribution-strip.test.tsx
+++ b/src/components/session-cost-distribution-strip.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
+import { SessionCostDistributionStrip } from "@/components/session-cost-distribution-strip";
+import {
+  buildSessionCostBuckets,
+  sessionCostBucketIndex,
+  type SessionCostBucket,
+} from "@/lib/session-cost-distribution";
+
+/**
+ * Unit tests for the cost-percentile distribution strip (#217).
+ *
+ * Pins the three acceptance behaviors:
+ *   1. The highlighted bucket matches the current session's cost.
+ *   2. The percentile label rounds correctly off the empirical CDF.
+ *   3. The strip hides entirely when the team has < 10 sessions in the
+ *      period (the threshold below which the percentile is meaningless).
+ */
+
+interface CapturedBar {
+  index: number;
+  isCurrent: boolean;
+  tooltip: string;
+}
+
+function collectBars(node: unknown): CapturedBar[] {
+  const out: CapturedBar[] = [];
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): void {
+    if (!n || typeof n !== "object") return;
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (seen.has(n as object)) return;
+    seen.add(n as object);
+    const el = n as ReactElement & {
+      props?: Record<string, unknown> & { children?: unknown };
+    };
+    const props = el.props as Record<string, unknown> | undefined;
+    if (props && props["data-bucket-index"] != null) {
+      out.push({
+        index: Number(props["data-bucket-index"]),
+        isCurrent:
+          (props as { "data-current"?: string })["data-current"] === "true",
+        tooltip: String((props as { title?: string }).title ?? ""),
+      });
+    }
+    walk(el.props?.children);
+  }
+  walk(node);
+  return out;
+}
+
+function collectByTestId(node: unknown, testId: string): unknown | null {
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): unknown | null {
+    if (!n || typeof n !== "object") return null;
+    if (Array.isArray(n)) {
+      for (const c of n) {
+        const f = walk(c);
+        if (f) return f;
+      }
+      return null;
+    }
+    if (seen.has(n as object)) return null;
+    seen.add(n as object);
+    const el = n as ReactElement & {
+      props?: Record<string, unknown> & { children?: unknown };
+    };
+    if (el.props && el.props["data-testid"] === testId) return el;
+    return walk(el.props?.children);
+  }
+  return walk(node);
+}
+
+function textOf(node: unknown): string {
+  const parts: string[] = [];
+  function walk(n: unknown): void {
+    if (n == null || typeof n === "boolean") return;
+    if (typeof n === "string" || typeof n === "number") {
+      parts.push(String(n));
+      return;
+    }
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (typeof n === "object") {
+      const el = n as ReactElement & { props?: { children?: unknown } };
+      walk(el.props?.children);
+    }
+  }
+  walk(node);
+  return parts.join("");
+}
+
+function bucketsWithCounts(counts: number[]): SessionCostBucket[] {
+  // Real log-spaced edges so the index resolution matches what the page sees.
+  const edges = buildSessionCostBuckets(
+    // Pick a max cost large enough that 20 buckets span the test range; the
+    // exact value doesn't matter for the highlight/label tests.
+    10_000,
+    counts.length
+  );
+  return edges.map((b, i) => ({ ...b, count: counts[i] ?? 0 }));
+}
+
+describe("SessionCostDistributionStrip (#217)", () => {
+  it("highlights the bucket containing the current session's cost", () => {
+    // Build buckets and pick a cost that lands in bucket index 7.
+    const buckets = bucketsWithCounts(new Array(20).fill(1));
+    const targetIdx = 7;
+    const targetCost =
+      (buckets[targetIdx]!.lower_cents + buckets[targetIdx]!.upper_cents) / 2;
+    const node = SessionCostDistributionStrip({
+      distribution: {
+        buckets,
+        total_sessions: 20,
+        max_cost_cents: 10_000,
+      },
+      currentCostCents: targetCost,
+    });
+    const bars = collectBars(node);
+    expect(bars).toHaveLength(20);
+    const highlighted = bars.filter((b) => b.isCurrent);
+    expect(highlighted).toHaveLength(1);
+    expect(highlighted[0]!.index).toBe(targetIdx);
+    // The resolver and the page must agree on which bucket the cost lands
+    // in — pin the contract that the strip reads via `sessionCostBucketIndex`.
+    expect(sessionCostBucketIndex(buckets, targetCost)).toBe(targetIdx);
+  });
+
+  it("renders a 'top X%' label that rounds correctly off the empirical CDF", () => {
+    // 100 sessions, all concentrated in bucket 19 (the most expensive).
+    // The current session also lands in bucket 19, so its rank is the
+    // midpoint (50/100 below + 100/2 inside = rank 50/100) → cdf = 0.5,
+    // top 50%. Use a more lopsided distribution for "top 5%":
+    //   - 95 sessions in bucket 0
+    //   - 5 sessions in bucket 19 (current session here)
+    //   midpoint rank = 95 + 5/2 = 97.5 → cdf = 0.975 → top 3%.
+    const counts = new Array(20).fill(0);
+    counts[0] = 95;
+    counts[19] = 5;
+    const buckets = bucketsWithCounts(counts);
+    const targetCost =
+      (buckets[19]!.lower_cents + buckets[19]!.upper_cents) / 2;
+    const node = SessionCostDistributionStrip({
+      distribution: {
+        buckets,
+        total_sessions: 100,
+        max_cost_cents: 10_000,
+      },
+      currentCostCents: targetCost,
+    });
+    const label = collectByTestId(node, "session-cost-percentile-label");
+    expect(label).not.toBeNull();
+    const text = textOf(label);
+    // 1 - 0.975 = 0.025 → rounds to 3% (Math.round(2.5) = 3 via banker's
+    // rounding is platform-defined; either way the label must say "top"
+    // since cdf > 0.5 and the rounded percent is small).
+    expect(text).toMatch(/^This session is in the top \d+% by cost\.$/);
+    const pct = Number(/top (\d+)%/.exec(text)?.[1]);
+    expect(pct).toBeGreaterThanOrEqual(1);
+    expect(pct).toBeLessThanOrEqual(5);
+  });
+
+  it("flips to 'bottom X%' when the current session is among the cheapest", () => {
+    // Mirror of the previous case: most sessions live in the top bucket,
+    // current session lands in bucket 0 → cdf ~ 0.025 → bottom 3%.
+    const counts = new Array(20).fill(0);
+    counts[0] = 5;
+    counts[19] = 95;
+    const buckets = bucketsWithCounts(counts);
+    const targetCost =
+      (buckets[0]!.lower_cents + buckets[0]!.upper_cents) / 2;
+    const node = SessionCostDistributionStrip({
+      distribution: {
+        buckets,
+        total_sessions: 100,
+        max_cost_cents: 10_000,
+      },
+      currentCostCents: targetCost,
+    });
+    const label = collectByTestId(node, "session-cost-percentile-label");
+    const text = textOf(label);
+    expect(text).toMatch(/^This session is in the bottom \d+% by cost\.$/);
+    const pct = Number(/bottom (\d+)%/.exec(text)?.[1]);
+    expect(pct).toBeGreaterThanOrEqual(1);
+    expect(pct).toBeLessThanOrEqual(5);
+  });
+
+  it("hides the strip entirely when the team has < 10 sessions in the period (#217 empty state)", () => {
+    // Below 10 the percentile is statistical noise — the strip must collapse
+    // to null rather than render a misleading "top 50%" off a 3-session
+    // sample.
+    const buckets = bucketsWithCounts(new Array(20).fill(0));
+    const node = SessionCostDistributionStrip({
+      distribution: {
+        buckets,
+        total_sessions: 9,
+        max_cost_cents: 50,
+      },
+      currentCostCents: 25,
+    });
+    expect(node).toBeNull();
+  });
+
+  it("hides when there are no buckets (period max below the first bucket's lower edge)", () => {
+    // `max_cost_cents = 0` means every session was free; the bucket bank
+    // collapses to an empty array and the strip has nothing to render.
+    const node = SessionCostDistributionStrip({
+      distribution: {
+        buckets: [],
+        total_sessions: 50,
+        max_cost_cents: 0,
+      },
+      currentCostCents: 0,
+    });
+    expect(node).toBeNull();
+  });
+});

--- a/src/components/session-cost-distribution-strip.tsx
+++ b/src/components/session-cost-distribution-strip.tsx
@@ -1,0 +1,149 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fmtCost } from "@/lib/format";
+import {
+  type SessionCostDistribution,
+  sessionCostBucketIndex,
+} from "@/lib/session-cost-distribution";
+
+/**
+ * Cost-percentile distribution strip on the session-detail page (#217).
+ *
+ * Renders a horizontal bank of bars — one per log-spaced cost bucket from
+ * `$0.01` to the period max — with the bar containing the current session's
+ * `total_cost_cents` highlighted. A label above the strip ("This session is in
+ * the top X%" / "bottom X%") collapses the empirical CDF down to a single
+ * number so a viewer answers "is this session abnormally expensive?" at a
+ * glance, without mentally diffing against the team's typical session.
+ *
+ * Empty-state contract (#217 acceptance): the strip hides entirely when the
+ * team has fewer than 10 sessions in the period — the percentile is
+ * statistically meaningless on a tiny sample and the bar bank would mostly
+ * read as noise.
+ *
+ * Privacy (ADR-0083 §1): only numeric session metadata reaches this
+ * component. No prompt / response / file path content is rendered.
+ */
+
+/** Sample size below which the percentile call-out is suppressed (#217). */
+export const SESSION_COST_DISTRIBUTION_MIN_SAMPLES = 10;
+
+export function SessionCostDistributionStrip({
+  distribution,
+  currentCostCents,
+}: {
+  distribution: SessionCostDistribution;
+  currentCostCents: number;
+}) {
+  if (distribution.total_sessions < SESSION_COST_DISTRIBUTION_MIN_SAMPLES) {
+    return null;
+  }
+  if (distribution.buckets.length === 0) return null;
+
+  const currentIdx = sessionCostBucketIndex(
+    distribution.buckets,
+    currentCostCents
+  );
+  const label = percentileLabel(
+    distribution.buckets,
+    distribution.total_sessions,
+    currentIdx
+  );
+
+  const maxBucketCount = Math.max(
+    1,
+    ...distribution.buckets.map((b) => b.count)
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cost vs team</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div
+          className="mb-2 text-sm text-zinc-200"
+          data-testid="session-cost-percentile-label"
+        >
+          {label}
+        </div>
+        <div
+          className="flex h-12 w-full items-end gap-[2px] rounded-md bg-white/[0.03] p-1"
+          role="list"
+          aria-label="Session cost distribution across the team"
+          data-testid="session-cost-distribution-bars"
+        >
+          {distribution.buckets.map((bucket, i) => {
+            const isCurrent = i === currentIdx;
+            const heightPct =
+              bucket.count === 0
+                ? 4
+                : Math.max(8, (bucket.count / maxBucketCount) * 100);
+            const tooltip = `${fmtCost(bucket.lower_cents)}–${fmtCost(
+              bucket.upper_cents
+            )} · ${bucket.count} session${bucket.count === 1 ? "" : "s"}`;
+            return (
+              <div
+                key={i}
+                role="listitem"
+                title={tooltip}
+                aria-label={tooltip}
+                aria-current={isCurrent ? "true" : undefined}
+                data-current={isCurrent ? "true" : undefined}
+                data-bucket-index={i}
+                className={
+                  "flex-1 rounded-sm transition-opacity " +
+                  (isCurrent ? "bg-amber-300" : "bg-blue-500/70")
+                }
+                style={{ height: `${heightPct}%` }}
+              />
+            );
+          })}
+        </div>
+        <div
+          className="mt-1 flex justify-between text-[10px] text-zinc-500"
+          aria-hidden="true"
+        >
+          <span>{fmtCost(distribution.buckets[0]!.lower_cents)}</span>
+          <span>
+            {fmtCost(
+              distribution.buckets[distribution.buckets.length - 1]!.upper_cents
+            )}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Build the "top X%" / "bottom X%" call-out. Uses a midpoint rank within the
+ * current bucket — the histogram is bucket-level so we don't know the exact
+ * intra-bucket position; midpoint is the unbiased estimator. Clamps the
+ * rendered percent to `[1, 99]` so "top 0%" / "bottom 0%" can never read as a
+ * formatting glitch.
+ */
+function percentileLabel(
+  buckets: { count: number }[],
+  totalSessions: number,
+  currentIdx: number
+): string {
+  if (currentIdx < 0 || totalSessions <= 0) {
+    return "This session is in the team distribution.";
+  }
+  let cumBelow = 0;
+  for (let i = 0; i < currentIdx; i++) cumBelow += buckets[i]!.count;
+  const currCount = buckets[currentIdx]!.count;
+  const rank = cumBelow + currCount / 2;
+  const cdf = rank / totalSessions;
+  const topPct = Math.round((1 - cdf) * 100);
+  if (topPct <= 50) {
+    return `This session is in the top ${clampPct(topPct)}% by cost.`;
+  }
+  const bottomPct = Math.round(cdf * 100);
+  return `This session is in the bottom ${clampPct(bottomPct)}% by cost.`;
+}
+
+function clampPct(p: number): number {
+  if (!Number.isFinite(p)) return 50;
+  return Math.min(99, Math.max(1, p));
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -2,6 +2,22 @@ import "server-only";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { utcInstantForLocalEnd, utcInstantForLocalStart } from "@/lib/timezone";
+import {
+  buildSessionCostBuckets,
+  sessionCostBucketIndex,
+  type SessionCostDistribution,
+} from "@/lib/session-cost-distribution";
+
+export type {
+  SessionCostBucket,
+  SessionCostDistribution,
+} from "@/lib/session-cost-distribution";
+export {
+  buildSessionCostBuckets,
+  sessionCostBucketIndex,
+  SESSION_COST_BUCKET_COUNT,
+  SESSION_COST_MIN_CENTS,
+} from "@/lib/session-cost-distribution";
 
 export interface DateRange {
   /** Inclusive lower bound in the **viewer's local TZ** (`YYYY-MM-DD`). */
@@ -1263,6 +1279,73 @@ export async function getDeviceSessionsForDay(
   const rows = (data ?? []) as SessionRow[];
   if (rows.length === 0) return rows;
   return attachOwners(admin, user, rows);
+}
+
+/**
+ * Cost-distribution histogram for the session-detail page (#217).
+ *
+ * Returns a fixed bank of log-spaced buckets between `$0.01` and the period's
+ * max session cost, with each bucket's session count. Combined with the
+ * caller-known `total_cost_cents` of the session on screen, this powers the
+ * "This session is in the top X%" strip rendered below the Activity card —
+ * answering "is this session abnormally expensive?" at a glance, without the
+ * viewer having to mentally compare a dollar figure against the team's typical
+ * session.
+ *
+ * Scope mirrors `getSessions`: visible-device set respects ADR-0083 §6 (manager
+ * sees the org; member sees their own devices), with optional `surfaces` /
+ * `scopedUserId` narrowing. Privacy: no prompt / file / response content is
+ * read here — only the numeric `total_cost_cents` column.
+ *
+ * The histogram is computed in JS rather than via a Postgres RPC because the
+ * aggregation is small (one row per session in the period, cost column only)
+ * and the same-day-timeline RPC-free pattern at `getDeviceSessionsForDay`
+ * sets the precedent (#218). Switch to an RPC if the row volume grows.
+ */
+export async function getSessionCostDistribution(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<SessionCostDistribution> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) {
+    return { buckets: [], total_sessions: 0, max_cost_cents: 0 };
+  }
+  const surfaces = normalizeSurfaces(options?.surfaces);
+  let query = admin
+    .from("session_summaries")
+    .select("total_cost_cents")
+    .in("device_id", deviceIds)
+    .gte("started_at", range.startedAtFrom)
+    .lte("started_at", range.startedAtTo);
+  if (surfaces) query = query.in("surface", surfaces);
+
+  const { data, error } = await query;
+  if (error) throw error;
+
+  const rows = (data ?? []) as { total_cost_cents: number | string }[];
+  const costs: number[] = [];
+  let maxCostCents = 0;
+  for (const r of rows) {
+    const n = Number(r.total_cost_cents);
+    if (!Number.isFinite(n)) continue;
+    costs.push(n);
+    if (n > maxCostCents) maxCostCents = n;
+  }
+  const totalSessions = costs.length;
+
+  const buckets = buildSessionCostBuckets(maxCostCents);
+  for (const c of costs) {
+    const idx = sessionCostBucketIndex(buckets, c);
+    if (idx >= 0) buckets[idx]!.count += 1;
+  }
+
+  return {
+    buckets,
+    total_sessions: totalSessions,
+    max_cost_cents: maxCostCents,
+  };
 }
 
 /**

--- a/src/lib/session-cost-distribution.ts
+++ b/src/lib/session-cost-distribution.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared types + pure helpers for the session cost-percentile distribution
+ * strip (#217). Lives in its own module — separate from `@/lib/dal` — because
+ * the strip component renders on the client/page boundary and `dal.ts` is
+ * marked `server-only`. Importing the histogram-building math from a neutral
+ * module keeps the strip free of an accidental server-only barrier.
+ */
+
+/** One bin in the cost-distribution histogram. */
+export interface SessionCostBucket {
+  /** Inclusive lower edge in cents. */
+  lower_cents: number;
+  /** Exclusive upper edge in cents (the top bucket treats it as inclusive). */
+  upper_cents: number;
+  /** Number of sessions in this bucket. */
+  count: number;
+}
+
+export interface SessionCostDistribution {
+  buckets: SessionCostBucket[];
+  /** Total sessions in the period — drives the < 10 empty state. */
+  total_sessions: number;
+  /** Period max in cents; useful for axis labels on the consumer. */
+  max_cost_cents: number;
+}
+
+/** Number of log-spaced bins used by `getSessionCostDistribution`. */
+export const SESSION_COST_BUCKET_COUNT = 20;
+/** Lower edge of the first bucket: $0.01. */
+export const SESSION_COST_MIN_CENTS = 1;
+
+/**
+ * Build a fixed bank of log-spaced buckets between `$0.01` and `maxCostCents`.
+ *
+ * Returns an empty array when the period's max cost is below the first
+ * bucket's lower edge — the consumer should then render the empty state.
+ */
+export function buildSessionCostBuckets(
+  maxCostCents: number,
+  bucketCount: number = SESSION_COST_BUCKET_COUNT
+): SessionCostBucket[] {
+  if (
+    !Number.isFinite(maxCostCents) ||
+    maxCostCents < SESSION_COST_MIN_CENTS ||
+    bucketCount < 1
+  ) {
+    return [];
+  }
+  // `+1` so the row at exactly `maxCostCents` lands inside the top bin rather
+  // than at the boundary (where exp/log floating-point drift can drop it).
+  const logMin = Math.log(SESSION_COST_MIN_CENTS);
+  const logMax = Math.log(maxCostCents + 1);
+  const step = (logMax - logMin) / bucketCount;
+  const buckets: SessionCostBucket[] = [];
+  for (let i = 0; i < bucketCount; i++) {
+    buckets.push({
+      lower_cents: Math.exp(logMin + i * step),
+      upper_cents: Math.exp(logMin + (i + 1) * step),
+      count: 0,
+    });
+  }
+  return buckets;
+}
+
+/**
+ * Resolve which bucket index a given cost lands in. Costs below the first
+ * lower edge clamp into bucket 0 (the "near-zero" bin); costs above the top
+ * edge clamp into the last bucket. Returns `-1` when there are no buckets.
+ */
+export function sessionCostBucketIndex(
+  buckets: SessionCostBucket[],
+  costCents: number
+): number {
+  if (buckets.length === 0) return -1;
+  const c = Number(costCents);
+  if (!Number.isFinite(c) || c <= buckets[0]!.lower_cents) return 0;
+  for (let i = 0; i < buckets.length; i++) {
+    if (c < buckets[i]!.upper_cents) return i;
+  }
+  return buckets.length - 1;
+}


### PR DESCRIPTION
## Summary

Closes #217. Renders a small log-spaced histogram of team session costs below the Activity card on `/dashboard/sessions/<id>`, with the bucket containing the current session's cost highlighted and a "top X%" / "bottom X%" call-out derived from the empirical CDF.

- DAL `getSessionCostDistribution(user, range, options?)` returns 20 log-spaced buckets from `$0.01` to the period max, per-bucket counts, total sessions, and period max. Scope mirrors `getSessions`.
- Bucket math extracted to `src/lib/session-cost-distribution.ts` so the strip can import the helpers without pulling the `server-only` barrier from `@/lib/dal` into the client surface.
- Empty state: strip hides entirely when the team has < 10 sessions in the period — the percentile is statistical noise on tiny samples.
- Period round-trips `?days=` from the URL; defaults to 30d (vs the dashboard's 7d default) because small teams often hit the empty state in a 7-day window.

## Test plan

- [x] `npx vitest run` — 310 passed
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] Strip highlights the correct bucket for a given cost.
- [x] Percentile label rounds correctly off the empirical CDF (both "top X%" and "bottom X%" paths).
- [x] Strip collapses to null on < 10-session sample.
- [x] Page-level: DAL is invoked, distribution + current cost are wired into the strip, `?days=` round-trips into the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)