### PR TITLE
refactor(sessions): drop ?device= from session-row link

### DIFF
--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -187,7 +187,7 @@ export default async function SessionsPage({
                     {sessions.map((s) => {
                       const href = `/dashboard/sessions/${encodeURIComponent(
                         s.session_id
-                      )}?device=${encodeURIComponent(s.device_id)}`;
+                      )}`;
                       return (
                         <tr
                           key={`${s.device_id}-${s.session_id}`}


### PR DESCRIPTION
## Summary
- Session-row clicks now navigate to `/dashboard/sessions/<session_id>` without the `?device=` query param.
- The param was a composite-PK lookup hint for `getSessionDetail`, not user-facing data — the detail page renders no device info (Member / Provider / Surface / Model / Repo / Branch / activity stats only).
- Internal clicks now use the session_id-only DAL path (`getSessionDetailBySessionId`) that already serves deep-links from #202. Shared session URLs no longer leak an opaque device UUID into chat/tickets.

## Trade-off
- `getSessionDetailBySessionId` is now the hot path for every internal click, not just deep-links. It scopes by viewer-visible devices and returns null on >1 match to preserve the privacy contract — same behavior, just exercised more often.

## Test plan
- [x] `pnpm vitest run src/app/dashboard/sessions/page.test.tsx` (11 passed)
- [ ] Click a session row in the dashboard — URL is `/dashboard/sessions/<id>` (no `?device=`), detail page renders, back-link round-trips filters
- [ ] Paste a session URL with no `?device=` — still resolves (existing #202 behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)