### PR TITLE
feat(recalc): recalculate_effective_cost SQL engine (#233)

### DIFF
--- a/src/lib/recalculate-effective-cost.test.ts
+++ b/src/lib/recalculate-effective-cost.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #233: wrapper tests for `recalculateEffectiveCost`. The math is exercised
+ * by the migration (021) on CI's Postgres dry-run; here we verify the JS
+ * adapter:
+ *   - forwards the camelCase inputs onto the snake_case RPC args
+ *   - parses the `recalc_summary` composite (numeric-as-string included) into
+ *     a plain JS object the dashboard server actions can consume
+ *   - tolerates the two shapes supabase-js can return composite types in
+ *   - propagates RPC errors instead of swallowing them silently — a failed
+ *     recalc is a load-bearing event for the audit trail in #235 and must
+ *     not be lost
+ */
+
+type RpcArgs = {
+  p_org_id: string;
+  p_from_date: string;
+  p_to_date: string;
+  p_triggered_by: string | null;
+};
+
+type RpcResult = {
+  data: unknown;
+  error: unknown;
+};
+
+let lastRpc: { name: string; args: RpcArgs } | null = null;
+let nextRpcResult: RpcResult = { data: null, error: null };
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    rpc: (name: string, args: RpcArgs) => {
+      lastRpc = { name, args };
+      return Promise.resolve(nextRpcResult);
+    },
+  }),
+}));
+
+beforeEach(() => {
+  lastRpc = null;
+  nextRpcResult = { data: null, error: null };
+});
+
+describe("recalculateEffectiveCost", () => {
+  it("forwards camelCase inputs to the snake_case RPC contract", async () => {
+    nextRpcResult = {
+      data: {
+        run_id: 42,
+        rows_processed: 100,
+        rows_changed: 7,
+        before_total_cents: 1234.5,
+        after_total_cents: 1100.25,
+      },
+      error: null,
+    };
+
+    const { recalculateEffectiveCost } =
+      await import("./recalculate-effective-cost");
+
+    const result = await recalculateEffectiveCost({
+      orgId: "org_abc",
+      fromDate: "2026-01-01",
+      toDate: "2026-01-31",
+      triggeredBy: "usr_mgr",
+    });
+
+    expect(lastRpc?.name).toBe("recalculate_effective_cost");
+    expect(lastRpc?.args).toEqual({
+      p_org_id: "org_abc",
+      p_from_date: "2026-01-01",
+      p_to_date: "2026-01-31",
+      p_triggered_by: "usr_mgr",
+    });
+    expect(result).toEqual({
+      runId: 42,
+      rowsProcessed: 100,
+      rowsChanged: 7,
+      beforeTotalCents: 1234.5,
+      afterTotalCents: 1100.25,
+    });
+  });
+
+  it("defaults `triggeredBy` to null for the nightly pg_cron caller", async () => {
+    nextRpcResult = {
+      data: {
+        run_id: 1,
+        rows_processed: 0,
+        rows_changed: 0,
+        before_total_cents: 0,
+        after_total_cents: 0,
+      },
+      error: null,
+    };
+
+    const { recalculateEffectiveCost } =
+      await import("./recalculate-effective-cost");
+
+    await recalculateEffectiveCost({
+      orgId: "org_abc",
+      fromDate: "2026-05-10",
+      toDate: "2026-05-10",
+    });
+
+    expect(lastRpc?.args.p_triggered_by).toBeNull();
+  });
+
+  it("unwraps a composite returned as a one-element array (driver variant)", async () => {
+    nextRpcResult = {
+      data: [
+        {
+          run_id: "5",
+          rows_processed: "10",
+          rows_changed: "0",
+          before_total_cents: "999.0000",
+          after_total_cents: "999.0000",
+        },
+      ],
+      error: null,
+    };
+
+    const { recalculateEffectiveCost } =
+      await import("./recalculate-effective-cost");
+
+    const result = await recalculateEffectiveCost({
+      orgId: "org_idem",
+      fromDate: "2026-01-01",
+      toDate: "2026-01-31",
+    });
+
+    // NUMERIC values arriving as JS strings get coerced into real numbers so
+    // downstream callers can compare them without `Number()` on every read.
+    expect(result.runId).toBe(5);
+    expect(result.rowsProcessed).toBe(10);
+    expect(result.rowsChanged).toBe(0);
+    expect(result.beforeTotalCents).toBe(999);
+    expect(result.afterTotalCents).toBe(999);
+  });
+
+  it("propagates RPC errors so a failed recalc surfaces to the caller", async () => {
+    nextRpcResult = {
+      data: null,
+      error: new Error("invalid date window [2026-02-01 .. 2026-01-01]"),
+    };
+
+    const { recalculateEffectiveCost } =
+      await import("./recalculate-effective-cost");
+
+    await expect(
+      recalculateEffectiveCost({
+        orgId: "org_abc",
+        fromDate: "2026-02-01",
+        toDate: "2026-01-01",
+      })
+    ).rejects.toThrow("invalid date window");
+  });
+
+  it("throws when the RPC returns no row (defensive)", async () => {
+    nextRpcResult = { data: null, error: null };
+
+    const { recalculateEffectiveCost } =
+      await import("./recalculate-effective-cost");
+
+    await expect(
+      recalculateEffectiveCost({
+        orgId: "org_abc",
+        fromDate: "2026-01-01",
+        toDate: "2026-01-31",
+      })
+    ).rejects.toThrow("returned no row");
+  });
+});

