### PR TITLE
feat(sessions): add token composition bar to session detail (#215)

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 import { dateRangeFromDays } from "@/lib/date-range";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { SessionCostDistributionStrip } from "@/components/session-cost-distribution-strip";
+import { SessionTokenComposition } from "@/components/session-token-composition";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import {
   fmtCost,
@@ -223,6 +224,17 @@ export default async function SessionDetailPage({
                 value={fmtCost(Number(session.total_cost_cents))}
               />
             </dl>
+            {/*
+              Token composition bar (#215). Sits beneath the Activity dl so
+              the input-vs-output split reads alongside the Tokens / Cost
+              pair instead of duplicating that field above. Hidden entirely
+              when both halves are 0 — a 0-width bar would read as a broken
+              UI element rather than an empty session.
+            */}
+            <SessionTokenComposition
+              inputTokens={inputTokens}
+              outputTokens={outputTokens}
+            />
           </CardContent>
         </Card>
       </div>

--- a/src/components/session-token-composition.test.tsx
+++ b/src/components/session-token-composition.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
+import { SessionTokenComposition } from "@/components/session-token-composition";
+
+/**
+ * Unit tests for the per-session input-vs-output bar (#215). Pins the three
+ * acceptance behaviors:
+ *   1. Normal session — both segments render with widths proportional to the
+ *      input/output split.
+ *   2. Output-only session — the bar collapses to a single full-width Output
+ *      segment annotated `(output-only)` (matches the May-2026+ Copilot Chat
+ *      shape from ADR-0092 §2.3 v3).
+ *   3. Empty session — both halves zero → the component returns null rather
+ *      than emitting a 0-width bar that reads as a broken UI element.
+ */
+
+interface CapturedSegment {
+  segment: string;
+  widthPct: number;
+  title: string;
+}
+
+function collectSegments(node: unknown): CapturedSegment[] {
+  const out: CapturedSegment[] = [];
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): void {
+    if (!n || typeof n !== "object") return;
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (seen.has(n as object)) return;
+    seen.add(n as object);
+    const el = n as ReactElement & {
+      props?: Record<string, unknown> & { children?: unknown };
+    };
+    const props = el.props as Record<string, unknown> | undefined;
+    if (props && typeof props["data-segment"] === "string") {
+      const style = (props.style as { width?: string } | undefined) ?? {};
+      const widthPct = Number(String(style.width ?? "0%").replace("%", ""));
+      out.push({
+        segment: String(props["data-segment"]),
+        widthPct,
+        title: String((props as { title?: string }).title ?? ""),
+      });
+    }
+    walk(el.props?.children);
+  }
+  walk(node);
+  return out;
+}
+
+function textOf(node: unknown): string {
+  const parts: string[] = [];
+  function walk(n: unknown): void {
+    if (n == null || typeof n === "boolean") return;
+    if (typeof n === "string" || typeof n === "number") {
+      parts.push(String(n));
+      return;
+    }
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (typeof n === "object") {
+      const el = n as ReactElement & { props?: { children?: unknown } };
+      walk(el.props?.children);
+    }
+  }
+  walk(node);
+  return parts.join("");
+}
+
+describe("SessionTokenComposition (#215)", () => {
+  it("renders both segments for a normal mixed-token session with proportional widths and per-segment tooltips", () => {
+    // 75% input / 25% output — values picked so rounding is unambiguous and
+    // the percent labels in the tooltips read 75% / 25% exactly.
+    const node = SessionTokenComposition({
+      inputTokens: 3000,
+      outputTokens: 1000,
+    });
+    const segs = collectSegments(node);
+    expect(segs.map((s) => s.segment).sort()).toEqual(["input", "output"]);
+    const input = segs.find((s) => s.segment === "input")!;
+    const output = segs.find((s) => s.segment === "output")!;
+    expect(input.widthPct).toBeCloseTo(75, 5);
+    expect(output.widthPct).toBeCloseTo(25, 5);
+    // The hover-tooltip contract from the ticket: absolute count and percent
+    // on each segment so the breakdown is readable without external math.
+    expect(input.title).toMatch(/Input:/);
+    expect(input.title).toContain("75%");
+    expect(output.title).toMatch(/Output:/);
+    expect(output.title).toContain("25%");
+    // The bar should not carry the output-only suffix when input > 0.
+    expect(output.title).not.toContain("output-only");
+    expect(textOf(node)).not.toContain("output-only");
+  });
+
+  it("collapses to a single full-width Output segment for output-only sessions and reuses the `(output-only)` annotation", () => {
+    // May-2026+ VS Code Copilot Chat shape — input lost on disk so the
+    // daemon's output-only fallback ships input_tokens=0, output_tokens>0.
+    // The bar must surface that state, not silently render a 100% Output
+    // segment indistinguishable from "the viewer scrolled past the input".
+    const node = SessionTokenComposition({
+      inputTokens: 0,
+      outputTokens: 1500,
+    });
+    const segs = collectSegments(node);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]!.segment).toBe("output");
+    expect(segs[0]!.widthPct).toBeCloseTo(100, 5);
+    expect(segs[0]!.title).toContain("output-only");
+    // The visible legend reuses the same annotation the Tokens field uses
+    // on the parent page so the two reads agree.
+    expect(textOf(node)).toContain("output-only");
+  });
+
+  it("hides entirely when both halves are zero (no 0-width bar)", () => {
+    // The acceptance criterion forbids emitting a 0-width bar — an empty
+    // session must read as "no chart", not "broken chart". Returning null
+    // is the contract the page relies on so the Activity card doesn't
+    // grow a hairline strip on empty rows.
+    const node = SessionTokenComposition({ inputTokens: 0, outputTokens: 0 });
+    expect(node).toBeNull();
+  });
+
+  it("renders only the input segment when the session has input tokens but no output (defensive — rare but possible for aborted sessions)", () => {
+    // An aborted run can land with prompt tokens recorded but no model
+    // response — pin that the bar still renders rather than collapsing back
+    // to the empty-state null. Symmetric with the output-only case.
+    const node = SessionTokenComposition({
+      inputTokens: 500,
+      outputTokens: 0,
+    });
+    const segs = collectSegments(node);
+    expect(segs).toHaveLength(1);
+    expect(segs[0]!.segment).toBe("input");
+    expect(segs[0]!.widthPct).toBeCloseTo(100, 5);
+    // Output-only annotation is *not* applied when output is the zero side —
+    // the daemon's output-only contract is specifically input=0/output>0.
+    expect(textOf(node)).not.toContain("output-only");
+  });
+});

--- a/src/components/session-token-composition.tsx
+++ b/src/components/session-token-composition.tsx
@@ -1,0 +1,98 @@
+import { fmtNum } from "@/lib/format";
+
+/**
+ * Per-session input-vs-output token bar (#215). Renders inside the Activity
+ * card on `/dashboard/sessions/<id>` so a viewer answers "was this session
+ * read-heavy or generation-heavy?" without doing the math themselves.
+ *
+ * Output-only sessions (input = 0, output > 0) — the May-2026+ VS Code
+ * Copilot Chat shape per ADR-0092 §2.3 v3 — collapse to a single full-width
+ * Output segment annotated with the same `(output-only)` label the Tokens
+ * field already uses, so the breakdown and the tabular row agree.
+ *
+ * Empty sessions (both 0) return null rather than rendering a 0-width bar
+ * that reads as a broken element. Cache tokens are intentionally absent —
+ * the column lives on `daily_rollups` but not on `session_summaries`
+ * (see #215 "Out of scope").
+ */
+export function SessionTokenComposition({
+  inputTokens,
+  outputTokens,
+}: {
+  inputTokens: number;
+  outputTokens: number;
+}) {
+  const total = inputTokens + outputTokens;
+  if (total <= 0) return null;
+
+  const isOutputOnly = inputTokens === 0 && outputTokens > 0;
+  const inputPct = (inputTokens / total) * 100;
+  const outputPct = (outputTokens / total) * 100;
+
+  const inputTooltip = `Input: ${fmtNum(inputTokens)} (${pctLabel(inputPct)})`;
+  const outputTooltip = `Output: ${fmtNum(outputTokens)} (${pctLabel(
+    outputPct
+  )})${isOutputOnly ? " (output-only)" : ""}`;
+
+  return (
+    <div className="mt-1" data-testid="session-token-composition">
+      <div
+        className="flex h-2.5 w-full overflow-hidden rounded-sm bg-white/[0.03]"
+        role="img"
+        aria-label={
+          isOutputOnly
+            ? `Output ${fmtNum(outputTokens)} tokens (output-only)`
+            : `Input ${fmtNum(inputTokens)} tokens, output ${fmtNum(
+                outputTokens
+              )} tokens`
+        }
+      >
+        {inputTokens > 0 ? (
+          <div
+            className="h-full bg-zinc-300"
+            style={{ width: `${inputPct}%` }}
+            title={inputTooltip}
+            aria-label={inputTooltip}
+            data-segment="input"
+          />
+        ) : null}
+        {outputTokens > 0 ? (
+          <div
+            className="h-full bg-emerald-400"
+            style={{ width: `${outputPct}%` }}
+            title={outputTooltip}
+            aria-label={outputTooltip}
+            data-segment="output"
+          />
+        ) : null}
+      </div>
+      <div
+        className="mt-1 flex justify-between text-[10px] text-zinc-500"
+        aria-hidden="true"
+      >
+        <span>
+          <span
+            className="mr-1 inline-block h-1.5 w-1.5 rounded-sm bg-zinc-300 align-middle"
+            aria-hidden="true"
+          />
+          Input {fmtNum(inputTokens)}
+        </span>
+        <span>
+          Output {fmtNum(outputTokens)}
+          {isOutputOnly ? " (output-only)" : ""}
+          <span
+            className="ml-1 inline-block h-1.5 w-1.5 rounded-sm bg-emerald-400 align-middle"
+            aria-hidden="true"
+          />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function pctLabel(pct: number): string {
+  if (!Number.isFinite(pct) || pct <= 0) return "0%";
+  if (pct >= 99.5) return "100%";
+  if (pct < 1) return "<1%";
+  return `${Math.round(pct)}%`;
+}


### PR DESCRIPTION
Closes #215.

## Summary

- New `SessionTokenComposition` component renders a stacked horizontal bar (input zinc-300 / output emerald-400) inside the Activity card on `/dashboard/sessions/<id>`.
- Each segment carries a tooltip with the absolute token count and percent share.
- Output-only sessions (input = 0, output > 0 — the May-2026+ Copilot Chat shape per ADR-0092 §2.3 v3) collapse to a single full-width Output segment annotated `(output-only)`, matching the existing Tokens-field annotation.
- Empty sessions (both = 0) return `null` so the card doesn't grow a 0-width hairline strip.

## Test plan

- [x] `npx vitest run src/components/session-token-composition.test.tsx` — new file pins normal, output-only, empty, and input-only render shapes.
- [x] `npx vitest run` — full suite (314 tests) still green.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)