### PR TITLE
fix(settings): add "← Settings" back link to pricing sub-page (#243)

### DIFF
--- a/src/app/dashboard/settings/pricing/page.tsx
+++ b/src/app/dashboard/settings/pricing/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -83,7 +84,14 @@ export default async function PricingSettingsPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold">Pricing</h1>
+        <Link
+          href="/dashboard/settings"
+          className="inline-flex items-center text-sm text-zinc-400 hover:text-zinc-200"
+        >
+          <span aria-hidden="true">←</span>
+          <span className="ml-1">Settings</span>
+        </Link>
+        <h1 className="mt-2 text-xl font-bold">Pricing</h1>
         <p className="mt-1 text-sm text-zinc-400">
           Manage your team&apos;s negotiated price lists. Recalculations use the
           active list to override the daemon&apos;s ingested costs.


### PR DESCRIPTION
## Summary
- Adds a keyboard-accessible "← Settings" back link above the `<h1>` on `/dashboard/settings/pricing`, restoring the parent→child→back navigation chain.

Closes #243.

## Test plan
- [ ] Visit `/dashboard/settings` → click "Manage pricing".
- [ ] Confirm "← Settings" link is visible above the "Pricing" heading.
- [ ] Click the link and verify it navigates to `/dashboard/settings`.
- [ ] Tab to the link with the keyboard and confirm focus state is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)