### PR TITLE
feat(dashboard): savings strip + Effective/List cost lens toggle (#235)

### DIFF
--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -6,6 +6,40 @@ import {
 } from "@/test-utils/page-tree";
 
 /**
+ * Find an element with a given displayName / function name anywhere in the
+ * tree. Lighter than rendering — Server Component bodies aren't invoked, so
+ * the walker just sees component nodes by their type. Used by the #235
+ * tests to assert the cost-lens toggle is or isn't mounted without peeking
+ * inside its function body.
+ */
+function containsElementType(node: unknown, name: string): boolean {
+  const seen = new WeakSet<object>();
+  function walk(n: unknown): boolean {
+    if (n == null || typeof n === "boolean") return false;
+    if (typeof n === "string" || typeof n === "number") return false;
+    if (Array.isArray(n)) return n.some(walk);
+    if (typeof n !== "object") return false;
+    if (seen.has(n as object)) return false;
+    seen.add(n as object);
+    const el = n as { type?: unknown; props?: { children?: unknown } };
+    const t = el.type as
+      | { displayName?: string; name?: string }
+      | string
+      | undefined;
+    if (
+      t &&
+      typeof t === "function" &&
+      ((t as { displayName?: string }).displayName === name ||
+        (t as { name?: string }).name === name)
+    ) {
+      return true;
+    }
+    return walk(el.props?.children);
+  }
+  return walk(node);
+}
+
+/**
  * Page-level coverage for `/dashboard` (the Overview page).
  *
  * Locks in four contracts the recent dashboard PRs have shipped without
@@ -37,6 +71,7 @@ const dal = {
   getOverviewStats: vi.fn(),
   getDailyActivity: vi.fn(),
   getEarliestActivity: vi.fn(),
+  getOrgHasActivePriceList: vi.fn(),
   getOrgMembers: vi.fn(),
   getSyncFreshness: vi.fn(),
   getCostByModel: vi.fn(),
@@ -65,6 +100,7 @@ beforeEach(() => {
   dal.getCurrentUser.mockResolvedValue(MANAGER);
   dal.getOverviewStats.mockResolvedValue({
     totalCostCents: 1_234_56,
+    totalCostCentsIngested: 1_234_56,
     totalInputTokens: 4000,
     totalOutputTokens: 2000,
     totalMessages: 17,
@@ -76,10 +112,12 @@ beforeEach(() => {
       input_tokens: 4000,
       output_tokens: 2000,
       cost_cents: 1_234_56,
+      cost_cents_ingested: 1_234_56,
       message_count: 17,
     },
   ]);
   dal.getEarliestActivity.mockResolvedValue("2026-04-01");
+  dal.getOrgHasActivePriceList.mockResolvedValue(false);
   dal.getOrgMembers.mockResolvedValue([]);
   dal.getSyncFreshness.mockResolvedValue({
     deviceCount: 1,
@@ -168,6 +206,7 @@ describe("dashboard /page (Overview)", () => {
   it("empty: renders headline + zero-value stat cards (not a crash) when the org has no devices yet", async () => {
     dal.getOverviewStats.mockResolvedValue({
       totalCostCents: 0,
+      totalCostCentsIngested: 0,
       totalInputTokens: 0,
       totalOutputTokens: 0,
       totalMessages: 0,
@@ -347,6 +386,114 @@ describe("dashboard /page (Overview)", () => {
     // here, otherwise a viewer is told to wait for a second IDE when the
     // real unlock is a daemon upgrade.
     expect(text).not.toContain("Single-surface org");
+  });
+
+  it("savings strip: hidden when the org has no active price list, even if costs differ (#235)", async () => {
+    // No active list — engine never ran. The strip must stay off so the
+    // empty-state acceptance criterion ("hidden when no active price list")
+    // is enforced regardless of the dual-cost column values.
+    dal.getOrgHasActivePriceList.mockResolvedValue(false);
+    dal.getOverviewStats.mockResolvedValue({
+      totalCostCents: 100_000,
+      totalCostCentsIngested: 150_000,
+      totalInputTokens: 1000,
+      totalOutputTokens: 500,
+      totalMessages: 10,
+      totalSessions: 2,
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).not.toContain("saved this period");
+  });
+
+  it("savings strip: hidden when an active price list exists but effective == ingested (no recalc divergence yet) (#235)", async () => {
+    dal.getOrgHasActivePriceList.mockResolvedValue(true);
+    // Both totals equal — the recalc engine hasn't run yet, or the team's
+    // negotiated rate happens to match list. Either way, no savings story.
+    const node = await render();
+    const text = extractText(node);
+    expect(text).not.toContain("saved this period");
+  });
+
+  it("savings strip: surfaces the gap when an active price list exists and effective < ingested (#235)", async () => {
+    dal.getOrgHasActivePriceList.mockResolvedValue(true);
+    dal.getOverviewStats.mockResolvedValue({
+      totalCostCents: 352_777,
+      totalCostCentsIngested: 481_520,
+      totalInputTokens: 4000,
+      totalOutputTokens: 2000,
+      totalMessages: 17,
+      totalSessions: 5,
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("saved this period at negotiated rates");
+  });
+
+  it("cost-lens toggle: hidden when ingested == effective for every visible point (#235 acceptance)", async () => {
+    dal.getOrgHasActivePriceList.mockResolvedValue(true);
+    // Every row has equal ingested/effective — the toggle would be a no-op,
+    // so it must collapse to keep the chrome quiet.
+    dal.getDailyActivity.mockResolvedValue([
+      {
+        bucket_day: "2026-04-15",
+        input_tokens: 4000,
+        output_tokens: 2000,
+        cost_cents: 100_00,
+        cost_cents_ingested: 100_00,
+        message_count: 17,
+      },
+    ]);
+    const node = await render();
+    expect(containsElementType(node, "CostLensToggle")).toBe(false);
+  });
+
+  it("cost-lens toggle: hidden when no active price list exists, even if mocked data carries a delta (#235)", async () => {
+    dal.getOrgHasActivePriceList.mockResolvedValue(false);
+    dal.getDailyActivity.mockResolvedValue([
+      {
+        bucket_day: "2026-04-15",
+        input_tokens: 4000,
+        output_tokens: 2000,
+        cost_cents: 70_00,
+        cost_cents_ingested: 100_00,
+        message_count: 17,
+      },
+    ]);
+    const node = await render();
+    expect(containsElementType(node, "CostLensToggle")).toBe(false);
+  });
+
+  it("cost-lens toggle: visible when any point has list ≠ effective and a price list is active (#235)", async () => {
+    dal.getOrgHasActivePriceList.mockResolvedValue(true);
+    dal.getDailyActivity.mockResolvedValue([
+      {
+        bucket_day: "2026-04-15",
+        input_tokens: 4000,
+        output_tokens: 2000,
+        cost_cents: 70_00,
+        cost_cents_ingested: 100_00,
+        message_count: 17,
+      },
+    ]);
+    const node = await render();
+    expect(containsElementType(node, "CostLensToggle")).toBe(true);
+  });
+
+  it("cost-lens toggle: hidden under ?units=tokens (the toggle only configures the dollar lens) (#235)", async () => {
+    dal.getOrgHasActivePriceList.mockResolvedValue(true);
+    dal.getDailyActivity.mockResolvedValue([
+      {
+        bucket_day: "2026-04-15",
+        input_tokens: 4000,
+        output_tokens: 2000,
+        cost_cents: 70_00,
+        cost_cents_ingested: 100_00,
+        message_count: 17,
+      },
+    ]);
+    const node = await render({ units: "tokens" });
+    expect(containsElementType(node, "CostLensToggle")).toBe(false);
   });
 
   it("surface chart: mixed window with a small unknown slice keeps the unknown bar visible alongside named surfaces (#210)", async () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import {
   getOverviewStats,
   getDailyActivity,
   getEarliestActivity,
+  getOrgHasActivePriceList,
   getOrgMembers,
   getSyncFreshness,
   getCostByModel,
@@ -18,6 +19,7 @@ import { dateRangeFromDays, previousDateRange } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit, type Unit } from "@/lib/units";
+import { parseCostLens } from "@/lib/cost-lens";
 import {
   fmtCost,
   fmtDelta,
@@ -39,6 +41,11 @@ import {
 import { ActivityChart } from "@/components/charts/activity-chart";
 import { ActivityHeatmap } from "@/components/charts/activity-heatmap";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
+import { CostLensToggle } from "@/components/cost-lens-toggle";
+import {
+  SavingsStrip,
+  buildSavingsStripCopy,
+} from "@/components/savings-strip";
 import {
   LinkDaemonBanner,
   FirstSyncInProgressBanner,
@@ -53,6 +60,7 @@ export default async function OverviewPage({
     user?: string;
     units?: string;
     surface?: string;
+    lens?: string;
   }>;
 }) {
   const params = await searchParams;
@@ -60,6 +68,7 @@ export default async function OverviewPage({
   if (!user?.org_id) return null;
 
   const unit = parseUnit(params.units);
+  const costLens = parseCostLens(params.lens);
   const scopedUserId = params.user || null;
   const surfaces = parseSurfaceParam(params.surface);
   const scope = { scopedUserId, surfaces };
@@ -97,6 +106,7 @@ export default async function OverviewPage({
     heatmap,
     knownSurfaces,
     surfaceShare,
+    hasActivePriceList,
   ] = await Promise.all([
     getOverviewStats(user, range, scope),
     getDailyActivity(user, range, scope),
@@ -119,7 +129,24 @@ export default async function OverviewPage({
     // still let the user widen out from a single-surface state.
     getKnownSurfaces(user, { scopedUserId }),
     getCostBySurface(user, range, scope),
+    getOrgHasActivePriceList(user.org_id),
   ]);
+
+  // Savings strip + Effective/List toggle (#235): only worth surfacing when
+  // the org has an active price list *and* the period actually has a list
+  // vs. effective gap. The two conditions are independent — a fresh upload
+  // with no recalc yet still shows the toggle (per-row delta exists but
+  // hasn't been materialized), so we don't collapse them into one flag.
+  const ingestedTotal = stats.totalCostCentsIngested;
+  const effectiveTotal = stats.totalCostCents;
+  const periodHasSavings = hasActivePriceList && ingestedTotal > effectiveTotal;
+  const hasAnyLensDelta = activity.some(
+    (d) => d.cost_cents_ingested !== d.cost_cents
+  );
+  // Toggle is hidden when ingested == effective for every visible point —
+  // acceptance criterion 2. Same gate covers the "no active price list"
+  // case because without a list the recalc engine never diverges the two.
+  const showCostLensToggle = hasActivePriceList && hasAnyLensDelta;
 
   // Caption for the headline-card delta (e.g. "vs previous 7d"). For numeric
   // ?days= we show the length verbatim; for any other window we say "previous
@@ -155,6 +182,9 @@ export default async function OverviewPage({
     user: params.user,
     units: params.units,
     surface: params.surface,
+    // `lens` is intentionally not forwarded: it only configures the
+    // Overview's cost chart, and the deep-link targets (Models, Team,
+    // Repos) render their own breakdowns that always read `_effective`.
   });
   const totalCostCents = stats.totalCostCents;
   const topModelLeader = topModels[0] ?? null;
@@ -183,6 +213,12 @@ export default async function OverviewPage({
 
       {showLinkBanner && <LinkDaemonBanner apiKey={user.api_key} />}
       {showFirstSyncBanner && <FirstSyncInProgressBanner />}
+
+      {periodHasSavings && (
+        <SavingsStrip
+          {...buildSavingsStripCopy(ingestedTotal, effectiveTotal)}
+        />
+      )}
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {unit === "tokens" ? (
@@ -267,10 +303,17 @@ export default async function OverviewPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>{`Daily Activity (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>{`Daily Activity (${unit === "tokens" ? "Tokens" : "Cost"})`}</CardTitle>
+            {unit === "dollars" && showCostLensToggle && (
+              <Suspense>
+                <CostLensToggle />
+              </Suspense>
+            )}
+          </div>
         </CardHeader>
         <CardContent>
-          <ActivityChart data={activity} unit={unit} />
+          <ActivityChart data={activity} unit={unit} costLens={costLens} />
         </CardContent>
       </Card>
 

--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -12,12 +12,20 @@ import {
 import { differenceInDays, format, startOfMonth, startOfWeek } from "date-fns";
 import { fmtCost, fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
 import type { Unit } from "@/lib/units";
+import type { CostLens } from "@/lib/cost-lens";
 
 interface ActivityData {
   bucket_day: string;
   input_tokens: number;
   output_tokens: number;
   cost_cents: number;
+  /**
+   * Daemon-uploaded cost prior to any team-pricing recalc (#235). Optional
+   * because the consumers that don't surface a lens toggle (sparkline math
+   * on `page.tsx`, the calendar heatmap) keep passing the legacy shape.
+   * Defaults to `cost_cents` when omitted so rebucket math stays consistent.
+   */
+  cost_cents_ingested?: number;
   message_count: number;
 }
 
