### PR TITLE
feat(pricing): show sample unmapped rows in CSV preview (#246)

### DIFF
--- a/src/app/actions/pricing.ts
+++ b/src/app/actions/pricing.ts
@@ -171,6 +171,7 @@ export type CsvPreview = {
   mappedCount: number;
   unmappedCount: number;
   sampleMapped: PreviewRow[];
+  sampleUnmapped: PreviewRow[];
   unmappedModels: string[];
   errors: { lineNumber: number; message: string }[];
   /** Same `(filename, sha256-ish)` heuristic surfaced as a duplicate warning. */
@@ -228,25 +229,33 @@ function shapePreview(
   const unmappedModels = Array.from(
     new Set(result.rows.filter((r) => !r.mapped).map((r) => r.model))
   );
+  const toPreviewRow = (r: ParseResult["rows"][number]): PreviewRow => ({
+    lineNumber: r.lineNumber,
+    platform: r.platform,
+    model: r.model,
+    tokenType: r.tokenType,
+    region: r.region,
+    listUsdPerMtok: r.listUsdPerMtok,
+    saleUsdPerMtok: r.saleUsdPerMtok,
+    mapped: r.mapped,
+  });
+
   const sampleMapped: PreviewRow[] = result.rows
     .filter((r) => r.mapped)
     .slice(0, 5)
-    .map((r) => ({
-      lineNumber: r.lineNumber,
-      platform: r.platform,
-      model: r.model,
-      tokenType: r.tokenType,
-      region: r.region,
-      listUsdPerMtok: r.listUsdPerMtok,
-      saleUsdPerMtok: r.saleUsdPerMtok,
-      mapped: r.mapped,
-    }));
+    .map(toPreviewRow);
+
+  const sampleUnmapped: PreviewRow[] = result.rows
+    .filter((r) => !r.mapped)
+    .slice(0, 5)
+    .map(toPreviewRow);
 
   return {
     totalRows: result.rows.length,
     mappedCount: result.mappedCount,
     unmappedCount: result.unmappedCount,
     sampleMapped,
+    sampleUnmapped,
     unmappedModels,
     errors: result.errors,
     duplicateOfListName,

--- a/src/app/dashboard/settings/pricing/upload-csv-section.tsx
+++ b/src/app/dashboard/settings/pricing/upload-csv-section.tsx
@@ -5,6 +5,7 @@ import {
   commitPricingDraft,
   previewPricingCsv,
   type CsvPreview,
+  type PreviewRow,
 } from "@/app/actions/pricing";
 
 function todayISO() {
@@ -233,42 +234,64 @@ function PreviewBlock({ preview }: { preview: CsvPreview }) {
       )}
 
       {preview.sampleMapped.length > 0 && (
-        <div>
-          <p className="mb-2 text-xs font-medium text-zinc-400">
-            Sample mapped rows
-          </p>
-          <div className="overflow-x-auto">
-            <table className="w-full text-xs">
-              <thead>
-                <tr className="border-b border-white/10 text-left text-zinc-500">
-                  <th className="pb-1 font-medium">Model</th>
-                  <th className="pb-1 font-medium">Token</th>
-                  <th className="pb-1 font-medium">Region</th>
-                  <th className="pb-1 font-medium text-right">List</th>
-                  <th className="pb-1 font-medium text-right">Sale</th>
-                </tr>
-              </thead>
-              <tbody>
-                {preview.sampleMapped.map((r) => (
-                  <tr key={r.lineNumber} className="border-b border-white/5">
-                    <td className="py-1 text-zinc-300">{r.model}</td>
-                    <td className="py-1 text-zinc-400">{r.tokenType}</td>
-                    <td className="py-1 text-zinc-400">{r.region ?? "—"}</td>
-                    <td className="py-1 text-right text-zinc-400">
-                      {r.listUsdPerMtok === null
-                        ? "—"
-                        : `$${r.listUsdPerMtok.toFixed(2)}`}
-                    </td>
-                    <td className="py-1 text-right text-zinc-200">
-                      ${r.saleUsdPerMtok.toFixed(2)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <SampleRowsTable label="Sample mapped rows" rows={preview.sampleMapped} />
       )}
+
+      {preview.sampleUnmapped.length > 0 && (
+        <SampleRowsTable
+          label="Sample unmapped rows"
+          rows={preview.sampleUnmapped}
+          muted
+        />
+      )}
+    </div>
+  );
+}
+
+function SampleRowsTable({
+  label,
+  rows,
+  muted,
+}: {
+  label: string;
+  rows: PreviewRow[];
+  muted?: boolean;
+}) {
+  return (
+    <div>
+      <p className="mb-2 text-xs font-medium text-zinc-400">{label}</p>
+      <div
+        className={`overflow-x-auto ${muted ? "rounded-md bg-white/5 p-2" : ""}`}
+      >
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-white/10 text-left text-zinc-500">
+              <th className="pb-1 font-medium">Model</th>
+              <th className="pb-1 font-medium">Token</th>
+              <th className="pb-1 font-medium">Region</th>
+              <th className="pb-1 font-medium text-right">List</th>
+              <th className="pb-1 font-medium text-right">Sale</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.lineNumber} className="border-b border-white/5">
+                <td className="py-1 text-zinc-300">{r.model}</td>
+                <td className="py-1 text-zinc-400">{r.tokenType}</td>
+                <td className="py-1 text-zinc-400">{r.region ?? "—"}</td>
+                <td className="py-1 text-right text-zinc-400">
+                  {r.listUsdPerMtok === null
+                    ? "—"
+                    : `$${r.listUsdPerMtok.toFixed(2)}`}
+                </td>
+                <td className="py-1 text-right text-zinc-200">
+                  ${r.saleUsdPerMtok.toFixed(2)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/settings/pricing/upload-csv-section.tsx
+++ b/src/app/dashboard/settings/pricing/upload-csv-section.tsx
@@ -234,7 +234,10 @@ function PreviewBlock({ preview }: { preview: CsvPreview }) {
       )}
 
       {preview.sampleMapped.length > 0 && (
-        <SampleRowsTable label="Sample mapped rows" rows={preview.sampleMapped} />
+        <SampleRowsTable
+          label="Sample mapped rows"
+          rows={preview.sampleMapped}
+        />
       )}
 
       {preview.sampleUnmapped.length > 0 && (


### PR DESCRIPTION
## Summary
- Adds a `Sample unmapped rows` table to the CSV upload preview so users can verify column parsing when `mappedCount === 0`.
- Server action `previewPricingCsv` now returns `sampleUnmapped` (capped at 5 rows) alongside `sampleMapped`.
- Both tables share columns (Model / Token / Region / List / Sale); unmapped is rendered with a subtle muted background for easy side-by-side comparison.

Closes #246.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (343 passed)
- [ ] Manual: upload a CSV with all-unmapped rows — confirm `Sample unmapped rows` renders with parsed columns.
- [ ] Manual: upload a mixed CSV — both sample tables render.
- [ ] Manual: upload a fully-mapped CSV — only the mapped table renders (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)