### PR TITLE
fix(surface-filter): hide chip when only `unknown` surface is present (#227)

### DIFF
--- a/src/components/surface-filter.test.tsx
+++ b/src/components/surface-filter.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Unit tests for the Surface filter chip's empty-state guards (#227).
+ *
+ * The chip is a `"use client"` component that pulls the URL via
+ * `useRouter` / `useSearchParams`. The hooks fire before the visibility
+ * guard, so we mock `next/navigation` to a no-op router with an empty
+ * query string. That keeps the test focused on the *guard contract* —
+ * does the chip render, or does it return `null`? — without pulling
+ * in `@testing-library/react`, which the repo doesn't depend on.
+ */
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: () => {} }),
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+import { SurfaceFilter } from "@/components/surface-filter";
+
+describe("SurfaceFilter empty-state guards (#227)", () => {
+  it("renders nothing when `surfaces` is empty (no rollups visible to viewer)", () => {
+    // Pre-existing contract from #187: an empty surface list means the org
+    // hasn't shipped any usage yet, so the dropdown has no signal to offer.
+    expect(SurfaceFilter({ surfaces: [] })).toBeNull();
+  });
+
+  it("renders nothing when the only known surface is `unknown` (today's deployments)", () => {
+    // Acceptance: orgs whose only surface is the migration-014 default
+    // `unknown` should not see the chip — the dropdown would otherwise read
+    // as "All surfaces / Unknown", which carries zero filtering signal but
+    // still steals header real estate next to Teammate / Period / Units.
+    expect(SurfaceFilter({ surfaces: ["unknown"] })).toBeNull();
+  });
+
+  it("renders the chip once a real surface joins `unknown`", () => {
+    // Acceptance: the day the first daemon ships a real `surface` value,
+    // the chip reappears so viewers can scope the dashboard to it. The
+    // guard must trip *only* on the single-`unknown` case, not on any list
+    // that happens to contain `unknown`.
+    const node = SurfaceFilter({ surfaces: ["unknown", "vscode"] });
+    expect(node).not.toBeNull();
+  });
+
+  it("renders the chip for a single non-`unknown` surface", () => {
+    // Symmetric defense: a list of length 1 only collapses to `null` for
+    // the literal `'unknown'` string. Any other single surface (e.g. an
+    // org that has only ever talked to one daemon) is a valid filter.
+    const node = SurfaceFilter({ surfaces: ["vscode"] });
+    expect(node).not.toBeNull();
+  });
+});

--- a/src/components/surface-filter.tsx
+++ b/src/components/surface-filter.tsx
@@ -17,18 +17,20 @@ const ALL_SURFACE_LABEL = "All surfaces";
  * multi-select UIs can ship without a wire-shape change. For v1 the chip
  * surfaces a single-select dropdown.
  *
- * Hidden only when `surfaces` is empty — i.e. the org has no rollups yet,
- * so a dropdown that would only offer "All surfaces" carries zero signal.
- * Once any surface is known (even just `unknown` from pre-bump daemons)
- * the chip renders so the dimension is discoverable: #203 explicitly asks
- * the filter to land alongside Teammate / time-range / $/Tokens
- * regardless of the number of distinct surfaces in the data.
+ * Hidden when `surfaces` is empty (org has no rollups yet) and also when
+ * the only known surface is the schema default `'unknown'` (#227): in that
+ * case the dropdown would read as "All surfaces / Unknown" with no real
+ * choice, because every daemon today predates the `surface` bump and lands
+ * on migration 014's `DEFAULT 'unknown'`. The chip reappears automatically
+ * as soon as `getKnownSurfaces` returns a second value — i.e. the day the
+ * first daemon ships a real `surface`.
  */
 export function SurfaceFilter({ surfaces }: { surfaces: string[] }) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   if (surfaces.length === 0) return null;
+  if (surfaces.length === 1 && surfaces[0] === "unknown") return null;
 
   const raw = searchParams.get("surface");
   const parsed = parseSurfaceParam(raw);


### PR DESCRIPTION
Closes #227.

## Summary
- Extend the empty-state guard in `src/components/surface-filter.tsx` so the chip also hides when the only known surface is the schema-default `unknown`.
- Add `src/components/surface-filter.test.tsx` pinning the four branches of the guard: empty, single-`unknown`, mixed-with-`unknown`, single-non-`unknown`.

The chip surfaces back automatically as soon as `getKnownSurfaces` returns a second value — i.e. the day the first daemon ships a real `surface`.

## Test plan
- [x] `npm test` — 305/305 pass (new file adds 4 tests).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` on the touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)