### PR TITLE
feat(ingest): surfaces_seen/providers_seen diagnostic in /v1/ingest response (#204)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -1315,6 +1315,69 @@ describe("POST /v1/ingest — surface round-trip (#204)", () => {
     expect(fake.rows("session_summaries")[0].surface).toBe("unknown");
   });
 
+  it("response echoes the persisted surfaces/providers so operators can verify what the cloud actually saw (#204)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        payload: {
+          daily_rollups: [
+            { ...baseRollup, surface: "terminal", provider: "claude_code" },
+            { ...baseRollup, surface: "cursor", provider: "claude_code" },
+            { ...baseRollup, surface: "vscode", provider: "copilot_chat" },
+          ],
+          session_summaries: [
+            {
+              session_id: "sess-vscode",
+              provider: "copilot_chat",
+              started_at: "2026-04-14T10:00:00Z",
+              ended_at: "2026-04-14T11:00:00Z",
+              duration_ms: 1,
+              repo_id: null,
+              git_branch: null,
+              ticket: null,
+              message_count: 1,
+              total_input_tokens: 1,
+              total_output_tokens: 1,
+              total_cost_cents: 1,
+              surface: "vscode",
+            },
+          ],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      surfaces_seen: string[];
+      providers_seen: string[];
+    };
+    // Sorted, deduped union across both row sets.
+    expect(body.surfaces_seen).toEqual(["cursor", "terminal", "vscode"]);
+    expect(body.providers_seen).toEqual(["claude_code", "copilot_chat"]);
+  });
+
+  it("response collapses to ['unknown'] when no envelope row carries a surface — the receipt that confirms the bug is daemon-side, not cloud-side (#204)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...baseEnvelope,
+        payload: {
+          daily_rollups: [{ ...baseRollup }, { ...baseRollup, role: "user" }],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { surfaces_seen: string[] };
+    expect(body.surfaces_seen).toEqual(["unknown"]);
+  });
+
   it("trims whitespace and caps the stored surface at MAX_SURFACE_LENGTH", async () => {
     seedUser();
     const { POST } = await import("./route");

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildRollupRows,
   buildSessionRows,
+  summarizeEnvelope,
   validateIngestMetrics,
   type IngestDailyRollup,
   type IngestSessionSummary,
@@ -285,13 +286,27 @@ export async function POST(request: NextRequest) {
   let dailyRollupsUpserted = 0;
   let sessionSummariesUpserted = 0;
 
-  if (body.payload.daily_rollups.length > 0) {
-    const rollupRows = buildRollupRows(
-      body.device_id,
-      body.synced_at,
-      body.payload.daily_rollups
-    );
+  // Build both row sets up front so the response-shape diagnostic (#204) can
+  // echo the exact `surface` / `provider` values the cloud actually persisted
+  // — see `summarizeEnvelope` for why this matters.
+  const rollupRows =
+    body.payload.daily_rollups.length > 0
+      ? buildRollupRows(
+          body.device_id,
+          body.synced_at,
+          body.payload.daily_rollups
+        )
+      : [];
+  const sessionRows =
+    body.payload.session_summaries.length > 0
+      ? buildSessionRows(
+          body.device_id,
+          body.synced_at,
+          body.payload.session_summaries
+        )
+      : [];
 
+  if (rollupRows.length > 0) {
     const { error: rollupError, count } = await supabase
       .from("daily_rollups")
       .upsert(rollupRows, {
@@ -316,13 +331,7 @@ export async function POST(request: NextRequest) {
 
   // --- UPSERT session summaries (ADR-0083 §5) ---
   // See `buildSessionRows` for the `started_at` coalescing that fixes #14.
-  if (body.payload.session_summaries.length > 0) {
-    const sessionRows = buildSessionRows(
-      body.device_id,
-      body.synced_at,
-      body.payload.session_summaries
-    );
-
+  if (sessionRows.length > 0) {
     const { error: sessionError, count } = await supabase
       .from("session_summaries")
       .upsert(sessionRows, {
@@ -354,11 +363,20 @@ export async function POST(request: NextRequest) {
   // --- ADR-0083 §5: Success response ---
   // `records_upserted` stays for backward compatibility with existing daemon
   // builds; the per-table counts make session regressions obvious (#14).
+  // `surfaces_seen` / `providers_seen` echo the exact axis values the cloud
+  // persisted for this envelope — the diagnostic that closes the #204 audit
+  // loop ("did the daemon actually send named surfaces?").
+  const { surfaces_seen, providers_seen } = summarizeEnvelope(
+    rollupRows,
+    sessionRows
+  );
   return Response.json({
     accepted: true,
     watermark,
     records_upserted: dailyRollupsUpserted + sessionSummariesUpserted,
     daily_rollups_upserted: dailyRollupsUpserted,
     session_summaries_upserted: sessionSummariesUpserted,
+    surfaces_seen,
+    providers_seen,
   });
 }

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -205,6 +205,44 @@ function normalizeSurface(raw: unknown): string {
   return trimmed.slice(0, MAX_SURFACE_LENGTH);
 }
 
+/**
+ * Diagnostic for #204. The receiving cloud knows exactly what `surface` /
+ * `provider` values it persisted for this envelope; echoing the sorted-unique
+ * sets back in the ingest response lets `budi cloud sync` (or `curl`) show
+ * the operator whether named surfaces are arriving at all, without having to
+ * pull cloud logs or open the dashboard.
+ *
+ * If `surfaces_seen === ["unknown"]` and the dashboard reports the same shape,
+ * the gap is daemon-side (envelope never carried the field). If the daemon
+ * sent named surfaces but the dashboard still aggregates everything as
+ * "unknown", the gap is somewhere between this point and the rendered chart.
+ *
+ * Costs nothing on the hot path: one pass over the already-built row arrays,
+ * Set-deduped, capped at the same `MAX_*_SEEN` to bound the response body.
+ */
+const MAX_SURFACES_SEEN = 32;
+const MAX_PROVIDERS_SEEN = 32;
+
+export function summarizeEnvelope(
+  rollupRows: ReadonlyArray<{ surface: string; provider: string }>,
+  sessionRows: ReadonlyArray<{ surface: string; provider: string }>
+): { surfaces_seen: string[]; providers_seen: string[] } {
+  const surfaces = new Set<string>();
+  const providers = new Set<string>();
+  for (const r of rollupRows) {
+    surfaces.add(r.surface);
+    providers.add(r.provider);
+  }
+  for (const s of sessionRows) {
+    surfaces.add(s.surface);
+    providers.add(s.provider);
+  }
+  return {
+    surfaces_seen: [...surfaces].sort().slice(0, MAX_SURFACES_SEEN),
+    providers_seen: [...providers].sort().slice(0, MAX_PROVIDERS_SEEN),
+  };
+}
+
 export interface IngestSessionSummary {
   session_id: string;
   provider: string;


### PR DESCRIPTION
Refs #204.

## Context

The latest audit on #204 concluded the cloud-side ingest path is structurally correct — `surface` round-trips through `buildRollupRows` / `buildSessionRows`, the upsert conflict target matches the migration 014 PK, and `normalizeSurface` accepts any non-empty string. The remaining symptom (every row in the dashboard tagged `Unknown`) points to the daemon's upload payload, not this repo.

Per the audit's verification suggestion ("capture one real envelope leaving the daemon"), the cleanest improvement we can ship here is **diagnostic visibility** — let the operator see exactly which axis values the cloud just persisted, without tailing logs or running raw SQL.

## What changed

`POST /v1/ingest` success response now includes two new fields:

```json
{
  "accepted": true,
  "watermark": "2026-04-15",
  "records_upserted": 4,
  "daily_rollups_upserted": 3,
  "session_summaries_upserted": 1,
  "surfaces_seen": ["cursor", "terminal", "vscode"],
  "providers_seen": ["claude_code", "copilot_chat"]
}
```

- Sorted, deduped union of `surface` and `provider` values from the envelope's persisted rows.
- Capped at 32 each so a pathological envelope can't blow up the response body.
- Computed from the already-built row arrays — one extra pass, no extra DB work on the hot path.
- Additive — existing daemon builds parsing the response shape ignore unknown fields.

## How this closes the #204 audit loop

After this lands, `budi cloud sync` (or a `curl` of the endpoint) immediately answers the question the audit asked:

- `surfaces_seen === ["unknown"]` → envelope never carried the field. **Daemon-side fix.**
- `surfaces_seen` contains named surfaces but dashboard still shows only `Unknown` → gap is between persist and render. **Cloud-side, file follow-up.**

No production-code change can make non-`unknown` rows appear on the dashboard until the daemon serializes the field — this PR provides the receipt that pins the bug location.

## Test plan

- [x] Vitest: 28 tests in `route.test.ts` pass (added 2 new tests covering the diagnostic — mixed envelope returns the deduped union; envelope with no surface field returns `["unknown"]`).
- [x] Full suite: 338/338 pass.
- [x] Lint clean.
- [x] Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)