--- a/src/lib/recalculate-effective-cost.ts
+++ b/src/lib/recalculate-effective-cost.ts
@@ -1,0 +1,80 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+
+/**
+ * #233: TypeScript wrapper around the Postgres `recalculate_effective_cost`
+ * function (migration 021). The math lives in SQL — see ADR-0094 §7 and the
+ * migration's header for the resolution + idempotency contracts. This wrapper
+ * only translates between camelCase callers (server actions, the nightly
+ * pg_cron shim, the "Recompute from <date>" admin button) and the Postgres
+ * `recalc_summary` composite the function returns.
+ *
+ * Only the service-role admin client can invoke the RPC: the migration
+ * REVOKE-s every other role. Manager gating happens above this layer in the
+ * server action — by the time control reaches here we trust the caller.
+ */
+
+export type RecalcSummary = {
+  /** `recalculation_runs.id` for the audit row this run wrote. */
+  runId: number;
+  /** Daily-rollup + session rows visited in scope. */
+  rowsProcessed: number;
+  /** Rows whose `_effective` cost actually changed (idempotent → 0). */
+  rowsChanged: number;
+  /** Sum of `cost_cents_effective` over the scope before the recalc. */
+  beforeTotalCents: number;
+  /** Sum of `cost_cents_effective` over the scope after the recalc. */
+  afterTotalCents: number;
+};
+
+export type RecalcInput = {
+  orgId: string;
+  /** Inclusive lower bound on `daily_rollups.bucket_day`. */
+  fromDate: string; // YYYY-MM-DD
+  /** Inclusive upper bound. */
+  toDate: string; // YYYY-MM-DD
+  /** Optional `users.id` of the manager who kicked this run off. */
+  triggeredBy?: string | null;
+};
+
+type RecalcRpcRow = {
+  run_id: number | string;
+  rows_processed: number | string;
+  rows_changed: number | string;
+  before_total_cents: number | string;
+  after_total_cents: number | string;
+};
+
+/**
+ * Invoke the `recalculate_effective_cost(org, from, to, by)` SQL function and
+ * normalize its `recalc_summary` composite into a JS object.
+ *
+ * The function returns a single composite row; supabase-js surfaces composite
+ * returns as either the object itself or a one-element array depending on
+ * driver version, so handle both shapes defensively.
+ */
+export async function recalculateEffectiveCost(
+  input: RecalcInput
+): Promise<RecalcSummary> {
+  const admin = createAdminClient();
+  const { data, error } = await admin.rpc("recalculate_effective_cost", {
+    p_org_id: input.orgId,
+    p_from_date: input.fromDate,
+    p_to_date: input.toDate,
+    p_triggered_by: input.triggeredBy ?? null,
+  });
+
+  if (error) throw error;
+
+  const row = (Array.isArray(data) ? data[0] : data) as RecalcRpcRow | null;
+  if (!row) {
+    throw new Error("recalculate_effective_cost returned no row");
+  }
+
+  return {
+    runId: Number(row.run_id),
+    rowsProcessed: Number(row.rows_processed),
+    rowsChanged: Number(row.rows_changed),
+    beforeTotalCents: Number(row.before_total_cents),
+    afterTotalCents: Number(row.after_total_cents),
+  };
+}

