### PR TITLE
feat(api): GET /v1/pricing/active for daemon price-list mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cloud alpha supports small teams (1–20 developers):
 - **Web dashboard**: Supabase Auth with GitHub, Google, and magic link sign-in
 - **Daemon sync**: API key (`budi_<key>`) in `Authorization: Bearer` header. Users link a local daemon to their cloud account with `budi cloud init --api-key <key>`; the daemon then owns the on-disk key storage.
 - **Ingest API**: `POST /v1/ingest` accepts the sync envelope; `GET /v1/ingest/status?device_id=…` returns watermark and sync health for a linked device.
+- **Pricing API**: `GET /v1/pricing/active` returns the org's active price list so the local daemon can mirror cloud math. Pass `?since_version=N` (or `If-None-Match`) to short-circuit to `304` when the daemon is up to date. Returns `404` when no active list is configured (daemon treats this as "no override" and keeps its default LiteLLM-derived pricing). Privacy-safe — only the negotiated sale price is sent; the vendor list price stays cloud-side.
 
 ## Setup
 

--- a/src/app/api/v1/pricing/active/route.test.ts
+++ b/src/app/api/v1/pricing/active/route.test.ts
@@ -88,7 +88,10 @@ class FakeQuery {
   // an array.
   then<TResult1 = { data: Row[]; error: null }, TResult2 = never>(
     onFulfilled?:
-      | ((value: { data: Row[]; error: null }) => TResult1 | PromiseLike<TResult1>)
+      | ((value: {
+          data: Row[];
+          error: null;
+        }) => TResult1 | PromiseLike<TResult1>)
       | null,
     onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
   ): Promise<TResult1 | TResult2> {
@@ -120,7 +123,8 @@ beforeEach(() => {
 async function call(opts: { since?: string; ifNoneMatch?: string } = {}) {
   const { GET } = await import("./route");
   const url = new URL("http://localhost/v1/pricing/active");
-  if (opts.since !== undefined) url.searchParams.set("since_version", opts.since);
+  if (opts.since !== undefined)
+    url.searchParams.set("since_version", opts.since);
   const headers: Record<string, string> = {
     authorization: "Bearer budi_testkey",
   };
@@ -155,10 +159,34 @@ describe("GET /v1/pricing/active (#234)", () => {
 
   it("404s when the only lists are draft / archived / future / past", async () => {
     fake.seed("org_price_lists", [
-      { id: 1, org_id: "org_acme", status: "draft", effective_from: PAST, effective_to: FUTURE },
-      { id: 2, org_id: "org_acme", status: "archived", effective_from: PAST, effective_to: FUTURE },
-      { id: 3, org_id: "org_acme", status: "active", effective_from: FUTURE, effective_to: null },
-      { id: 4, org_id: "org_acme", status: "active", effective_from: "2010-01-01", effective_to: "2010-12-31" },
+      {
+        id: 1,
+        org_id: "org_acme",
+        status: "draft",
+        effective_from: PAST,
+        effective_to: FUTURE,
+      },
+      {
+        id: 2,
+        org_id: "org_acme",
+        status: "archived",
+        effective_from: PAST,
+        effective_to: FUTURE,
+      },
+      {
+        id: 3,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: FUTURE,
+        effective_to: null,
+      },
+      {
+        id: 4,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: "2010-01-01",
+        effective_to: "2010-12-31",
+      },
     ]);
     const res = await call();
     expect(res.status).toBe(404);
@@ -294,7 +322,7 @@ describe("GET /v1/pricing/active (#234)", () => {
     expect(body.list_version).toBe(42);
   });
 
-  it("honours If-None-Match: \"<list_version>\"", async () => {
+  it('honours If-None-Match: "<list_version>"', async () => {
     fake.seed("org_price_lists", [
       {
         id: 13,

--- a/src/app/api/v1/pricing/active/route.test.ts
+++ b/src/app/api/v1/pricing/active/route.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #234: `GET /v1/pricing/active` — hands the daemon the org's active price
+ * list so local recalc stays in lockstep with cloud math.
+ *
+ * Tests drive the real route handler against a per-table fake Supabase that
+ * implements just enough of the postgrest fluent API to satisfy the queries
+ * the handler issues (.select, .eq, .in, .lte, .single, .maybeSingle).
+ */
+
+type Row = Record<string, unknown>;
+type Filter = (r: Row) => boolean;
+
+class FakeSupabase {
+  private byTable: Record<string, Row[]> = {};
+
+  seed(table: string, rows: Row[]) {
+    this.byTable[table] = [...rows];
+  }
+
+  reset() {
+    this.byTable = {};
+  }
+
+  from(table: string) {
+    return new FakeQuery(this.byTable[table] ?? []);
+  }
+
+  // Rate-limit RPC — return "allowed".
+  async rpc(_name: string, _args: unknown) {
+    void _name;
+    void _args;
+    return {
+      data: [{ allowed: true, current_count: 1, retry_after_seconds: 60 }],
+      error: null,
+    };
+  }
+}
+
+class FakeQuery {
+  private filters: Filter[] = [];
+
+  constructor(private readonly rows: Row[]) {}
+
+  select(_cols?: string) {
+    void _cols;
+    return this;
+  }
+
+  eq(col: string, value: unknown) {
+    this.filters.push((r) => r[col] === value);
+    return this;
+  }
+
+  in(col: string, values: unknown[]) {
+    this.filters.push((r) => values.includes(r[col]));
+    return this;
+  }
+
+  lte(col: string, value: unknown) {
+    this.filters.push((r) => {
+      const v = r[col];
+      if (typeof v !== "string" || typeof value !== "string") return false;
+      return v <= value;
+    });
+    return this;
+  }
+
+  private matched() {
+    return this.rows.filter((r) => this.filters.every((f) => f(r)));
+  }
+
+  async single() {
+    const m = this.matched();
+    if (m.length !== 1) return { data: null, error: { message: "not found" } };
+    return { data: m[0], error: null };
+  }
+
+  async maybeSingle() {
+    const m = this.matched();
+    if (m.length === 0) return { data: null, error: null };
+    return { data: m[0], error: null };
+  }
+
+  // Awaiting the chain without a terminator should resolve to the matched set —
+  // mirrors postgrest, which lets `await supabase.from(...).select(...)` return
+  // an array.
+  then<TResult1 = { data: Row[]; error: null }, TResult2 = never>(
+    onFulfilled?:
+      | ((value: { data: Row[]; error: null }) => TResult1 | PromiseLike<TResult1>)
+      | null,
+    onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): Promise<TResult1 | TResult2> {
+    const result = { data: this.matched(), error: null as null };
+    return Promise.resolve(result).then(onFulfilled, onRejected);
+  }
+}
+
+const fake = new FakeSupabase();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => fake,
+}));
+
+const USER = {
+  id: "usr_test",
+  org_id: "org_acme",
+  api_key: "budi_testkey",
+};
+
+const PAST = "2020-01-01";
+const FUTURE = "2099-12-31";
+
+beforeEach(() => {
+  fake.reset();
+  fake.seed("users", [USER]);
+});
+
+async function call(opts: { since?: string; ifNoneMatch?: string } = {}) {
+  const { GET } = await import("./route");
+  const url = new URL("http://localhost/v1/pricing/active");
+  if (opts.since !== undefined) url.searchParams.set("since_version", opts.since);
+  const headers: Record<string, string> = {
+    authorization: "Bearer budi_testkey",
+  };
+  if (opts.ifNoneMatch) headers["if-none-match"] = opts.ifNoneMatch;
+  const req = new Request(url, { method: "GET", headers });
+  return GET(req as unknown as Parameters<typeof GET>[0]);
+}
+
+describe("GET /v1/pricing/active (#234)", () => {
+  it("401s when the Authorization header is missing", async () => {
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/pricing/active");
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("401s for a key that doesn't start with budi_", async () => {
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/pricing/active", {
+      headers: { authorization: "Bearer sk-openai-abc" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+  });
+
+  it("404s when the org has no active price list", async () => {
+    fake.seed("org_price_lists", []);
+    const res = await call();
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe("No active price list");
+  });
+
+  it("404s when the only lists are draft / archived / future / past", async () => {
+    fake.seed("org_price_lists", [
+      { id: 1, org_id: "org_acme", status: "draft", effective_from: PAST, effective_to: FUTURE },
+      { id: 2, org_id: "org_acme", status: "archived", effective_from: PAST, effective_to: FUTURE },
+      { id: 3, org_id: "org_acme", status: "active", effective_from: FUTURE, effective_to: null },
+      { id: 4, org_id: "org_acme", status: "active", effective_from: "2010-01-01", effective_to: "2010-12-31" },
+    ]);
+    const res = await call();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with privacy-safe rows + list_version + ETag", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 7,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", [
+      {
+        list_id: 7,
+        platform: "bedrock",
+        model_pattern: "claude-sonnet-4-5-*",
+        region: "global",
+        token_type: "input",
+        sale_usd_per_mtok: 2.91,
+        // Defense-in-depth: even if a row carries `list_usd_per_mtok`, the
+        // endpoint must not leak it.
+        list_usd_per_mtok: 9.99,
+      },
+      {
+        list_id: 7,
+        platform: "bedrock",
+        model_pattern: "claude-sonnet-4-5-*",
+        region: "global",
+        token_type: "output",
+        sale_usd_per_mtok: 14.55,
+        list_usd_per_mtok: 30,
+      },
+    ]);
+    fake.seed("org_pricing_defaults", [
+      {
+        org_id: "org_acme",
+        default_platform: "bedrock",
+        default_region: "global",
+      },
+    ]);
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("etag")).toBe('"7"');
+    expect(res.headers.get("cache-control")).toMatch(/max-age=300/);
+
+    const body = (await res.json()) as {
+      org_id: string;
+      list_version: number;
+      effective_from: string;
+      effective_to: string | null;
+      defaults: { platform: string | null; region: string | null };
+      rows: Array<Record<string, unknown>>;
+      generated_at: string;
+    };
+
+    expect(body.org_id).toBe("org_acme");
+    expect(body.list_version).toBe(7);
+    expect(body.effective_from).toBe(PAST);
+    expect(body.effective_to).toBeNull();
+    expect(body.defaults).toEqual({ platform: "bedrock", region: "global" });
+    expect(body.rows).toHaveLength(2);
+    for (const row of body.rows) {
+      expect(row).not.toHaveProperty("list_usd_per_mtok");
+      expect(row).toHaveProperty("sale_usd_per_mtok");
+    }
+    expect(typeof body.generated_at).toBe("string");
+  });
+
+  it("never echoes the api_key in the response", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 7,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", []);
+    const res = await call();
+    const text = await res.text();
+    expect(text).not.toContain("budi_testkey");
+    expect(text).not.toContain("api_key");
+  });
+
+  it("returns 304 when since_version matches current list_version", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 42,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", [
+      {
+        list_id: 42,
+        platform: "anthropic",
+        model_pattern: "claude-haiku-4-5",
+        region: null,
+        token_type: "input",
+        sale_usd_per_mtok: 1,
+      },
+    ]);
+
+    const res = await call({ since: "42" });
+    expect(res.status).toBe(304);
+    expect(res.headers.get("etag")).toBe('"42"');
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns full body when since_version is stale", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 42,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", []);
+
+    const res = await call({ since: "41" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { list_version: number };
+    expect(body.list_version).toBe(42);
+  });
+
+  it("honours If-None-Match: \"<list_version>\"", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 13,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", []);
+
+    const res = await call({ ifNoneMatch: '"13"' });
+    expect(res.status).toBe(304);
+  });
+
+  it("scopes results to the authenticated user's org (cannot see other orgs)", async () => {
+    fake.seed("org_price_lists", [
+      // Foreign org's list — must be invisible.
+      {
+        id: 99,
+        org_id: "org_other",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    const res = await call();
+    expect(res.status).toBe(404);
+  });
+
+  it("returns null defaults when org_pricing_defaults is empty", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 1,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: PAST,
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", []);
+    fake.seed("org_pricing_defaults", []);
+
+    const res = await call();
+    const body = (await res.json()) as {
+      defaults: { platform: string | null; region: string | null };
+    };
+    expect(body.defaults).toEqual({ platform: null, region: null });
+  });
+
+  it("merges multiple active lists into one envelope (union of rows, MAX(id) as list_version)", async () => {
+    fake.seed("org_price_lists", [
+      {
+        id: 10,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: "2026-01-01",
+        effective_to: "2026-12-31",
+      },
+      {
+        id: 12,
+        org_id: "org_acme",
+        status: "active",
+        effective_from: "2026-03-01",
+        effective_to: null,
+      },
+    ]);
+    fake.seed("org_price_list_rows", [
+      {
+        list_id: 10,
+        platform: "anthropic",
+        model_pattern: "claude-haiku-4-5",
+        region: null,
+        token_type: "input",
+        sale_usd_per_mtok: 1,
+      },
+      {
+        list_id: 12,
+        platform: "bedrock",
+        model_pattern: "claude-sonnet-4-5-*",
+        region: "global",
+        token_type: "input",
+        sale_usd_per_mtok: 2.91,
+      },
+    ]);
+
+    const res = await call();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      list_version: number;
+      effective_from: string;
+      effective_to: string | null;
+      rows: Array<{ platform: string }>;
+    };
+    expect(body.list_version).toBe(12);
+    expect(body.effective_from).toBe("2026-01-01");
+    // One open-ended list wins — union end is "still in effect".
+    expect(body.effective_to).toBeNull();
+    expect(body.rows.map((r) => r.platform).sort()).toEqual([
+      "anthropic",
+      "bedrock",
+    ]);
+  });
+});

--- a/src/app/api/v1/pricing/active/route.ts
+++ b/src/app/api/v1/pricing/active/route.ts
@@ -1,0 +1,227 @@
+import { type NextRequest } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  clientIp,
+  hashKey,
+  rateLimit,
+  rateLimitResponse,
+} from "@/lib/rate-limit";
+
+// #234: daemon polls this endpoint to mirror the team's negotiated pricing so
+// the local recalc keeps matching cloud math. 60/min/key tracks the ingest cap
+// — a healthy daemon polls every few minutes, retries on top.
+const RATE_LIMIT = { limit: 60, windowSeconds: 60 } as const;
+
+// Server-side response freshness cap. Spec calls for a 5-min cache keyed by
+// (org_id, list_version); we expose it via Cache-Control so any intermediary
+// can honour it and so the daemon sees a stable hint even when our internal
+// cache layer is bypassed.
+const CACHE_MAX_AGE_SECONDS = 300;
+
+type PricingRow = {
+  platform: string;
+  model_pattern: string;
+  region: string | null;
+  token_type: "input" | "output" | "cache_read" | "cache_write";
+  sale_usd_per_mtok: number;
+};
+
+/**
+ * Authenticate the request via Bearer token. Same shape as `/v1/ingest` and
+ * `/v1/whoami`; intentionally duplicated so each endpoint stays grep-able.
+ */
+async function authenticateApiKey(
+  supabase: ReturnType<typeof createAdminClient>,
+  authHeader: string | null
+) {
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const apiKey = authHeader.slice(7);
+  if (!apiKey.startsWith("budi_")) return null;
+
+  const { data, error } = await supabase
+    .from("users")
+    .select("id, org_id")
+    .eq("api_key", apiKey)
+    .single();
+
+  if (error || !data) return null;
+  return data;
+}
+
+/**
+ * Parse the optional `?since_version=N` short-circuit. Returns the integer or
+ * `null` if the param is absent / malformed. Malformed values are treated as
+ * "no since_version" rather than 400 — a daemon with corrupt state should
+ * receive the full list and resynchronize, not bounce off a validation error.
+ */
+function parseSinceVersion(request: NextRequest): number | null {
+  const raw = new URL(request.url).searchParams.get("since_version");
+  if (!raw) return null;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return n;
+}
+
+/**
+ * GET /v1/pricing/active
+ *
+ * Hands the daemon the org's active price list so local recalc stays in
+ * lockstep with cloud math. Privacy-safe rows only — list (vendor-published)
+ * price is procurement metadata and never leaves the cloud; the daemon needs
+ * the sale price alone to compute `_effective`.
+ *
+ * Auth: Authorization: Bearer budi_<key>
+ * Query: ?since_version=N (optional; daemon's last-seen version)
+ *
+ * Response (200): { org_id, list_version, effective_from, effective_to,
+ *                   defaults: { platform, region }, rows: [...], generated_at }
+ * Response (304): empty body — daemon is up to date
+ * Response (404): { error: "No active price list" } — daemon treats as "no override"
+ * Response (401): { error: "Unauthorized" } — daemon pauses pricing polling
+ * Response (429): rate-limited
+ *
+ * Issue: siropkin/budi-cloud#234. Design: ADR-0094 §6.
+ */
+export async function GET(request: NextRequest) {
+  // --- Pre-auth IP rate limit (#179 pattern) ---
+  const ipLimit = await rateLimit(
+    `pricing-active:ip:${clientIp(request)}`,
+    RATE_LIMIT
+  );
+  if (!ipLimit.success) return rateLimitResponse(ipLimit.retryAfterSeconds);
+
+  const supabase = createAdminClient();
+  const authHeader = request.headers.get("authorization");
+  const user = await authenticateApiKey(supabase, authHeader);
+  if (!user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // --- Per-key rate limit ---
+  const keyLimit = await rateLimit(
+    `pricing-active:key:${hashKey(authHeader!.slice(7))}`,
+    RATE_LIMIT
+  );
+  if (!keyLimit.success) return rateLimitResponse(keyLimit.retryAfterSeconds);
+
+  // --- Fetch active price lists currently in effect ---
+  // Today must fall within [effective_from, effective_to or open). A list that
+  // is `active` but dated in the future or already past is ignored — the
+  // recalc engine would do the same, so the daemon should not mirror it.
+  const today = new Date().toISOString().slice(0, 10);
+  const { data: lists, error: listsError } = await supabase
+    .from("org_price_lists")
+    .select("id, effective_from, effective_to")
+    .eq("org_id", user.org_id)
+    .eq("status", "active")
+    .lte("effective_from", today);
+
+  if (listsError) {
+    console.error("Failed to load org_price_lists:", listsError);
+    return Response.json({ error: "Internal error" }, { status: 500 });
+  }
+
+  const inWindow = (lists ?? []).filter(
+    (l) =>
+      l.effective_to === null ||
+      l.effective_to === undefined ||
+      (typeof l.effective_to === "string" && l.effective_to >= today)
+  );
+
+  if (inWindow.length === 0) {
+    return Response.json({ error: "No active price list" }, { status: 404 });
+  }
+
+  // list_version is the MAX(id) of every active-in-window list — monotonic
+  // when a manager activates a new list and stable across polls in between.
+  // Same value goes into the ETag so clients have one identifier to track.
+  const listVersion = inWindow.reduce(
+    (max, l) => (typeof l.id === "number" && l.id > max ? l.id : max),
+    0
+  );
+  const etag = `"${listVersion}"`;
+
+  // --- 304 short-circuit on `since_version` or `If-None-Match` ---
+  const since = parseSinceVersion(request);
+  const ifNoneMatch = request.headers.get("if-none-match");
+  const matchesEtag = ifNoneMatch !== null && ifNoneMatch.replace(/^W\//, "") === etag;
+  if (since === listVersion || matchesEtag) {
+    return new Response(null, {
+      status: 304,
+      headers: {
+        ETag: etag,
+        "Cache-Control": `private, max-age=${CACHE_MAX_AGE_SECONDS}`,
+      },
+    });
+  }
+
+  // --- Compute the union effective range across active lists ---
+  // effective_from = MIN(effective_from); effective_to = MAX(effective_to)
+  // with NULL acting as "still in effect" (so any NULL wins).
+  let effectiveFrom: string = inWindow[0]!.effective_from as string;
+  let effectiveTo: string | null = inWindow[0]!.effective_to as string | null;
+  let openEnded = effectiveTo === null;
+  for (const l of inWindow) {
+    const from = l.effective_from as string;
+    const to = l.effective_to as string | null;
+    if (from < effectiveFrom) effectiveFrom = from;
+    if (to === null) openEnded = true;
+    else if (!openEnded && to > (effectiveTo ?? "")) effectiveTo = to;
+  }
+  if (openEnded) effectiveTo = null;
+
+  // --- Fetch the rows for every active-in-window list ---
+  const listIds = inWindow.map((l) => l.id as number);
+  const { data: rowData, error: rowsError } = await supabase
+    .from("org_price_list_rows")
+    .select("platform, model_pattern, region, token_type, sale_usd_per_mtok")
+    .in("list_id", listIds);
+
+  if (rowsError) {
+    console.error("Failed to load org_price_list_rows:", rowsError);
+    return Response.json({ error: "Internal error" }, { status: 500 });
+  }
+
+  const rows: PricingRow[] = (rowData ?? []).map((r) => ({
+    platform: r.platform as string,
+    model_pattern: r.model_pattern as string,
+    region: (r.region as string | null) ?? null,
+    token_type: r.token_type as PricingRow["token_type"],
+    // sale_usd_per_mtok arrives as a NUMERIC string from postgrest — coerce to
+    // a finite number so the daemon doesn't have to second-guess the type.
+    sale_usd_per_mtok: Number(r.sale_usd_per_mtok),
+  }));
+
+  // --- Pricing defaults (platform / region) ---
+  // Missing row → empty defaults object with null fields, matching the ADR
+  // contract; the daemon's recalc treats nulls as "no preference".
+  const { data: defaultsRow } = await supabase
+    .from("org_pricing_defaults")
+    .select("default_platform, default_region")
+    .eq("org_id", user.org_id)
+    .maybeSingle();
+
+  const defaults = {
+    platform: (defaultsRow?.default_platform as string | null) ?? null,
+    region: (defaultsRow?.default_region as string | null) ?? null,
+  };
+
+  return Response.json(
+    {
+      org_id: user.org_id,
+      list_version: listVersion,
+      effective_from: effectiveFrom,
+      effective_to: effectiveTo,
+      defaults,
+      rows,
+      generated_at: new Date().toISOString(),
+    },
+    {
+      headers: {
+        ETag: etag,
+        "Cache-Control": `private, max-age=${CACHE_MAX_AGE_SECONDS}`,
+      },
+    }
+  );
+}

--- a/src/app/api/v1/pricing/active/route.ts
+++ b/src/app/api/v1/pricing/active/route.ts
@@ -145,7 +145,8 @@ export async function GET(request: NextRequest) {
   // --- 304 short-circuit on `since_version` or `If-None-Match` ---
   const since = parseSinceVersion(request);
   const ifNoneMatch = request.headers.get("if-none-match");
-  const matchesEtag = ifNoneMatch !== null && ifNoneMatch.replace(/^W\//, "") === etag;
+  const matchesEtag =
+    ifNoneMatch !== null && ifNoneMatch.replace(/^W\//, "") === etag;
   if (since === listVersion || matchesEtag) {
     return new Response(null, {
       status: 304,


### PR DESCRIPTION
Closes #234.

## Summary
- New route handler at `src/app/api/v1/pricing/active/route.ts`. Same Bearer auth, IP+key rate-limit, and 401 contract as `/v1/ingest` and `/v1/whoami`.
- Returns the union of every `org_price_lists` row that is `status='active'` AND today ∈ [`effective_from`, `effective_to` or open). `list_version` = `MAX(id)` of those lists; doubles as the `ETag`.
- Short-circuits to `304` on `?since_version=<list_version>` OR `If-None-Match: "<list_version>"`. `404` when no active list is in effect (daemon treats this as "no override"). `429` on rate-limit. `401` on auth failure.
- Rows are projected to the privacy-safe shape from the issue (`platform`, `model_pattern`, `region`, `token_type`, `sale_usd_per_mtok`); `list_usd_per_mtok` never leaves the cloud.
- README §Auth gets a one-line entry alongside `/v1/ingest`.

## Acceptance criteria
- ✅ Org A bearer cannot read Org B's price list — handler scopes every query on `user.org_id`. Covered by the "scopes results to the authenticated user's org" test.
- ✅ `since_version` short-circuit returns `304` with empty body when up to date — `returns 304 when since_version matches current list_version` test.
- ✅ Endpoint contract documented in README alongside `/v1/ingest`.
- ✅ No ADR-0083 amendment needed (already shipped in siropkin/budi#725).

## Test plan
- [x] `npm test` — 324 passed, 12 new tests for this route (`route.test.ts`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Manual smoke against staging Supabase once a draft list is promoted (out of scope for this PR — covered by the recalc-engine ticket #233 once it can write rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)