### PR TITLE
fix(pricing): map vendor display names to canonical wire ids (#244)

### DIFF
--- a/src/app/actions/pricing.ts
+++ b/src/app/actions/pricing.ts
@@ -82,6 +82,75 @@ export async function savePricingDefaults(
   return { ok: true };
 }
 
+/**
+ * Build the alias dictionary used to map CSV rows. The "known models" hint
+ * (issue #244) is sourced from the org's own `daily_rollups.model` set so the
+ * vendor-display-name normalizer can confirm its guesses match real ingested
+ * data — and so a freshly pasted daemon id still maps when `model_aliases` is
+ * empty.
+ */
+async function loadAliasDict(
+  admin: ReturnType<typeof createAdminClient>,
+  orgId: string
+) {
+  const aliasRowsPromise = admin
+    .from("model_aliases")
+    .select("display_name, patterns");
+
+  const knownModelsPromise = loadKnownModels(admin, orgId);
+
+  const [{ data: aliasRows }, knownModels] = await Promise.all([
+    aliasRowsPromise,
+    knownModelsPromise,
+  ]);
+
+  return buildAliasDict(
+    (aliasRows ?? []).map((r) => ({
+      display_name: r.display_name as string,
+      patterns: (r.patterns as string[] | null) ?? [],
+    })),
+    knownModels
+  );
+}
+
+/**
+ * Distinct `daily_rollups.model` values ever uploaded by any of the org's
+ * devices. Two-step query mirrors the pattern in `org.ts` (users → devices →
+ * rollups) to avoid relying on Supabase's nested-relation filter syntax.
+ */
+async function loadKnownModels(
+  admin: ReturnType<typeof createAdminClient>,
+  orgId: string
+): Promise<string[]> {
+  const { data: orgUsers } = await admin
+    .from("users")
+    .select("id")
+    .eq("org_id", orgId);
+  const userIds = (orgUsers ?? []).map((u) => u.id as string);
+  if (userIds.length === 0) return [];
+
+  const { data: orgDevices } = await admin
+    .from("devices")
+    .select("id")
+    .in("user_id", userIds);
+  const deviceIds = (orgDevices ?? []).map((d) => d.id as string);
+  if (deviceIds.length === 0) return [];
+
+  const { data: rows } = await admin
+    .from("daily_rollups")
+    .select("model")
+    .in("device_id", deviceIds);
+  if (!Array.isArray(rows)) return [];
+
+  return Array.from(
+    new Set(
+      rows
+        .map((r) => (r as { model: unknown }).model)
+        .filter((m): m is string => typeof m === "string" && m.length > 0)
+    )
+  );
+}
+
 // ============================================================
 // CSV preview (parse-only; no DB writes)
 // ============================================================
@@ -128,15 +197,7 @@ export async function previewPricingCsv(
   const text = await file.text();
   const admin = createAdminClient();
 
-  const { data: aliasRows } = await admin
-    .from("model_aliases")
-    .select("display_name, patterns");
-  const aliases = buildAliasDict(
-    (aliasRows ?? []).map((r) => ({
-      display_name: r.display_name as string,
-      patterns: (r.patterns as string[] | null) ?? [],
-    }))
-  );
+  const aliases = await loadAliasDict(admin, auth.me.org_id);
 
   const result = parsePricingCsv(text, aliases);
 
@@ -227,15 +288,7 @@ export async function commitPricingDraft(
   const text = await file.text();
   const admin = createAdminClient();
 
-  const { data: aliasRows } = await admin
-    .from("model_aliases")
-    .select("display_name, patterns");
-  const aliases = buildAliasDict(
-    (aliasRows ?? []).map((r) => ({
-      display_name: r.display_name as string,
-      patterns: (r.patterns as string[] | null) ?? [],
-    }))
-  );
+  const aliases = await loadAliasDict(admin, auth.me.org_id);
 
   const parsed = parsePricingCsv(text, aliases);
   if (parsed.rows.length === 0) {

--- a/src/lib/pricing-csv.test.ts
+++ b/src/lib/pricing-csv.test.ts
@@ -1,8 +1,49 @@
 import { describe, it, expect } from "vitest";
-import { buildAliasDict, parsePricingCsv } from "./pricing-csv";
+import {
+  buildAliasDict,
+  normalizeVendorClaudeModel,
+  parsePricingCsv,
+} from "./pricing-csv";
 
 const HEADER =
   "Platform,Model,Type,Region,List Price (USD/MTok/Month),Sale Price (USD/MTok/Month)";
+
+describe("normalizeVendorClaudeModel", () => {
+  it("converts vendor display names to canonical wire ids", () => {
+    expect(normalizeVendorClaudeModel("Claude Sonnet 4.5")).toBe(
+      "claude-sonnet-4-5"
+    );
+    expect(normalizeVendorClaudeModel("Claude Opus 4.5")).toBe(
+      "claude-opus-4-5"
+    );
+    expect(normalizeVendorClaudeModel("Claude Haiku 4.5")).toBe(
+      "claude-haiku-4-5"
+    );
+    expect(normalizeVendorClaudeModel("Claude Opus 4.6")).toBe(
+      "claude-opus-4-6"
+    );
+  });
+
+  it("tolerates case and whitespace variation", () => {
+    expect(normalizeVendorClaudeModel("claude opus 4.5")).toBe(
+      "claude-opus-4-5"
+    );
+    expect(normalizeVendorClaudeModel("  Claude   Sonnet   4.5  ")).toBe(
+      "claude-sonnet-4-5"
+    );
+    expect(normalizeVendorClaudeModel("Claude-Sonnet-4.5")).toBe(
+      "claude-sonnet-4-5"
+    );
+  });
+
+  it("returns null for non-Claude or non-matching shapes", () => {
+    expect(normalizeVendorClaudeModel("Claude Sonnet 4")).toBeNull();
+    expect(normalizeVendorClaudeModel("Claude Banana 4.5")).toBeNull();
+    expect(normalizeVendorClaudeModel("GPT-4o")).toBeNull();
+    expect(normalizeVendorClaudeModel("claude-sonnet-4-5")).toBeNull();
+    expect(normalizeVendorClaudeModel("")).toBeNull();
+  });
+});
 
 describe("parsePricingCsv", () => {
   it("rejects a file missing required headers", () => {
@@ -30,9 +71,11 @@ describe("parsePricingCsv", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.rows).toHaveLength(4);
 
+    // Vendor display "Claude Sonnet 4.5" is normalized to its canonical wire
+    // id even without an alias dictionary (#244).
     expect(result.rows[0]).toMatchObject({
       platform: "bedrock",
-      model: "Claude Sonnet 4.5",
+      model: "claude-sonnet-4-5",
       tokenType: "input",
       region: "regional",
       listUsdPerMtok: 3.3,
@@ -100,6 +143,51 @@ describe("parsePricingCsv", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.rows[0]?.listUsdPerMtok).toBeNull();
     expect(result.rows[0]?.saleUsdPerMtok).toBe(0.1);
+  });
+
+  it("maps vendor display names to canonical wire ids (#244)", () => {
+    // model_aliases is empty — the vendor-display normalizer is the only
+    // thing that should make these map.
+    const aliases = buildAliasDict([]);
+
+    const csv = [
+      HEADER,
+      "Anthropic,Claude Sonnet 4.5,Prompts,Global,$3.00,$3.00",
+      "Anthropic,Claude Opus 4.5,Prompts,Global,$15.00,$15.00",
+      "Anthropic,Claude Haiku 4.5,Prompts,Global,$0.80,$0.80",
+      "Anthropic,Claude Opus 4.6,Prompts,Global,$15.00,$15.00",
+    ].join("\n");
+
+    const result = parsePricingCsv(csv, aliases);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows).toHaveLength(4);
+    expect(result.mappedCount).toBe(4);
+    expect(result.unmappedCount).toBe(0);
+    expect(result.rows.map((r) => r.model)).toEqual([
+      "claude-sonnet-4-5",
+      "claude-opus-4-5",
+      "claude-haiku-4-5",
+      "claude-opus-4-6",
+    ]);
+  });
+
+  it("maps daemon-emitted wire ids when known to the org (#244 regression)", () => {
+    // model_aliases empty, but the org has uploaded "claude-sonnet-4-5"
+    // rollups before — the known-models hint should still map the row.
+    const aliases = buildAliasDict([], ["claude-sonnet-4-5"]);
+
+    const csv = [
+      HEADER,
+      "Anthropic,claude-sonnet-4-5,Prompts,Global,$3.00,$3.00",
+    ].join("\n");
+
+    const result = parsePricingCsv(csv, aliases);
+    expect(result.errors).toHaveLength(0);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      model: "claude-sonnet-4-5",
+      mapped: true,
+    });
   });
 
   it("ignores blank lines between rows", () => {

--- a/src/lib/pricing-csv.ts
+++ b/src/lib/pricing-csv.ts
@@ -129,11 +129,19 @@ export type AliasDict = {
   displayNames: Set<string>;
   /** Map each wire-model pattern → its canonical display name. */
   patternToDisplay: Map<string, string>;
+  /**
+   * Wire-model ids actually observed in `daily_rollups.model` for the caller's
+   * org. Used as a fallback when a CSV row carries a vendor display form
+   * ("Claude Sonnet 4.5") that the model_aliases seed doesn't cover — issue
+   * #244. Empty when the org has no ingested rollups yet.
+   */
+  knownModels: Set<string>;
 };
 
 /** Build an alias dictionary from `{display_name, patterns}` rows. */
 export function buildAliasDict(
-  rows: Array<{ display_name: string; patterns: string[] | null }>
+  rows: Array<{ display_name: string; patterns: string[] | null }>,
+  knownModels: Iterable<string> = []
 ): AliasDict {
   const displayNames = new Set<string>();
   const patternToDisplay = new Map<string, string>();
@@ -144,7 +152,31 @@ export function buildAliasDict(
       if (p) patternToDisplay.set(p, row.display_name);
     }
   }
-  return { displayNames, patternToDisplay };
+  return {
+    displayNames,
+    patternToDisplay,
+    knownModels: new Set(knownModels),
+  };
+}
+
+/**
+ * Normalize a vendor's human-readable Claude model name (the form Anthropic
+ * publishes on its pricing page) to the canonical wire id the daemon emits.
+ *
+ *   "Claude Sonnet 4.5"  → "claude-sonnet-4-5"
+ *   "Claude  Opus  4.6"  → "claude-opus-4-6"
+ *   "claude opus 4.5"    → "claude-opus-4-5"
+ *
+ * Returns `null` if the input doesn't match the vendor display shape — the
+ * caller falls through to the existing alias dictionary in that case.
+ */
+export function normalizeVendorClaudeModel(model: string): string | null {
+  const collapsed = model.trim().replace(/\s+/g, " ").toLowerCase();
+  const match = collapsed.match(
+    /^claude[\s-]+(sonnet|opus|haiku)[\s-]+(\d+)\.(\d+)$/
+  );
+  if (!match) return null;
+  return `claude-${match[1]}-${match[2]}-${match[3]}`;
 }
 
 /**
@@ -154,7 +186,11 @@ export function buildAliasDict(
  */
 export function parsePricingCsv(
   source: string,
-  aliases: AliasDict = { displayNames: new Set(), patternToDisplay: new Map() }
+  aliases: AliasDict = {
+    displayNames: new Set(),
+    patternToDisplay: new Map(),
+    knownModels: new Set(),
+  }
 ): ParseResult {
   const lines = source
     .split(/\r?\n/)
@@ -249,8 +285,15 @@ export function parsePricingCsv(
       continue;
     }
 
-    // Resolve canonical model: alias display-name match wins; otherwise check
-    // if a pattern lookup canonicalizes; otherwise mark unmapped (still kept).
+    // Resolve canonical model. Resolution order:
+    //   1. exact alias display-name match
+    //   2. alias pattern lookup (canonicalizes to the display name)
+    //   3. wire id already present in the org's `daily_rollups` (handles a
+    //      pasted daemon id even when model_aliases is empty)
+    //   4. vendor display form ("Claude Sonnet 4.5") → wire id via
+    //      `normalizeVendorClaudeModel`; accepted as mapped because the
+    //      transformed id is what the recalc engine matches exactly against
+    //      `daily_rollups.model` (issue #244)
     let canonicalModel = model;
     let mapped = false;
     if (aliases.displayNames.has(model)) {
@@ -258,6 +301,14 @@ export function parsePricingCsv(
     } else if (aliases.patternToDisplay.has(model)) {
       canonicalModel = aliases.patternToDisplay.get(model)!;
       mapped = true;
+    } else if (aliases.knownModels.has(model)) {
+      mapped = true;
+    } else {
+      const vendorWireId = normalizeVendorClaudeModel(model);
+      if (vendorWireId !== null) {
+        canonicalModel = vendorWireId;
+        mapped = true;
+      }
     }
 
     const raw: Record<string, string> = {};


### PR DESCRIPTION
## Summary

- CSV uploads using Anthropic's published model names ("Claude Sonnet 4.5", "Claude Opus 4.6", …) used to land in the "Unmapped models" bucket, producing a silent no-op recalc. The parser now normalizes the vendor display form to the canonical wire id ("claude-sonnet-4-5") so the recalc engine matches it exactly against `daily_rollups.model`.
- Resolution order: exact alias display-name → alias pattern → wire id seen in the org's rollups → vendor display normalizer. The org's `daily_rollups.model` set is wired in as a "known models" hint so a pasted daemon id maps even when `model_aliases` is empty.

Fixes #244.

## Test plan

- [x] `npm test` — added unit tests for the vendor-display normalizer and end-to-end `parsePricingCsv` mapping (incl. the Sonnet/Opus/Haiku 4.5 + Opus 4.6 case from the issue).
- [x] `npm run typecheck` + `npm run lint` + `npm run format:check` all clean.
- [x] Regression guard: a CSV row with the daemon wire id `claude-sonnet-4-5` still maps when the org has uploaded that model.
- [ ] Manual: upload a real Anthropic-pricing-page CSV in the Settings → Pricing flow and confirm preview shows `Mapped == totalRows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)