@@ -48,6 +56,9 @@ function rebucket(data: ActivityData[]): ActivityData[] {
       existing.input_tokens += row.input_tokens;
       existing.output_tokens += row.output_tokens;
       existing.cost_cents += row.cost_cents;
+      existing.cost_cents_ingested =
+        (existing.cost_cents_ingested ?? existing.cost_cents) +
+        (row.cost_cents_ingested ?? row.cost_cents);
       existing.message_count += row.message_count;
     } else {
       byBucket.set(key, { ...row, bucket_day: key });
@@ -61,9 +72,17 @@ function rebucket(data: ActivityData[]): ActivityData[] {
 export function ActivityChart({
   data,
   unit = "tokens",
+  costLens = "effective",
 }: {
   data: ActivityData[];
   unit?: Unit;
+  /**
+   * Which cost column to plot when `unit === "dollars"`. `"effective"` reads
+   * `cost_cents` (the post-recalc value); `"list"` reads `cost_cents_ingested`
+   * (what the daemon shipped). Ignored when `unit === "tokens"`. Default
+   * "effective" keeps every existing caller on today's behavior (#235).
+   */
+  costLens?: CostLens;
 }) {
   if (data.length === 0) {
     return (
@@ -77,11 +96,24 @@ export function ActivityChart({
   const isTokens = unit === "tokens";
   const fmt = isTokens ? fmtNum : fmtCost;
   const yAxisLabel = isTokens ? "Tokens" : "Cost";
+  // For the dollar view, project the active lens onto a single `cost_value`
+  // field so the bar binds to one stable dataKey regardless of which column
+  // the recharts series reads. Avoids the temptation to remount the BarChart
+  // — and the animation glitch that would come with it — on every toggle.
+  const series = isTokens
+    ? bucketed
+    : bucketed.map((d) => ({
+        ...d,
+        cost_value:
+          costLens === "list"
+            ? (d.cost_cents_ingested ?? d.cost_cents)
+            : d.cost_cents,
+      }));
 
   return (
     <ResponsiveContainer width="100%" height={300}>
       <BarChart
-        data={bucketed}
+        data={series}
         margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
       >
         <CartesianGrid
@@ -126,7 +158,9 @@ export function ActivityChart({
               ? key === "input_tokens"
                 ? "Input"
                 : "Output"
-              : "Cost";
+              : costLens === "list"
+                ? "List cost"
+                : "Effective cost";
             return [fmt(Number(value)), seriesLabel];
           }}
         />
@@ -151,7 +185,7 @@ export function ActivityChart({
           </>
         ) : (
           <Bar
-            dataKey="cost_cents"
+            dataKey="cost_value"
             fill="#3b82f6"
             maxBarSize={28}
             radius={[4, 4, 0, 0]}

--- a/src/components/cost-lens-toggle.tsx
+++ b/src/components/cost-lens-toggle.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { clsx } from "clsx";
+import {
+  COST_LENSES,
+  COST_LENS_STORAGE_KEY,
+  DEFAULT_COST_LENS,
+  parseCostLens,
+} from "@/lib/cost-lens";
+
+/**
+ * Effective | List toggle for the Overview cost chart (#235). Mirrors the
+ * URL+localStorage pattern used by `UnitsSelector` and `PeriodSelector` so
+ * the choice round-trips through links, bookmarks, and the back/forward
+ * stack while still surviving a bare-URL reload via localStorage hydration.
+ *
+ * The toggle is rendered inline next to the chart's title (not in the
+ * page-level filter row), so it stays scoped to "what the cost chart
+ * shows" rather than implying it filters other tiles on the page.
+ */
+export function CostLensToggle() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlValue = searchParams.get("lens");
+  const current = parseCostLens(urlValue);
+
+  useEffect(() => {
+    if (urlValue) return;
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(COST_LENS_STORAGE_KEY);
+    const persisted = parseCostLens(stored);
+    if (persisted === DEFAULT_COST_LENS) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("lens", persisted);
+    router.replace(`?${params.toString()}`);
+  }, [urlValue, router, searchParams]);
+
+  function selectLens(value: string) {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(COST_LENS_STORAGE_KEY, value);
+    }
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("lens", value);
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Cost lens"
+      className="flex gap-1 rounded-lg border border-white/10 bg-white/[0.02] p-1"
+    >
+      {COST_LENSES.map((l) => (
+        <button
+          key={l.value}
+          role="radio"
+          aria-checked={current === l.value}
+          onClick={() => selectLens(l.value)}
+          className={clsx(
+            "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+            current === l.value
+              ? "bg-white/10 text-white"
+              : "text-zinc-400 hover:text-zinc-200"
+          )}
+        >
+          {l.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/savings-strip.tsx
+++ b/src/components/savings-strip.tsx
@@ -1,0 +1,59 @@
+import { fmtCost } from "@/lib/format";
+
+/**
+ * "You saved $X this period at negotiated rates" banner for /dashboard
+ * (#235). Renders above the cost chart whenever the org has an active price
+ * list AND the period's effective cost is strictly below the ingested cost.
+ *
+ * Hidden when:
+ *   - The org has no active `org_price_lists` row — there is no negotiated
+ *     rate to compare against, so the strip would just be visual noise.
+ *   - `effective >= ingested` — either nothing was recalculated yet for this
+ *     window, or the team's negotiated rate is *worse* than vendor list (a
+ *     legitimate case we don't surface as "savings" because the framing is
+ *     wrong; the audit history tab is where that detail belongs).
+ *
+ * The component itself is a pure render — the page decides whether to mount
+ * it. Keeping the visibility logic in the caller (rather than nesting it
+ * inside an `if (showStrip) return null`) means the SSR snapshot only ever
+ * paints the strip when it's going to stick, avoiding a hydration-time
+ * disappearance.
+ *
+ * The user-visible copy is composed by the caller and threaded through
+ * `title` / `subtitle` props rather than baked into the component body —
+ * page-tree tests (`src/test-utils/page-tree.ts`) pick up text from those
+ * recognized props but cannot peek into a Server Component's body, so this
+ * shape keeps the regression test surface honest.
+ */
+export function SavingsStrip({
+  title,
+  subtitle,
+}: {
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div
+      role="status"
+      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 text-sm"
+    >
+      <span aria-hidden className="text-emerald-300">
+        ●
+      </span>
+      <span className="font-semibold text-emerald-200">{title}</span>
+      <span className="text-zinc-400">{subtitle}</span>
+    </div>
+  );
+}
+
+/** Format the strip's copy from raw cents. Exported so the page wires it in. */
+export function buildSavingsStripCopy(
+  ingestedCents: number,
+  effectiveCents: number
+): { title: string; subtitle: string } {
+  const savedCents = ingestedCents - effectiveCents;
+  return {
+    title: `${fmtCost(savedCents)} saved this period at negotiated rates`,
+    subtitle: `list: ${fmtCost(ingestedCents)} → effective: ${fmtCost(effectiveCents)}`,
+  };
+}

--- a/src/lib/cost-lens.ts
+++ b/src/lib/cost-lens.ts
@@ -1,0 +1,34 @@
+/**
+ * "Effective vs list price" lens toggle for the Overview cost chart (#235).
+ *
+ * Each daily-rollup row carries two cost numbers since #231:
+ *   - `cost_cents_effective` — what the recalculation engine landed on
+ *     (defaults to ingested until #233 ships and a price list is active)
+ *   - `cost_cents_ingested`  — what the daemon shipped, before any recalc
+ *
+ * The lens decides which column the chart series reads. Keep the values,
+ * default, and parser in one module so every consumer agrees on the
+ * `?lens=` wire shape and on what falls back when the param is absent or
+ * malformed — the same recipe `units.ts` follows.
+ */
+export const COST_LENSES = [
+  { label: "Effective", value: "effective" },
+  { label: "List", value: "list" },
+] as const;
+
+export type CostLens = (typeof COST_LENSES)[number]["value"];
+
+/** Default lens when the URL has no `?lens=` param. */
+export const DEFAULT_COST_LENS: CostLens = "effective";
+
+/** localStorage key used by `CostLensToggle` to persist the last choice. */
+export const COST_LENS_STORAGE_KEY = "budi.dashboard.costLens";
+
+/**
+ * Coerce a raw `?lens=` value into a known lens. Anything other than the
+ * literal `"list"` collapses to `"effective"` — the safer fallback, since
+ * the effective column is what the rest of the dashboard reads.
+ */
+export function parseCostLens(raw: string | null | undefined): CostLens {
+  return raw === "list" ? "list" : "effective";
+}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -114,17 +114,27 @@ export async function getCurrentUser(): Promise<BudiUser | null> {
  * was enough to collapse the previous-period count to zero while every
  * other card on the same row showed real period-over-period deltas.
  */
+export interface OverviewStats {
+  totalCostCents: number;
+  totalCostCentsIngested: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalMessages: number;
+  totalSessions: number;
+}
+
 export async function getOverviewStats(
   user: BudiUser,
   range: DateRange,
   options?: ScopeOptions
-) {
+): Promise<OverviewStats> {
   const admin = createAdminClient();
 
   const deviceIds = await getVisibleDeviceIds(admin, user, options);
   if (deviceIds.length === 0) {
     return {
       totalCostCents: 0,
+      totalCostCentsIngested: 0,
       totalInputTokens: 0,
       totalOutputTokens: 0,
       totalMessages: 0,
@@ -141,8 +151,14 @@ export async function getOverviewStats(
   if (error) throw error;
 
   const row = (data?.[0] ?? null) as OverviewRow | null;
+  // Pre-#235 the RPC didn't surface `_ingested`; default to the effective
+  // total so a deployment that ships the dashboard ahead of migration 020
+  // simply reports zero savings rather than crashing on `undefined`.
+  const effective: number = Number(row?.total_cost_cents ?? 0);
+  const ingested: number = Number(row?.total_cost_cents_ingested ?? effective);
   return {
-    totalCostCents: Number(row?.total_cost_cents ?? 0),
+    totalCostCents: effective,
+    totalCostCentsIngested: ingested,
     totalInputTokens: Number(row?.total_input_tokens ?? 0),
     totalOutputTokens: Number(row?.total_output_tokens ?? 0),
     totalMessages: Number(row?.total_messages ?? 0),
@@ -152,6 +168,7 @@ export async function getOverviewStats(
 
 interface OverviewRow {
   total_cost_cents: number | string;
+  total_cost_cents_ingested?: number | string;
   total_input_tokens: number | string;
   total_output_tokens: number | string;
   total_messages: number | string;
@@ -185,13 +202,20 @@ export async function getDailyActivity(
   if (error) throw error;
 
   return ((data ?? []) as DailyActivityRow[])
-    .map((r) => ({
-      bucket_day: r.bucket_day,
-      input_tokens: Number(r.input_tokens),
-      output_tokens: Number(r.output_tokens),
-      cost_cents: Number(r.cost_cents),
-      message_count: Number(r.message_count),
-    }))
+    .map((r) => {
+      const effective = Number(r.cost_cents);
+      return {
+        bucket_day: r.bucket_day,
+        input_tokens: Number(r.input_tokens),
+        output_tokens: Number(r.output_tokens),
+        cost_cents: effective,
+        // Pre-#235 RPC has no `_ingested` column — collapse to effective so
+        // the toggle's "hide when ingested == effective everywhere" check
+        // stays correct and we never paint a fake savings delta.
+        cost_cents_ingested: Number(r.cost_cents_ingested ?? effective),
+        message_count: Number(r.message_count),
+      };
+    })
     .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
 }
 
@@ -200,6 +224,7 @@ interface DailyActivityRow {
   input_tokens: number | string;
   output_tokens: number | string;
   cost_cents: number | string;
+  cost_cents_ingested?: number | string;
   message_count: number | string;
 }
 
@@ -1310,6 +1335,30 @@ export async function getSyncFreshness(user: BudiUser): Promise<{
     lastRollupAt: (lastRollupRow?.synced_at as string | null) ?? null,
     lastSessionAt: (lastSessionRow?.started_at as string | null) ?? null,
   };
+}
+
+/**
+ * Whether the org has at least one `active` price list. Powers the
+ * conditional rendering of the savings strip and the Effective/List toggle
+ * on the Overview (#235): when no list is active, the daemon-uploaded cost
+ * is the only number that exists, so there is nothing to compare against
+ * and the UI stays clean. Until the upload UI ships (#232) this returns
+ * `false` for every org — and the Overview keeps rendering exactly as it
+ * does today, which is the acceptance criterion for migration 019.
+ */
+export async function getOrgHasActivePriceList(
+  orgId: string
+): Promise<boolean> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("org_price_lists")
+    .select("id")
+    .eq("org_id", orgId)
+    .eq("status", "active")
+    .limit(1)
+    .maybeSingle();
+  if (error) return false;
+  return data !== null;
 }
 
 /**

--- a/supabase/migrations/020_overview_dual_cost.sql
+++ b/supabase/migrations/020_overview_dual_cost.sql
@@ -1,0 +1,108 @@
+-- #235: surface the dual `cost_cents_*` columns from the two Overview RPCs.
+-- Migration 019 added the columns + aliased `cost_cents_effective AS cost_cents`
+-- so existing dashboard code kept rendering unchanged. The savings strip and
+-- the Effective/List view toggle on /dashboard need both values in a single
+-- payload, so we extend the RPC return shapes with `_ingested` siblings.
+--
+-- The existing `cost_cents` aliases stay so other readers (every other RPC,
+-- every breakdown table) remain on the effective lens — they don't care about
+-- the gap. Only the Overview surfaces the delta in v1.
+--
+-- Postgres rule: changing a `RETURNS TABLE` column list is *not* compatible
+-- with `CREATE OR REPLACE FUNCTION` — we have to drop and recreate. Each
+-- DROP/CREATE pair is inside the same migration so a fresh project never
+-- observes an intermediate state.
+
+-- ============================================================
+-- 1. dashboard_overview_stats: add `total_cost_cents_ingested`
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.dashboard_overview_stats(TEXT[], DATE, DATE, TEXT[]);
+
+CREATE FUNCTION public.dashboard_overview_stats(
+    p_device_ids   TEXT[],
+    p_bucket_from  DATE,
+    p_bucket_to    DATE,
+    p_surfaces     TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    total_cost_cents            NUMERIC,
+    total_cost_cents_ingested   NUMERIC,
+    total_input_tokens          BIGINT,
+    total_output_tokens         BIGINT,
+    total_messages              BIGINT,
+    total_sessions              BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    WITH r AS (
+        SELECT
+            COALESCE(SUM(cost_cents_effective), 0)   AS total_cost_cents,
+            COALESCE(SUM(cost_cents_ingested), 0)    AS total_cost_cents_ingested,
+            COALESCE(SUM(input_tokens), 0)::BIGINT   AS total_input_tokens,
+            COALESCE(SUM(output_tokens), 0)::BIGINT  AS total_output_tokens,
+            COALESCE(SUM(message_count), 0)::BIGINT  AS total_messages
+        FROM daily_rollups
+        WHERE device_id = ANY(p_device_ids)
+          AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+          AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+               OR surface = ANY(p_surfaces))
+    ),
+    s AS (
+        SELECT COUNT(*)::BIGINT AS total_sessions
+        FROM session_summaries
+        WHERE device_id = ANY(p_device_ids)
+          AND COALESCE(started_at, ended_at, synced_at)::date
+              BETWEEN p_bucket_from AND p_bucket_to
+          AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+               OR surface = ANY(p_surfaces))
+    )
+    SELECT r.total_cost_cents, r.total_cost_cents_ingested,
+           r.total_input_tokens, r.total_output_tokens,
+           r.total_messages, s.total_sessions
+    FROM r, s;
+$$;
+
+-- ============================================================
+-- 2. dashboard_daily_activity: add `cost_cents_ingested`
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.dashboard_daily_activity(TEXT[], DATE, DATE, TEXT[]);
+
+CREATE FUNCTION public.dashboard_daily_activity(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    bucket_day            DATE,
+    input_tokens          BIGINT,
+    output_tokens         BIGINT,
+    cost_cents            NUMERIC,
+    cost_cents_ingested   NUMERIC,
+    message_count         BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        bucket_day,
+        SUM(input_tokens)::BIGINT     AS input_tokens,
+        SUM(output_tokens)::BIGINT    AS output_tokens,
+        SUM(cost_cents_effective)     AS cost_cents,
+        SUM(cost_cents_ingested)      AS cost_cents_ingested,
+        SUM(message_count)::BIGINT    AS message_count
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY bucket_day
+    ORDER BY bucket_day ASC;
+$$;


### PR DESCRIPTION
Closes #235.

## Summary

Surfaces the list-vs-effective cost gap on `/dashboard` now that #231 has the dual cost columns in place. The two pieces are independent so each hides cleanly when there's nothing to surface:

- **`SavingsStrip`** — renders above the cost chart when the org has an `active` `org_price_lists` row **and** the period's effective cost is strictly below ingested. Until the recalc engine (#233) ships and a price list is uploaded (#232), every org returns no active list, so the strip stays hidden and the page renders exactly as it does today.
- **`CostLensToggle` (Effective | List)** — flips the cost chart series between `cost_cents_effective` and `cost_cents_ingested`, persists per user in `localStorage`, mirrors the existing `?units` / `?days` URL+storage pattern, and stays hidden when `ingested == effective` for every visible point (acceptance criterion 2).

Migration `020_overview_dual_cost.sql` extends `dashboard_overview_stats` and `dashboard_daily_activity` with the `_ingested` sibling columns. The existing `cost_cents` aliases stay so every other breakdown RPC keeps reading the effective lens — only Overview surfaces the delta in v1.

## Out of scope (deferred follow-ups)

- **Settings → Pricing audit history tab** — depends on the parent pricing settings page in #232.
- **Per-row list/effective tooltip on Sessions / Models / Repos detail tables** — separate ticket; would balloon this PR's scope across four pages.

## Test plan

- [x] `npm test` — 312 tests pass, including 7 new ones in `src/app/dashboard/page.test.tsx` covering all four acceptance branches (strip hidden when no active list / when no delta, visible when both; toggle hidden when no delta / no list / under `?units=tokens`, visible when delta + list).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeds.
- [ ] Manual: apply migration 020 against a local Supabase, seed an active `org_price_lists` row + a `daily_rollups` row with `cost_cents_ingested > cost_cents_effective`, reload `/dashboard`, confirm strip + toggle appear; flip the toggle and confirm the chart re-renders with the ingested series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)