### PR TITLE
feat(sessions): add same-branch-over-time chart to session detail (#216)

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -35,6 +35,7 @@ const dal = {
   getDeviceSessionsForDay: vi.fn(),
   getEarliestActivity: vi.fn(),
   getSessionCostDistribution: vi.fn(),
+  getBranchSessionTimeline: vi.fn(),
 };
 // The strip component imports `sessionCostBucketIndex` directly from
 // `@/lib/dal`; spread the real exports so that helper resolves while the
@@ -49,6 +50,7 @@ vi.mock("@/lib/dal", async () => {
     getDeviceSessionsForDay: dal.getDeviceSessionsForDay,
     getEarliestActivity: dal.getEarliestActivity,
     getSessionCostDistribution: dal.getSessionCostDistribution,
+    getBranchSessionTimeline: dal.getBranchSessionTimeline,
   };
 });
 vi.mock("@/lib/viewer-timezone", () => ({
@@ -108,6 +110,10 @@ beforeEach(() => {
     total_sessions: 0,
     max_cost_cents: 0,
   });
+  // Default: empty branch timeline so the same-branch chart is hidden in
+  // baseline smoke tests. Suites that exercise the chart override per-case
+  // (#216).
+  dal.getBranchSessionTimeline.mockReset().mockResolvedValue([]);
 });
 
 async function render(

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import {
+  getBranchSessionTimeline,
   getCurrentUser,
   getDeviceSessionsForDay,
   getEarliestActivity,
@@ -10,6 +11,8 @@ import {
 } from "@/lib/dal";
 import { dateRangeFromDays } from "@/lib/date-range";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { parseUnit } from "@/lib/units";
+import { BranchSessionTimeline } from "@/components/branch-session-timeline";
 import { SessionCostDistributionStrip } from "@/components/session-cost-distribution-strip";
 import { SessionTokenComposition } from "@/components/session-token-composition";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -52,6 +55,7 @@ export default async function SessionDetailPage({
     device?: string;
     days?: string;
     user?: string;
+    units?: string;
     cursor?: string;
     p?: string;
   }>;
@@ -125,6 +129,25 @@ export default async function SessionDetailPage({
     user,
     distributionRange
   );
+
+  // Same-branch timeline (#216). Trailing-30d window on the same
+  // `(repo_id, git_branch)` so a viewer can see whether this branch has been
+  // chewing tokens for weeks or this is a one-off spike. The window is
+  // independent of the list-page `?days=` — the comparative is most useful at
+  // 30d regardless of the period the viewer arrived from. Skipped entirely
+  // when the session is missing either half of the (repo, branch) key, since
+  // there's nothing meaningful to plot against.
+  const branchTimelineRange = dateRangeFromDays("30", null, viewerTz);
+  const branchTimeline =
+    session.repo_id && session.git_branch
+      ? await getBranchSessionTimeline(
+          user,
+          session.repo_id,
+          session.git_branch,
+          branchTimelineRange
+        )
+      : [];
+  const unit = parseUnit(sp.units);
 
   return (
     <div className="space-y-6">
@@ -244,6 +267,14 @@ export default async function SessionDetailPage({
         currentCostCents={Number(session.total_cost_cents)}
       />
 
+      <BranchSessionTimeline
+        sessions={branchTimeline}
+        currentSessionId={sessionId}
+        rangeStartIso={branchTimelineRange.startedAtFrom}
+        rangeEndIso={branchTimelineRange.startedAtTo}
+        unit={unit}
+      />
+
       {sessionLocalDate ? (
         <DeviceDayTimeline
           sessions={sameDaySessions}
@@ -277,12 +308,14 @@ function Field({ label, value }: { label: string; value: string | number }) {
 function buildSessionsBackHref(sp: {
   days?: string;
   user?: string;
+  units?: string;
   cursor?: string;
   p?: string;
 }): string {
   const qs = new URLSearchParams();
   if (sp.days) qs.set("days", sp.days);
   if (sp.user) qs.set("user", sp.user);
+  if (sp.units) qs.set("units", sp.units);
   if (sp.cursor) qs.set("cursor", sp.cursor);
   if (sp.p) qs.set("p", sp.p);
   const s = qs.toString();

--- a/src/components/branch-session-timeline.test.tsx
+++ b/src/components/branch-session-timeline.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
+import { BranchSessionTimeline } from "@/components/branch-session-timeline";
+import { type BranchSessionTimelineRow } from "@/lib/dal";
+
+/**
+ * Unit tests for the same-branch-over-time bar chart (#216).
+ *
+ * Pins the three acceptance behaviors:
+ *   1. Timeline renders 1+ bars when there are other sessions on the branch.
+ *   2. The current session's bar is visually marked.
+ *   3. Empty-state copy renders when this is the only session on the branch.
+ */
+
+interface CapturedBar {
+  sessionId: string;
+  isCurrent: boolean;
+}
+
+function collectBars(node: unknown): CapturedBar[] {
+  const out: CapturedBar[] = [];
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): void {
+    if (!n || typeof n !== "object") return;
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (seen.has(n as object)) return;
+    seen.add(n as object);
+    const el = n as ReactElement & {
+      props?: Record<string, unknown> & { children?: unknown };
+    };
+    const props = el.props as Record<string, unknown> | undefined;
+    if (props && props["data-session-id"] != null) {
+      out.push({
+        sessionId: String(props["data-session-id"]),
+        isCurrent:
+          (props as { "data-current"?: string })["data-current"] === "true",
+      });
+    }
+    walk(el.props?.children);
+  }
+  walk(node);
+  return out;
+}
+
+function findByTestId(node: unknown, testId: string): unknown | null {
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): unknown | null {
+    if (!n || typeof n !== "object") return null;
+    if (Array.isArray(n)) {
+      for (const c of n) {
+        const f = walk(c);
+        if (f) return f;
+      }
+      return null;
+    }
+    if (seen.has(n as object)) return null;
+    seen.add(n as object);
+    const el = n as ReactElement & {
+      props?: Record<string, unknown> & { children?: unknown };
+    };
+    if (el.props && el.props["data-testid"] === testId) return el;
+    return walk(el.props?.children);
+  }
+  return walk(node);
+}
+
+function textOf(node: unknown): string {
+  const parts: string[] = [];
+  function walk(n: unknown): void {
+    if (n == null || typeof n === "boolean") return;
+    if (typeof n === "string" || typeof n === "number") {
+      parts.push(String(n));
+      return;
+    }
+    if (Array.isArray(n)) {
+      for (const c of n) walk(c);
+      return;
+    }
+    if (typeof n === "object") {
+      const el = n as ReactElement & { props?: { children?: unknown } };
+      walk(el.props?.children);
+    }
+  }
+  walk(node);
+  return parts.join("");
+}
+
+function mkSession(
+  overrides: Partial<BranchSessionTimelineRow> & { session_id: string }
+): BranchSessionTimelineRow {
+  return {
+    started_at: "2026-05-01T10:00:00.000Z",
+    total_cost_cents: 50,
+    total_input_tokens: 1000,
+    total_output_tokens: 500,
+    ...overrides,
+  };
+}
+
+const rangeStart = "2026-04-11T00:00:00.000Z";
+const rangeEnd = "2026-05-11T23:59:59.999Z";
+
+describe("BranchSessionTimeline (#216)", () => {
+  it("renders one bar per session and marks the current session's bar", () => {
+    const sessions = [
+      mkSession({ session_id: "sess_a", started_at: "2026-04-15T12:00:00Z" }),
+      mkSession({ session_id: "sess_b", started_at: "2026-04-22T12:00:00Z" }),
+      mkSession({ session_id: "sess_c", started_at: "2026-05-01T12:00:00Z" }),
+    ];
+    const node = BranchSessionTimeline({
+      sessions,
+      currentSessionId: "sess_b",
+      rangeStartIso: rangeStart,
+      rangeEndIso: rangeEnd,
+      unit: "dollars",
+    });
+    const bars = collectBars(node);
+    expect(bars).toHaveLength(3);
+    const current = bars.filter((b) => b.isCurrent);
+    expect(current).toHaveLength(1);
+    expect(current[0]!.sessionId).toBe("sess_b");
+  });
+
+  it("renders empty-state copy when this is the only session on the branch", () => {
+    const node = BranchSessionTimeline({
+      sessions: [mkSession({ session_id: "sess_only" })],
+      currentSessionId: "sess_only",
+      rangeStartIso: rangeStart,
+      rangeEndIso: rangeEnd,
+      unit: "dollars",
+    });
+    const empty = findByTestId(node, "branch-session-timeline-empty");
+    expect(empty).not.toBeNull();
+    expect(textOf(empty)).toMatch(
+      /only session on this branch in the last 30 days/i
+    );
+    // And critically, no bars are rendered alongside the empty-state copy
+    // (a 0-bar chart would read as a broken UI).
+    expect(findByTestId(node, "branch-session-timeline-bars")).toBeNull();
+  });
+
+  it("renders the bar lane when other sessions exist alongside the current one", () => {
+    const sessions = [
+      mkSession({ session_id: "sess_a", started_at: "2026-04-15T12:00:00Z" }),
+      mkSession({ session_id: "sess_current" }),
+    ];
+    const node = BranchSessionTimeline({
+      sessions,
+      currentSessionId: "sess_current",
+      rangeStartIso: rangeStart,
+      rangeEndIso: rangeEnd,
+      unit: "dollars",
+    });
+    expect(findByTestId(node, "branch-session-timeline-bars")).not.toBeNull();
+    expect(findByTestId(node, "branch-session-timeline-empty")).toBeNull();
+  });
+
+  it("renders nothing when the session has no branch context (sessions=[])", () => {
+    // Page-side guard: when the session is missing a (repo_id, git_branch)
+    // pair, the DAL is skipped and we pass `[]` — the component must collapse
+    // to null rather than render an "only session" message that would be
+    // misleading.
+    const node = BranchSessionTimeline({
+      sessions: [],
+      currentSessionId: "sess_x",
+      rangeStartIso: rangeStart,
+      rangeEndIso: rangeEnd,
+      unit: "dollars",
+    });
+    expect(node).toBeNull();
+  });
+});

--- a/src/components/branch-session-timeline.tsx
+++ b/src/components/branch-session-timeline.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fmtCost, fmtNum } from "@/lib/format";
+import { type BranchSessionTimelineRow } from "@/lib/dal";
+import { type Unit } from "@/lib/units";
+
+/**
+ * "Same branch over time" bar chart on the session-detail page (#216).
+ *
+ * Renders one bar per session on the same `(repo_id, git_branch)` over the
+ * trailing 30 days, sized by cost (or tokens, if the viewer's units toggle is
+ * on tokens — same `?units=` contract the Sessions list uses, #84). The bar
+ * for the session currently on screen is highlighted in amber so a viewer
+ * instantly answers "has this branch been chewing tokens for weeks, or is
+ * this a one-off spike?" — the manager-facing decision the detail page is
+ * supposed to drive.
+ *
+ * Empty-state contract (#216 acceptance): when no *other* sessions exist on
+ * this branch in the period — the current session is the only one — we
+ * render a small explanatory line instead of a 0-bar chart. A single
+ * one-bar chart carries no comparative information beyond what the cards
+ * above already show.
+ *
+ * Privacy (ADR-0083 §1): only numeric metrics and the daemon-emitted
+ * `session_id` reach this component. No prompt / response / file path
+ * content is rendered.
+ */
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MIN_BAR_HEIGHT_PCT = 4;
+// Five tick labels evenly span a 30-day window: one per week from the start
+// of the range to today.
+const TICK_COUNT = 5;
+
+export function BranchSessionTimeline({
+  sessions,
+  currentSessionId,
+  rangeStartIso,
+  rangeEndIso,
+  unit,
+}: {
+  sessions: BranchSessionTimelineRow[];
+  currentSessionId: string;
+  rangeStartIso: string;
+  rangeEndIso: string;
+  unit: Unit;
+}) {
+  // No sessions at all: the page didn't have a (repo, branch) to query on, or
+  // visibility scope filtered every row out. Render nothing rather than an
+  // empty card.
+  if (sessions.length === 0) return null;
+
+  const onlyCurrent =
+    sessions.length === 1 && sessions[0]!.session_id === currentSessionId;
+
+  const isTokens = unit === "tokens";
+  const rangeStartMs = new Date(rangeStartIso).getTime();
+  const rangeEndMs = new Date(rangeEndIso).getTime();
+  // Defensive: a malformed range collapses to a single-day window so the
+  // bars still render rather than throwing on a divide-by-zero.
+  const spanMs = Math.max(DAY_MS, rangeEndMs - rangeStartMs);
+
+  const values = sessions.map((s) =>
+    isTokens
+      ? Number(s.total_input_tokens) + Number(s.total_output_tokens)
+      : Number(s.total_cost_cents)
+  );
+  const maxValue = Math.max(1, ...values);
+  const weekTicks = buildWeekTicks(rangeStartMs, rangeEndMs);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Same branch over time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {onlyCurrent ? (
+          <p
+            className="py-2 text-sm text-zinc-400"
+            data-testid="branch-session-timeline-empty"
+          >
+            This is the only session on this branch in the last 30 days.
+          </p>
+        ) : (
+          <>
+            <div
+              className="relative h-32 w-full overflow-hidden rounded-md bg-white/[0.03]"
+              role="list"
+              aria-label="Sessions on this branch over the last 30 days"
+              data-testid="branch-session-timeline-bars"
+            >
+              {sessions.map((session, i) => {
+                const startedMs = new Date(session.started_at).getTime();
+                const leftFraction = clampFraction(
+                  (startedMs - rangeStartMs) / spanMs
+                );
+                const value = values[i]!;
+                const rawHeight = (value / maxValue) * 100;
+                const heightPct = Math.max(
+                  MIN_BAR_HEIGHT_PCT,
+                  Number.isFinite(rawHeight) ? rawHeight : MIN_BAR_HEIGHT_PCT
+                );
+                const isCurrent = session.session_id === currentSessionId;
+                const tooltip = buildTooltip(session, isTokens);
+                return (
+                  <Link
+                    key={session.session_id}
+                    href={`/dashboard/sessions/${encodeURIComponent(
+                      session.session_id
+                    )}`}
+                    title={tooltip}
+                    role="listitem"
+                    aria-current={isCurrent ? "page" : undefined}
+                    aria-label={tooltip}
+                    data-current={isCurrent ? "true" : undefined}
+                    data-session-id={session.session_id}
+                    className={
+                      "absolute bottom-0 rounded-sm transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-400 " +
+                      (isCurrent
+                        ? "bg-amber-300 w-[6px] -translate-x-[3px] opacity-100 z-10"
+                        : "bg-blue-500/70 w-[3px] -translate-x-[1.5px] opacity-90")
+                    }
+                    style={{
+                      left: `${leftFraction * 100}%`,
+                      height: `${heightPct}%`,
+                    }}
+                  />
+                );
+              })}
+            </div>
+            <div
+              className="mt-1 flex justify-between text-[10px] text-zinc-500"
+              aria-hidden="true"
+            >
+              {weekTicks.map((t, i) => (
+                <span key={i}>{t.label}</span>
+              ))}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function clampFraction(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function buildTooltip(
+  session: BranchSessionTimelineRow,
+  isTokens: boolean
+): string {
+  const startedAt = session.started_at
+    ? new Date(session.started_at).toLocaleString()
+    : "-";
+  const value = isTokens
+    ? `${fmtNum(
+        Number(session.total_input_tokens) + Number(session.total_output_tokens)
+      )} tokens`
+    : fmtCost(Number(session.total_cost_cents));
+  return `${startedAt} · ${value}`;
+}
+
+/**
+ * Five tick labels evenly spaced across the visible range. The labels read
+ * as `Mon DD` so a viewer can anchor any bar against a calendar date
+ * without the row overflowing on narrow widths (the `flex justify-between`
+ * parent spreads them edge-to-edge).
+ */
+function buildWeekTicks(
+  rangeStartMs: number,
+  rangeEndMs: number
+): { label: string }[] {
+  const span = Math.max(DAY_MS, rangeEndMs - rangeStartMs);
+  const out: { label: string }[] = [];
+  for (let i = 0; i < TICK_COUNT; i++) {
+    const tickMs = rangeStartMs + (i * span) / (TICK_COUNT - 1);
+    const d = new Date(tickMs);
+    out.push({
+      label: d.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      }),
+    });
+  }
+  return out;
+}

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -2122,3 +2122,111 @@ describe("getSessions multi-provider visibility (#202)", () => {
     }
   });
 });
+
+describe("getBranchSessionTimeline (#216 same-branch chart)", () => {
+  // Acceptance: returns per-session rows on `(repo_id, git_branch)`, ordered
+  // oldest → newest, scoped the same way as `getSessions` so a foreign-org
+  // session that happens to share a branch name never leaks across.
+  const manager = {
+    id: "usr_ivan",
+    org_id: "org_team",
+    role: "manager" as const,
+    api_key: "budi_i",
+    display_name: "Ivan",
+    email: "ivan@example.com",
+  };
+  const wideRange = utcRange("2026-01-01", "2026-12-31");
+
+  it("returns every session on the same (repo_id, git_branch), oldest → newest", async () => {
+    fake.seed("orgs", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [{ ...manager }]);
+    fake.seed("devices", [{ id: "dev_ivan", user_id: manager.id }]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_newer",
+        repo_id: "repo_x",
+        git_branch: "refs/heads/feat/216",
+        started_at: "2026-05-05T10:00:00.000Z",
+        total_cost_cents: 200,
+        total_input_tokens: 1000,
+        total_output_tokens: 500,
+      },
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_older",
+        repo_id: "repo_x",
+        git_branch: "refs/heads/feat/216",
+        started_at: "2026-05-01T10:00:00.000Z",
+        total_cost_cents: 50,
+        total_input_tokens: 200,
+        total_output_tokens: 100,
+      },
+      {
+        // Different branch — must not appear in the timeline.
+        device_id: "dev_ivan",
+        session_id: "sess_other_branch",
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        started_at: "2026-05-03T10:00:00.000Z",
+        total_cost_cents: 99,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+      },
+    ]);
+    const { getBranchSessionTimeline } = await loadDal();
+    const rows = await getBranchSessionTimeline(
+      manager,
+      "repo_x",
+      "refs/heads/feat/216",
+      wideRange
+    );
+    expect(rows.map((r) => r.session_id)).toEqual(["sess_older", "sess_newer"]);
+  });
+
+  it("excludes sessions on devices outside the viewer's scope", async () => {
+    fake.seed("orgs", [
+      { id: "org_team", name: "team" },
+      { id: "org_other", name: "other" },
+    ]);
+    fake.seed("users", [
+      { ...manager },
+      {
+        id: "usr_outsider",
+        org_id: "org_other",
+        role: "manager",
+        api_key: "budi_o",
+        display_name: "Outsider",
+        email: "outsider@example.com",
+      },
+    ]);
+    fake.seed("devices", [
+      { id: "dev_ivan", user_id: manager.id },
+      { id: "dev_outsider", user_id: "usr_outsider" },
+    ]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_visible",
+        repo_id: "repo_x",
+        git_branch: "refs/heads/shared",
+        started_at: "2026-05-01T10:00:00.000Z",
+      },
+      {
+        device_id: "dev_outsider",
+        session_id: "sess_foreign",
+        repo_id: "repo_x",
+        git_branch: "refs/heads/shared",
+        started_at: "2026-05-02T10:00:00.000Z",
+      },
+    ]);
+    const { getBranchSessionTimeline } = await loadDal();
+    const rows = await getBranchSessionTimeline(
+      manager,
+      "repo_x",
+      "refs/heads/shared",
+      wideRange
+    );
+    expect(rows.map((r) => r.session_id)).toEqual(["sess_visible"]);
+  });
+});

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1349,6 +1349,57 @@ export async function getSessionCostDistribution(
 }
 
 /**
+ * Per-session timeline of every session on the same `(repo_id, git_branch)`
+ * the viewer can see, ordered oldest → newest (#216).
+ *
+ * Powers the "same branch over time" bar chart on the session-detail page:
+ * a manager investigating a costly session reads at a glance whether the
+ * branch has been chewing tokens for weeks or this is a one-off spike. Scope
+ * mirrors `getSessions` — manager sees the org, member sees own devices — so
+ * the chart never leaks the existence of a foreign-org session that happens
+ * to share a branch name.
+ *
+ * Returns a thin row shape (cost + token totals only) rather than the full
+ * `SessionRow`: the chart only needs what's plotted, and trimming the select
+ * keeps the round-trip light on long-running branches with hundreds of
+ * sessions. Privacy (ADR-0083 §1): no prompt / response / file content is
+ * read here, only numeric metrics and the daemon-emitted `session_id`.
+ */
+export interface BranchSessionTimelineRow {
+  session_id: string;
+  started_at: string;
+  total_cost_cents: number | string;
+  total_input_tokens: number | string;
+  total_output_tokens: number | string;
+}
+
+export async function getBranchSessionTimeline(
+  user: BudiUser,
+  repoId: string,
+  gitBranch: string,
+  range: DateRange
+): Promise<BranchSessionTimelineRow[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user);
+  if (deviceIds.length === 0) return [];
+
+  const { data } = await admin
+    .from("session_summaries")
+    .select(
+      "session_id, started_at, total_cost_cents, total_input_tokens, total_output_tokens"
+    )
+    .in("device_id", deviceIds)
+    .eq("repo_id", repoId)
+    .eq("git_branch", gitBranch)
+    .gte("started_at", range.startedAtFrom)
+    .lte("started_at", range.startedAtTo)
+    .order("started_at", { ascending: true })
+    .order("session_id", { ascending: true });
+
+  return (data ?? []) as BranchSessionTimelineRow[];
+}
+
+/**
  * Sync freshness snapshot for the viewer.
  *
  * Used by the dashboard header to render a "Last synced X ago" indicator and


### PR DESCRIPTION
## Summary

- New DAL `getBranchSessionTimeline(user, repoId, gitBranch, range)` returning thin per-session rows (`session_id`, `started_at`, cost/token totals) scoped the same way as `getSessions`, ordered oldest → newest.
- New `BranchSessionTimeline` component rendering one bar per session over a trailing 30-day window, positioned by `started_at` and sized by cost (or tokens via the `?units=` toggle). The current session's bar is highlighted in amber.
- Empty-state copy when this is the only session on the branch ("This is the only session on this branch in the last 30 days") instead of a misleading one-bar chart.
- Page wiring on `/dashboard/sessions/[id]`: 30-day window independent of the list-page period; the `units` param now round-trips on the back link too.

Closes #216.

## Test plan

- [x] `npm test` — 320 passing (DAL ordering/scope + 4 component cases).
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Manual: deep-link a session whose branch has multiple sessions; confirm bars render, current bar is amber, and weekly tick labels read sensibly.
- [ ] Manual: deep-link a session whose branch is otherwise empty; confirm the empty-state copy renders instead of an empty chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)