--- a/supabase/migrations/021_recalculate_effective_cost.sql
+++ b/supabase/migrations/021_recalculate_effective_cost.sql
@@ -1,0 +1,390 @@
+-- #233: Recalculation engine — recompute `cost_cents_effective` from a team's
+-- active price list(s). Implements the math layer of ADR-0094 §7.
+--
+-- Inputs: org_id, date window. The function:
+--   1. Inserts a `recalculation_runs` row in `running` and captures the
+--      pre-recalc `cost_cents_effective` total for the scope.
+--   2. For every (daily_rollups row, token_type) in scope, picks the
+--      most-specific matching price-list row from the org's active lists
+--      (most-specific = exact model match beats alias; region-pinned beats
+--      region-agnostic). Same resolution applies to `session_summaries`.
+--   3. Recomputes `cost_cents_effective` =
+--        (input × in_rate + output × out_rate +
+--         cache_creation × cache_write_rate + cache_read × cache_read_rate)
+--        / 10_000     (tokens × USD/MTok → cents)
+--      If *no* price-list row matches a rollup's (provider, model, region,
+--      bucket_day) combination, the row falls through to
+--      `cost_cents_ingested` (the LiteLLM-priced number the daemon already
+--      shipped). That is what makes the rollback path work: archive every
+--      list → no matches → effective reverts to ingested.
+--   4. Captures the post-recalc total, closes the `recalculation_runs` row
+--      with status `succeeded` and a `rows_changed` count. The whole thing
+--      is one transaction (it's a single function call), so a mid-run
+--      failure rolls everything back including the audit row.
+--
+-- Idempotency: the UPDATE skips rows whose `cost_cents_effective` already
+-- equals the freshly-computed value, so a second run over the same window
+-- with the same active lists records `rows_changed = 0` (acceptance #2).
+
+-- ============================================================
+-- 1. Return type
+-- ============================================================
+
+DROP TYPE IF EXISTS recalc_summary CASCADE;
+
+CREATE TYPE recalc_summary AS (
+    run_id              BIGINT,
+    rows_processed      BIGINT,
+    rows_changed        BIGINT,
+    before_total_cents  NUMERIC,
+    after_total_cents   NUMERIC
+);
+
+-- ============================================================
+-- 2. recalculate_effective_cost
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.recalculate_effective_cost(
+    p_org_id        TEXT,
+    p_from_date     DATE,
+    p_to_date       DATE,
+    p_triggered_by  TEXT DEFAULT NULL
+)
+RETURNS recalc_summary
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_run_id              BIGINT;
+    v_before_rollups      NUMERIC;
+    v_before_sessions     NUMERIC;
+    v_after_rollups       NUMERIC;
+    v_after_sessions      NUMERIC;
+    v_rows_processed      BIGINT := 0;
+    v_rows_changed        BIGINT := 0;
+    v_active_list_ids     BIGINT[];
+    v_result              recalc_summary;
+BEGIN
+    IF p_from_date IS NULL OR p_to_date IS NULL OR p_from_date > p_to_date THEN
+        RAISE EXCEPTION 'recalculate_effective_cost: invalid date window [% .. %]',
+            p_from_date, p_to_date;
+    END IF;
+
+    -- Lists driving this run (snapshotted into the audit row so future
+    -- archival of a list doesn't lose the "which list was active here?" link).
+    SELECT COALESCE(array_agg(id ORDER BY id), ARRAY[]::BIGINT[])
+      INTO v_active_list_ids
+      FROM org_price_lists
+     WHERE org_id = p_org_id
+       AND status = 'active'
+       AND effective_from <= p_to_date
+       AND (effective_to IS NULL OR effective_to >= p_from_date);
+
+    -- Pre-recalc totals across both surfaces of `_effective`. Sessions are
+    -- bucketed by COALESCE(started_at, ended_at, synced_at) to match the
+    -- convention every dashboard RPC uses.
+    SELECT COALESCE(SUM(r.cost_cents_effective), 0)
+      INTO v_before_rollups
+      FROM daily_rollups r
+      JOIN devices d ON d.id = r.device_id
+      JOIN users   u ON u.id = d.user_id
+     WHERE u.org_id = p_org_id
+       AND r.bucket_day BETWEEN p_from_date AND p_to_date;
+
+    SELECT COALESCE(SUM(s.total_cost_cents_effective), 0)
+      INTO v_before_sessions
+      FROM session_summaries s
+      JOIN devices d ON d.id = s.device_id
+      JOIN users   u ON u.id = d.user_id
+     WHERE u.org_id = p_org_id
+       AND COALESCE(s.started_at, s.ended_at, s.synced_at)::date
+             BETWEEN p_from_date AND p_to_date;
+
+    INSERT INTO recalculation_runs (
+        org_id, status, scope_from_date, scope_to_date,
+        price_list_ids, before_total_cents, triggered_by
+    ) VALUES (
+        p_org_id, 'running', p_from_date, p_to_date,
+        v_active_list_ids, v_before_rollups + v_before_sessions, p_triggered_by
+    )
+    RETURNING id INTO v_run_id;
+
+    -- --------------------------------------------------------
+    -- 2a. daily_rollups: per-row, per-token-type rate resolution
+    -- --------------------------------------------------------
+    -- The CTE pipeline:
+    --   scope     → daily_rollups in this org × this date window
+    --   matches   → every active-list row that *could* apply, joined to
+    --               alias rows so the daemon's wire model names match the
+    --               canonical CSV `model_pattern`
+    --   ranked    → pick the most-specific row per (rollup, token_type):
+    --               region-pinned wins over region-agnostic; exact model
+    --               match wins over alias match; deterministic tiebreak
+    --               on price_list_rows.id
+    --   pivoted   → 4-rate row per rollup, one column per token_type
+    --   new_costs → final new effective cost, with fall-through to
+    --               `cost_cents_ingested` when *no* token_type matched
+    WITH defaults AS (
+        SELECT default_platform, default_region
+          FROM org_pricing_defaults
+         WHERE org_id = p_org_id
+    ),
+    scope AS (
+        SELECT r.*
+          FROM daily_rollups r
+          JOIN devices d ON d.id = r.device_id
+          JOIN users   u ON u.id = d.user_id
+         WHERE u.org_id = p_org_id
+           AND r.bucket_day BETWEEN p_from_date AND p_to_date
+    ),
+    matches AS (
+        SELECT
+            s.device_id, s.bucket_day, s.role, s.provider, s.model,
+            s.repo_id, s.git_branch, s.surface,
+            plr.token_type,
+            plr.sale_usd_per_mtok,
+            plr.region,
+            plr.model_pattern,
+            plr.id AS price_row_id,
+            (plr.model_pattern = s.model) AS exact_model
+          FROM scope s
+          JOIN org_price_lists al
+            ON al.org_id = p_org_id
+           AND al.status = 'active'
+           AND s.bucket_day
+               BETWEEN al.effective_from
+                   AND COALESCE(al.effective_to, 'infinity'::date)
+          JOIN org_price_list_rows plr ON plr.list_id = al.id
+          LEFT JOIN model_aliases ma ON ma.display_name = plr.model_pattern
+          LEFT JOIN defaults def ON TRUE
+         WHERE plr.platform = s.provider
+           AND (plr.region IS NULL
+                OR def.default_region IS NULL
+                OR plr.region = def.default_region)
+           AND (plr.model_pattern = s.model
+                OR (ma.display_name IS NOT NULL AND s.model = ANY(ma.patterns)))
+    ),
+    ranked AS (
+        SELECT *,
+            ROW_NUMBER() OVER (
+                PARTITION BY device_id, bucket_day, role, provider, model,
+                             repo_id, git_branch, surface, token_type
+                ORDER BY
+                    (region IS NOT NULL) DESC,   -- region-pinned beats agnostic
+                    exact_model DESC,             -- exact > alias
+                    price_row_id                  -- deterministic tiebreak
+            ) AS rn
+          FROM matches
+    ),
+    best AS (
+        SELECT device_id, bucket_day, role, provider, model,
+               repo_id, git_branch, surface,
+               token_type, sale_usd_per_mtok
+          FROM ranked
+         WHERE rn = 1
+    ),
+    pivoted AS (
+        SELECT
+            device_id, bucket_day, role, provider, model,
+            repo_id, git_branch, surface,
+            MAX(CASE WHEN token_type = 'input'       THEN sale_usd_per_mtok END) AS r_input,
+            MAX(CASE WHEN token_type = 'output'      THEN sale_usd_per_mtok END) AS r_output,
+            MAX(CASE WHEN token_type = 'cache_write' THEN sale_usd_per_mtok END) AS r_cwrite,
+            MAX(CASE WHEN token_type = 'cache_read'  THEN sale_usd_per_mtok END) AS r_cread
+          FROM best
+         GROUP BY device_id, bucket_day, role, provider, model,
+                  repo_id, git_branch, surface
+    ),
+    new_costs AS (
+        SELECT
+            s.device_id, s.bucket_day, s.role, s.provider, s.model,
+            s.repo_id, s.git_branch, s.surface,
+            s.cost_cents_effective AS old_cost,
+            CASE
+                WHEN p.device_id IS NULL THEN s.cost_cents_ingested
+                ELSE (
+                    s.input_tokens          * COALESCE(p.r_input,  0)
+                  + s.output_tokens         * COALESCE(p.r_output, 0)
+                  + s.cache_creation_tokens * COALESCE(p.r_cwrite, 0)
+                  + s.cache_read_tokens     * COALESCE(p.r_cread,  0)
+                ) / 10000.0
+            END AS new_cost
+          FROM scope s
+          LEFT JOIN pivoted p USING (
+              device_id, bucket_day, role, provider, model,
+              repo_id, git_branch, surface
+          )
+    ),
+    upd AS (
+        UPDATE daily_rollups dr
+           SET cost_cents_effective = nc.new_cost
+          FROM new_costs nc
+         WHERE dr.device_id  = nc.device_id
+           AND dr.bucket_day = nc.bucket_day
+           AND dr.role       = nc.role
+           AND dr.provider   = nc.provider
+           AND dr.model      = nc.model
+           AND dr.repo_id    = nc.repo_id
+           AND dr.git_branch = nc.git_branch
+           AND dr.surface    = nc.surface
+           AND dr.cost_cents_effective IS DISTINCT FROM nc.new_cost
+         RETURNING 1
+    ),
+    proc AS (SELECT COUNT(*) AS c FROM new_costs)
+    SELECT proc.c, (SELECT COUNT(*) FROM upd)
+      INTO v_rows_processed, v_rows_changed
+      FROM proc;
+
+    -- --------------------------------------------------------
+    -- 2b. session_summaries: only input + output. Sessions don't carry
+    --     cache-token splits in v1, so the cache rates don't apply here.
+    --     Sessions without a `main_model` fall through to ingested.
+    -- --------------------------------------------------------
+    WITH defaults AS (
+        SELECT default_platform, default_region
+          FROM org_pricing_defaults
+         WHERE org_id = p_org_id
+    ),
+    scope AS (
+        SELECT s.*,
+               COALESCE(s.started_at, s.ended_at, s.synced_at)::date AS bucket_day
+          FROM session_summaries s
+          JOIN devices d ON d.id = s.device_id
+          JOIN users   u ON u.id = d.user_id
+         WHERE u.org_id = p_org_id
+           AND COALESCE(s.started_at, s.ended_at, s.synced_at)::date
+                 BETWEEN p_from_date AND p_to_date
+    ),
+    matches AS (
+        SELECT
+            s.device_id, s.session_id,
+            plr.token_type, plr.sale_usd_per_mtok,
+            plr.region, plr.model_pattern, plr.id AS price_row_id,
+            (plr.model_pattern = s.main_model) AS exact_model
+          FROM scope s
+          JOIN org_price_lists al
+            ON al.org_id = p_org_id
+           AND al.status = 'active'
+           AND s.bucket_day
+               BETWEEN al.effective_from
+                   AND COALESCE(al.effective_to, 'infinity'::date)
+          JOIN org_price_list_rows plr ON plr.list_id = al.id
+          LEFT JOIN model_aliases ma ON ma.display_name = plr.model_pattern
+          LEFT JOIN defaults def ON TRUE
+         WHERE s.main_model IS NOT NULL
+           AND plr.platform = s.provider
+           AND plr.token_type IN ('input', 'output')
+           AND (plr.region IS NULL
+                OR def.default_region IS NULL
+                OR plr.region = def.default_region)
+           AND (plr.model_pattern = s.main_model
+                OR (ma.display_name IS NOT NULL
+                    AND s.main_model = ANY(ma.patterns)))
+    ),
+    ranked AS (
+        SELECT *,
+            ROW_NUMBER() OVER (
+                PARTITION BY device_id, session_id, token_type
+                ORDER BY
+                    (region IS NOT NULL) DESC,
+                    exact_model DESC,
+                    price_row_id
+            ) AS rn
+          FROM matches
+    ),
+    best AS (
+        SELECT device_id, session_id, token_type, sale_usd_per_mtok
+          FROM ranked WHERE rn = 1
+    ),
+    pivoted AS (
+        SELECT
+            device_id, session_id,
+            MAX(CASE WHEN token_type = 'input'  THEN sale_usd_per_mtok END) AS r_input,
+            MAX(CASE WHEN token_type = 'output' THEN sale_usd_per_mtok END) AS r_output
+          FROM best
+         GROUP BY device_id, session_id
+    ),
+    new_costs AS (
+        SELECT
+            s.device_id, s.session_id,
+            CASE
+                WHEN p.device_id IS NULL THEN s.total_cost_cents_ingested
+                ELSE (
+                    s.total_input_tokens  * COALESCE(p.r_input,  0)
+                  + s.total_output_tokens * COALESCE(p.r_output, 0)
+                ) / 10000.0
+            END AS new_cost
+          FROM scope s
+          LEFT JOIN pivoted p USING (device_id, session_id)
+    ),
+    upd AS (
+        UPDATE session_summaries ss
+           SET total_cost_cents_effective = nc.new_cost
+          FROM new_costs nc
+         WHERE ss.device_id  = nc.device_id
+           AND ss.session_id = nc.session_id
+           AND ss.total_cost_cents_effective IS DISTINCT FROM nc.new_cost
+         RETURNING 1
+    ),
+    proc AS (SELECT COUNT(*) AS c FROM new_costs)
+    SELECT
+        v_rows_processed + proc.c,
+        v_rows_changed   + (SELECT COUNT(*) FROM upd)
+      INTO v_rows_processed, v_rows_changed
+      FROM proc;
+
+    -- Post-recalc totals, same scoping as the `before` reads.
+    SELECT COALESCE(SUM(r.cost_cents_effective), 0)
+      INTO v_after_rollups
+      FROM daily_rollups r
+      JOIN devices d ON d.id = r.device_id
+      JOIN users   u ON u.id = d.user_id
+     WHERE u.org_id = p_org_id
+       AND r.bucket_day BETWEEN p_from_date AND p_to_date;
+
+    SELECT COALESCE(SUM(s.total_cost_cents_effective), 0)
+      INTO v_after_sessions
+      FROM session_summaries s
+      JOIN devices d ON d.id = s.device_id
+      JOIN users   u ON u.id = d.user_id
+     WHERE u.org_id = p_org_id
+       AND COALESCE(s.started_at, s.ended_at, s.synced_at)::date
+             BETWEEN p_from_date AND p_to_date;
+
+    UPDATE recalculation_runs
+       SET status             = 'succeeded',
+           finished_at        = now(),
+           rows_processed     = v_rows_processed,
+           rows_changed       = v_rows_changed,
+           after_total_cents  = v_after_rollups + v_after_sessions
+     WHERE id = v_run_id;
+
+    v_result.run_id             := v_run_id;
+    v_result.rows_processed     := v_rows_processed;
+    v_result.rows_changed       := v_rows_changed;
+    v_result.before_total_cents := v_before_rollups + v_before_sessions;
+    v_result.after_total_cents  := v_after_rollups  + v_after_sessions;
+    RETURN v_result;
+END;
+$$;
+
+-- ============================================================
+-- 3. Permissions
+--
+-- Only the service-role admin client invokes the engine (the manager-only
+-- server actions in #232 route through there). Strip every other role's
+-- access; the CI dry-run runs on vanilla Postgres without `service_role`,
+-- mirror the guarded GRANT pattern from migration 017.
+-- ============================================================
+
+REVOKE ALL ON FUNCTION recalculate_effective_cost(TEXT, DATE, DATE, TEXT)
+    FROM PUBLIC;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+        EXECUTE 'GRANT EXECUTE ON FUNCTION recalculate_effective_cost(TEXT, DATE, DATE, TEXT) TO service_role';
+    END IF;
+END
+$$;


### PR DESCRIPTION
Closes #233. Implements the math layer of ADR-0094 §7 on top of the schema landed in #231/migration 019.

## Summary
- New migration `021_recalculate_effective_cost.sql` adds a `recalc_summary` composite type and a single `recalculate_effective_cost(org_id, from_date, to_date, triggered_by)` SQL function that:
  - Snapshots `cost_cents_effective` totals before/after over the scope.
  - Picks the most-specific matching `org_price_list_rows` row per `(rollup, token_type)` from the org's active lists — region-pinned beats region-agnostic, exact `model` beats alias resolution via `model_aliases`, deterministic tiebreak.
  - Recomputes `daily_rollups.cost_cents_effective` (input + output + cache_creation + cache_read) and `session_summaries.total_cost_cents_effective` (input + output only; sessions don't carry cache splits in v1).
  - Falls through to `cost_cents_ingested` when no price-list row matches — that's what makes the rollback path work (archive the active list → next recalc reverts every row).
  - Writes a `recalculation_runs` row (`running` → `succeeded`) with `price_list_ids`, before/after totals, and `rows_processed` / `rows_changed`.
- New `src/lib/recalculate-effective-cost.ts` wraps the RPC for the upcoming server actions (#232 "Recompute from <date>", nightly pg_cron shim).
- Unit tests verify the JS adapter; the SQL itself is dry-run by the existing `migrations` CI job on Postgres 15.

## Notes
- Function is `SECURITY DEFINER` and `service_role`-only (REVOKE PUBLIC + guarded GRANT, same pattern as migration 017 rate-limit). Manager gating belongs above this layer.
- Idempotent: the UPDATE uses `IS DISTINCT FROM`, so re-running over the same window with the same active lists records `rows_changed = 0` (acceptance criterion 2).
- before/after totals match `SUM(cost_cents_effective)` to the cent — both sides use the same NUMERIC type, no rounding.

## Test plan
- [x] `npm test` — 329 / 329 pass (5 new for the wrapper).
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` all clean.
- [ ] Migrations CI job dry-runs `021_recalculate_effective_cost.sql` on the Postgres 15 service container.
- [ ] Apply against a staging Supabase project and verify acceptance criteria end-to-end: deterministic math, idempotency, rollback-by-archival, `before/after_total_cents` agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)