### PR TITLE
feat(pricing): audit history tab + per-row cost tooltips (#733)

### DIFF
--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -12,7 +12,13 @@ import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { fmtCost, fmtNum, formatModelName, formatProvider } from "@/lib/format";
+import {
+  buildCostCellTooltip,
+  fmtCost,
+  fmtNum,
+  formatModelName,
+  formatProvider,
+} from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -166,7 +172,17 @@ export default async function ModelsPage({
                         <td className="py-2 text-right tabular-nums text-zinc-400">
                           {fmtNum(m.output_tokens)}
                         </td>
-                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                        <td
+                          className="py-2 text-right tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  m.cost_cents_ingested,
+                                  m.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             m.cost_cents,
                             m.input_tokens + m.output_tokens
@@ -186,7 +202,17 @@ export default async function ModelsPage({
                         <span className="text-zinc-200">
                           {formatModelName(m.model)}
                         </span>
-                        <span className="tabular-nums text-zinc-300">
+                        <span
+                          className="tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  m.cost_cents_ingested,
+                                  m.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             m.cost_cents,
                             m.input_tokens + m.output_tokens

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -217,6 +217,11 @@ export default async function OverviewPage({
       {periodHasSavings && (
         <SavingsStrip
           {...buildSavingsStripCopy(ingestedTotal, effectiveTotal)}
+          href={
+            user.role === "manager"
+              ? "/dashboard/settings/pricing#audit-history"
+              : undefined
+          }
         />
       )}
 

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -12,7 +12,7 @@ import { dateRangeFromDays } from "@/lib/date-range";
 import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
-import { fmtCost, fmtNum, repoName } from "@/lib/format";
+import { buildCostCellTooltip, fmtCost, fmtNum, repoName } from "@/lib/format";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -65,18 +65,25 @@ export default async function ReposPage({
   // the user actually sees.
   const repoBuckets = new Map<
     string,
-    { cost_cents: number; input_tokens: number; output_tokens: number }
+    {
+      cost_cents: number;
+      cost_cents_ingested: number;
+      input_tokens: number;
+      output_tokens: number;
+    }
   >();
   for (const r of repos) {
     const label = repoName(r.repo_id);
     const existing = repoBuckets.get(label);
     if (existing) {
       existing.cost_cents += r.cost_cents;
+      existing.cost_cents_ingested += r.cost_cents_ingested;
       existing.input_tokens += r.input_tokens;
       existing.output_tokens += r.output_tokens;
     } else {
       repoBuckets.set(label, {
         cost_cents: r.cost_cents,
+        cost_cents_ingested: r.cost_cents_ingested,
         input_tokens: r.input_tokens,
         output_tokens: r.output_tokens,
       });
@@ -93,6 +100,7 @@ export default async function ReposPage({
   const repoRows = Array.from(repoBuckets, ([label, totals]) => ({
     label,
     cost_cents: totals.cost_cents,
+    cost_cents_ingested: totals.cost_cents_ingested,
     input_tokens: totals.input_tokens,
     output_tokens: totals.output_tokens,
   }))
@@ -104,6 +112,7 @@ export default async function ReposPage({
       project: repoName(b.repo_id),
       branch: b.git_branch.replace(/^refs\/heads\//, ""),
       cost_cents: b.cost_cents,
+      cost_cents_ingested: b.cost_cents_ingested,
       input_tokens: b.input_tokens,
       output_tokens: b.output_tokens,
     }))
@@ -175,7 +184,17 @@ export default async function ReposPage({
                         <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
                           {fmtNum(r.output_tokens)}
                         </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-300">
+                        <td
+                          className="py-2 pl-4 text-right tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  r.cost_cents_ingested,
+                                  r.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             r.cost_cents,
                             r.input_tokens + r.output_tokens
@@ -195,7 +214,17 @@ export default async function ReposPage({
                         >
                           {r.label}
                         </span>
-                        <span className="shrink-0 tabular-nums text-zinc-300">
+                        <span
+                          className="shrink-0 tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  r.cost_cents_ingested,
+                                  r.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             r.cost_cents,
                             r.input_tokens + r.output_tokens
@@ -283,7 +312,17 @@ export default async function ReposPage({
                         <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
                           {fmtNum(b.output_tokens)}
                         </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-300">
+                        <td
+                          className="py-2 pl-4 text-right tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  b.cost_cents_ingested,
+                                  b.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             b.cost_cents,
                             b.input_tokens + b.output_tokens
@@ -303,7 +342,17 @@ export default async function ReposPage({
                         >
                           {b.project} / {b.branch}
                         </span>
-                        <span className="shrink-0 tabular-nums text-zinc-300">
+                        <span
+                          className="shrink-0 tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  b.cost_cents_ingested,
+                                  b.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             b.cost_cents,
                             b.input_tokens + b.output_tokens
@@ -369,7 +418,17 @@ export default async function ReposPage({
                         <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
                           {fmtNum(t.output_tokens)}
                         </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-300">
+                        <td
+                          className="py-2 pl-4 text-right tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  t.cost_cents_ingested,
+                                  t.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             t.cost_cents,
                             t.input_tokens + t.output_tokens
@@ -389,7 +448,17 @@ export default async function ReposPage({
                         >
                           {t.ticket}
                         </span>
-                        <span className="shrink-0 tabular-nums text-zinc-300">
+                        <span
+                          className="shrink-0 tabular-nums text-zinc-300"
+                          title={
+                            isTokens
+                              ? undefined
+                              : buildCostCellTooltip(
+                                  t.cost_cents_ingested,
+                                  t.cost_cents
+                                )
+                          }
+                        >
                           {fmtValue(
                             t.cost_cents,
                             t.input_tokens + t.output_tokens

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { SessionTokenComposition } from "@/components/session-token-composition";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import {
+  buildCostCellTooltip,
   fmtCost,
   fmtNum,
   formatDuration,
@@ -173,6 +174,10 @@ export default async function SessionDetailPage({
               <Field
                 label="Cost"
                 value={fmtCost(Number(session.total_cost_cents_effective))}
+                title={buildCostCellTooltip(
+                  Number(session.total_cost_cents_ingested),
+                  Number(session.total_cost_cents_effective)
+                )}
               />
             </dl>
             {/*
@@ -193,13 +198,24 @@ export default async function SessionDetailPage({
   );
 }
 
-function Field({ label, value }: { label: string; value: string | number }) {
+function Field({
+  label,
+  value,
+  title,
+}: {
+  label: string;
+  value: string | number;
+  /** Override the default value-as-title tooltip — used by the cost field to
+   * show "List: $X / Effective: $Y" when team pricing changed the number
+   * (#733). When omitted, falls back to the rendered value. */
+  title?: string;
+}) {
   return (
     <div className="min-w-0">
       <dt className="text-xs uppercase tracking-wide text-zinc-500">{label}</dt>
       <dd
         className="mt-0.5 truncate whitespace-nowrap text-zinc-200"
-        title={typeof value === "string" ? value : String(value)}
+        title={title ?? (typeof value === "string" ? value : String(value))}
       >
         {value}
       </dd>

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -17,6 +17,7 @@ import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
 import {
+  buildCostCellTooltip,
   fmtCost,
   fmtNum,
   formatDuration,
@@ -291,7 +292,17 @@ export default async function SessionsPage({
                               {fmtNum(s.message_count)}
                             </Link>
                           </td>
-                          <td className="text-right tabular-nums text-zinc-200">
+                          <td
+                            className="text-right tabular-nums text-zinc-200"
+                            title={
+                              isTokens
+                                ? undefined
+                                : buildCostCellTooltip(
+                                    Number(s.total_cost_cents_ingested),
+                                    Number(s.total_cost_cents_effective)
+                                  )
+                            }
+                          >
                             <Link
                               href={href}
                               className="block py-2 whitespace-nowrap"

--- a/src/app/dashboard/settings/pricing/audit-history-table.test.tsx
+++ b/src/app/dashboard/settings/pricing/audit-history-table.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { extractText } from "@/test-utils/page-tree";
+import type { RecalculationRunRow } from "@/lib/dal";
+import {
+  AuditHistoryTable,
+  PAGE_SIZE,
+  parsePage,
+  parseStatusFilter,
+} from "./audit-history-table";
+
+/**
+ * Tests for the Settings → Pricing → Audit history surface (#733).
+ *
+ * The component is a Server Component — these tests inspect the returned
+ * React tree via `extractText` rather than rendering, matching the rest of
+ * the dashboard's page-level coverage pattern (#112).
+ */
+
+describe("parseStatusFilter", () => {
+  it("defaults to 'all' when no value is supplied", () => {
+    expect(parseStatusFilter(undefined)).toBe("all");
+    expect(parseStatusFilter(null)).toBe("all");
+    expect(parseStatusFilter("")).toBe("all");
+  });
+
+  it("accepts the known status values verbatim", () => {
+    expect(parseStatusFilter("succeeded")).toBe("succeeded");
+    expect(parseStatusFilter("running")).toBe("running");
+    expect(parseStatusFilter("failed")).toBe("failed");
+  });
+
+  it("coerces unknown values back to 'all' so a bad URL never zeroes the table out", () => {
+    expect(parseStatusFilter("garbage")).toBe("all");
+  });
+});
+
+describe("parsePage", () => {
+  it("defaults to page 1", () => {
+    expect(parsePage(undefined)).toBe(1);
+    expect(parsePage(null)).toBe(1);
+    expect(parsePage("")).toBe(1);
+  });
+
+  it("parses positive integers", () => {
+    expect(parsePage("3")).toBe(3);
+    expect(parsePage("12")).toBe(12);
+  });
+
+  it("rejects zero, negative, and non-numeric values", () => {
+    expect(parsePage("0")).toBe(1);
+    expect(parsePage("-4")).toBe(1);
+    expect(parsePage("abc")).toBe(1);
+  });
+});
+
+const sampleRow: RecalculationRunRow = {
+  id: 42,
+  startedAt: "2026-05-01T10:30:00Z",
+  finishedAt: "2026-05-01T10:31:15Z",
+  status: "succeeded",
+  scopeFromDate: "2026-04-01",
+  scopeToDate: "2026-04-30",
+  priceListIds: [7, 8],
+  rowsProcessed: 5000,
+  rowsChanged: 4200,
+  beforeTotalCents: 481_520,
+  afterTotalCents: 352_777,
+  triggeredBy: "usr_admin",
+};
+
+describe("AuditHistoryTable", () => {
+  it("renders the row's stats and trigger label", () => {
+    const tree = AuditHistoryTable({
+      runs: [sampleRow],
+      total: 1,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      status: "all",
+      usersById: new Map([["usr_admin", "Admin Person"]]),
+    });
+    const text = extractText(tree);
+    expect(text).toContain("Admin Person");
+    expect(text).toContain("4200");
+    expect(text).toContain("$4,815.20".replace(/,/g, ""));
+    expect(text).toContain("succeeded");
+    expect(text).toContain("2026-04-01");
+  });
+
+  it("falls back to the raw user id when the user lookup misses", () => {
+    const tree = AuditHistoryTable({
+      runs: [sampleRow],
+      total: 1,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      status: "all",
+      usersById: new Map(),
+    });
+    expect(extractText(tree)).toContain("usr_admin");
+  });
+
+  it("shows an empty-state hint that mentions the active filter", () => {
+    const tree = AuditHistoryTable({
+      runs: [],
+      total: 0,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      status: "failed",
+      usersById: new Map(),
+    });
+    const text = extractText(tree);
+    expect(text).toContain("failed");
+    // The empty state should not pretend the page is paginated.
+    expect(text).not.toContain("Showing");
+  });
+
+  it("omits the pager when total fits on one page", () => {
+    const tree = AuditHistoryTable({
+      runs: [sampleRow],
+      total: 1,
+      page: 1,
+      pageSize: PAGE_SIZE,
+      status: "all",
+      usersById: new Map(),
+    });
+    expect(extractText(tree)).not.toContain("Previous");
+  });
+
+  it("renders the pager when total exceeds one page", () => {
+    const tree = AuditHistoryTable({
+      runs: Array(PAGE_SIZE).fill(sampleRow),
+      total: PAGE_SIZE * 3,
+      page: 2,
+      pageSize: PAGE_SIZE,
+      status: "all",
+      usersById: new Map(),
+    });
+    const text = extractText(tree);
+    expect(text).toContain("Previous");
+    expect(text).toContain("Next");
+    // `extractText` joins separate React children with spaces, so the literal
+    // "Page 2 / 3" arrives with extra whitespace. Assert the parts instead.
+    expect(text).toMatch(/Page\s+2\s+\/\s+3/);
+    expect(text).toMatch(/Showing\s+51\s*–\s*100\s+of\s+150/);
+  });
+});

--- a/src/app/dashboard/settings/pricing/audit-history-table.tsx
+++ b/src/app/dashboard/settings/pricing/audit-history-table.tsx
@@ -1,0 +1,305 @@
+import Link from "next/link";
+import type { RecalculationRunRow } from "@/lib/dal";
+import { fmtCost } from "@/lib/format";
+
+/**
+ * Settings → Pricing → Audit history (#733). Renders the org's
+ * `recalculation_runs` audit trail with status filter + offset pagination
+ * (50 rows/page). Server component: filter / page state lives in the URL
+ * (`?recalc_status=`, `?recalc_page=`) so a deep-link to "show every failed
+ * run on page 3" is shareable without client-side state.
+ *
+ * Rows are immutable audit records (#728), so no row-level actions are
+ * exposed — only inspection. The expandable detail pane is a native
+ * `<details>` element rather than a client component because the data is
+ * read-once and we don't pay React hydration for a static disclosure.
+ */
+export const PAGE_SIZE = 50;
+
+/** Status values worth offering in the filter chip. Includes the two values
+ * the recalc engine actually writes (#728 — `running` while in-flight,
+ * `succeeded` on commit) plus `failed` as a forward-looking option so a
+ * future change to the engine doesn't require revisiting this UI. */
+export const STATUS_FILTER_OPTIONS = [
+  "all",
+  "running",
+  "succeeded",
+  "failed",
+] as const;
+export type StatusFilter = (typeof STATUS_FILTER_OPTIONS)[number];
+
+export function parseStatusFilter(
+  raw: string | undefined | null
+): StatusFilter {
+  if (!raw) return "all";
+  const known = STATUS_FILTER_OPTIONS.find((s) => s === raw);
+  return known ?? "all";
+}
+
+export function parsePage(raw: string | undefined | null): number {
+  if (!raw) return 1;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return 1;
+  return n;
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const tone =
+    status === "succeeded"
+      ? "bg-emerald-500/15 text-emerald-300"
+      : status === "running"
+        ? "bg-amber-500/15 text-amber-300"
+        : status === "failed"
+          ? "bg-red-500/15 text-red-300"
+          : "bg-zinc-500/15 text-zinc-400";
+  return (
+    <span
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${tone}`}
+    >
+      {status || "—"}
+    </span>
+  );
+}
+
+function formatStarted(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatScope(from: string | null, to: string | null): string {
+  if (!from && !to) return "—";
+  if (from && to && from === to) return from;
+  return `${from ?? "…"} → ${to ?? "…"}`;
+}
+
+function formatDelta(
+  before: number | null,
+  after: number | null
+): { label: string; tone: "up" | "down" | "flat" } {
+  if (before == null || after == null) return { label: "—", tone: "flat" };
+  const diff = after - before;
+  if (diff === 0)
+    return { label: `${fmtCost(before)} → ${fmtCost(after)}`, tone: "flat" };
+  const tone = diff < 0 ? "down" : "up";
+  return {
+    label: `${fmtCost(before)} → ${fmtCost(after)}`,
+    tone,
+  };
+}
+
+export function AuditHistoryTable({
+  runs,
+  total,
+  page,
+  pageSize,
+  status,
+  usersById,
+}: {
+  runs: RecalculationRunRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+  status: StatusFilter;
+  usersById: Map<string, string>;
+}) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const showingFrom = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const showingTo = Math.min(page * pageSize, total);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-zinc-500">Filter:</span>
+        {STATUS_FILTER_OPTIONS.map((opt) => {
+          const isActive = opt === status;
+          const href = buildHref({
+            status: opt,
+            page: 1,
+          });
+          return (
+            <Link
+              key={opt}
+              href={href}
+              className={`rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors ${
+                isActive
+                  ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+                  : "border-white/10 bg-white/[0.02] text-zinc-300 hover:border-white/20"
+              }`}
+            >
+              {opt}
+            </Link>
+          );
+        })}
+      </div>
+
+      {runs.length === 0 ? (
+        <p className="text-sm text-zinc-500">
+          No recalculation runs
+          {status === "all" ? " yet" : ` with status "${status}"`}.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-left text-zinc-400">
+                <th className="pb-2 font-medium">Started</th>
+                <th className="pb-2 font-medium">Triggered by</th>
+                <th className="pb-2 font-medium">Scope</th>
+                <th className="pb-2 text-right font-medium">Rows changed</th>
+                <th className="pb-2 font-medium">Before → After</th>
+                <th className="pb-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((run) => {
+                const delta = formatDelta(
+                  run.beforeTotalCents,
+                  run.afterTotalCents
+                );
+                const trigger = run.triggeredBy
+                  ? (usersById.get(run.triggeredBy) ?? run.triggeredBy)
+                  : "—";
+                return (
+                  <tr
+                    key={run.id}
+                    className="border-b border-white/5 align-top"
+                  >
+                    <td className="py-2 text-zinc-200">
+                      <details>
+                        <summary className="cursor-pointer list-none whitespace-nowrap">
+                          <span aria-hidden className="mr-1 text-zinc-500">
+                            ▸
+                          </span>
+                          {formatStarted(run.startedAt)}
+                        </summary>
+                        <dl className="mt-2 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs text-zinc-400">
+                          <dt>Run id</dt>
+                          <dd className="font-mono text-zinc-300">{run.id}</dd>
+                          <dt>Finished</dt>
+                          <dd className="text-zinc-300">
+                            {run.finishedAt
+                              ? formatStarted(run.finishedAt)
+                              : "—"}
+                          </dd>
+                          <dt>Active price lists</dt>
+                          <dd className="text-zinc-300">
+                            {run.priceListIds.length === 0
+                              ? "—"
+                              : run.priceListIds.join(", ")}
+                          </dd>
+                          <dt>Rows processed</dt>
+                          <dd className="text-zinc-300">
+                            {run.rowsProcessed ?? "—"}
+                          </dd>
+                        </dl>
+                      </details>
+                    </td>
+                    <td className="py-2 text-zinc-300">{trigger}</td>
+                    <td className="py-2 text-zinc-400">
+                      {formatScope(run.scopeFromDate, run.scopeToDate)}
+                    </td>
+                    <td className="py-2 text-right text-zinc-200 tabular-nums">
+                      {run.rowsChanged ?? "—"}
+                    </td>
+                    <td
+                      className={`py-2 tabular-nums ${
+                        delta.tone === "down"
+                          ? "text-emerald-300"
+                          : delta.tone === "up"
+                            ? "text-amber-300"
+                            : "text-zinc-300"
+                      }`}
+                    >
+                      {delta.label}
+                    </td>
+                    <td className="py-2">
+                      <StatusBadge status={run.status} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {total > pageSize && (
+        <nav
+          aria-label="Audit history pagination"
+          className="flex items-center justify-between text-xs text-zinc-500"
+        >
+          <span>
+            Showing {showingFrom}–{showingTo} of {total}
+          </span>
+          <div className="flex items-center gap-2">
+            <PagerLink
+              status={status}
+              page={page - 1}
+              disabled={page <= 1}
+              label="← Previous"
+            />
+            <span className="text-zinc-400">
+              Page {page} / {totalPages}
+            </span>
+            <PagerLink
+              status={status}
+              page={page + 1}
+              disabled={page >= totalPages}
+              label="Next →"
+            />
+          </div>
+        </nav>
+      )}
+    </div>
+  );
+}
+
+function PagerLink({
+  status,
+  page,
+  disabled,
+  label,
+}: {
+  status: StatusFilter;
+  page: number;
+  disabled: boolean;
+  label: string;
+}) {
+  if (disabled) {
+    return (
+      <span className="rounded-md border border-white/5 bg-white/[0.01] px-2 py-1 text-zinc-600">
+        {label}
+      </span>
+    );
+  }
+  return (
+    <Link
+      href={buildHref({ status, page })}
+      className="rounded-md border border-white/10 bg-white/[0.02] px-2 py-1 text-zinc-300 hover:border-white/20"
+    >
+      {label}
+    </Link>
+  );
+}
+
+function buildHref({
+  status,
+  page,
+}: {
+  status: StatusFilter;
+  page: number;
+}): string {
+  const params = new URLSearchParams();
+  if (status !== "all") params.set("recalc_status", status);
+  if (page > 1) params.set("recalc_page", String(page));
+  const qs = params.toString();
+  // Land on the audit-history card with the deep-link anchor (#733).
+  return `/dashboard/settings/pricing${qs ? `?${qs}` : ""}#audit-history`;
+}

--- a/src/app/dashboard/settings/pricing/page.tsx
+++ b/src/app/dashboard/settings/pricing/page.tsx
@@ -1,11 +1,17 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getCurrentUser } from "@/lib/dal";
+import { getCurrentUser, getRecalculationRuns } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { DefaultsForm } from "./defaults-form";
 import { UploadCsvSection } from "./upload-csv-section";
 import { PriceListsTable } from "./price-lists-table";
+import {
+  AuditHistoryTable,
+  PAGE_SIZE,
+  parsePage,
+  parseStatusFilter,
+} from "./audit-history-table";
 
 /**
  * #232: Settings → Pricing. Admin-only surface for managing the team's
@@ -21,27 +27,45 @@ import { PriceListsTable } from "./price-lists-table";
  * Non-managers get a 404 (same response the rest of the dashboard uses for
  * manager-only sections — see #110).
  */
-export default async function PricingSettingsPage() {
+export default async function PricingSettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    recalc_status?: string;
+    recalc_page?: string;
+  }>;
+}) {
   const user = await getCurrentUser();
   if (!user?.org_id) return null;
   if (user.role !== "manager") notFound();
 
+  const params = await searchParams;
+  const recalcStatus = parseStatusFilter(params.recalc_status);
+  const recalcPage = parsePage(params.recalc_page);
+  const recalcOffset = (recalcPage - 1) * PAGE_SIZE;
+
   const admin = createAdminClient();
 
-  const [{ data: defaultsRow }, { data: lists }] = await Promise.all([
-    admin
-      .from("org_pricing_defaults")
-      .select("default_platform, default_region")
-      .eq("org_id", user.org_id)
-      .maybeSingle(),
-    admin
-      .from("org_price_lists")
-      .select(
-        "id, name, status, effective_from, effective_to, source_file_name, uploaded_at, uploaded_by"
-      )
-      .eq("org_id", user.org_id)
-      .order("uploaded_at", { ascending: false }),
-  ]);
+  const [{ data: defaultsRow }, { data: lists }, recalcRuns] =
+    await Promise.all([
+      admin
+        .from("org_pricing_defaults")
+        .select("default_platform, default_region")
+        .eq("org_id", user.org_id)
+        .maybeSingle(),
+      admin
+        .from("org_price_lists")
+        .select(
+          "id, name, status, effective_from, effective_to, source_file_name, uploaded_at, uploaded_by"
+        )
+        .eq("org_id", user.org_id)
+        .order("uploaded_at", { ascending: false }),
+      getRecalculationRuns(user.org_id, {
+        status: recalcStatus === "all" ? null : recalcStatus,
+        limit: PAGE_SIZE,
+        offset: recalcOffset,
+      }),
+    ]);
 
   const defaults = {
     platform: (defaultsRow?.default_platform as string | null) ?? null,
@@ -50,9 +74,10 @@ export default async function PricingSettingsPage() {
 
   const lookupUserIds = Array.from(
     new Set(
-      (lists ?? [])
-        .map((l) => l.uploaded_by as string | null)
-        .filter((v): v is string => Boolean(v))
+      [
+        ...(lists ?? []).map((l) => l.uploaded_by as string | null),
+        ...recalcRuns.rows.map((r) => r.triggeredBy),
+      ].filter((v): v is string => Boolean(v))
     )
   );
   const usersById = new Map<string, string>();
@@ -125,6 +150,24 @@ export default async function PricingSettingsPage() {
         </CardHeader>
         <CardContent>
           <UploadCsvSection />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div id="audit-history" className="scroll-mt-6">
+            <CardTitle>Audit history</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <AuditHistoryTable
+            runs={recalcRuns.rows}
+            total={recalcRuns.total}
+            page={recalcPage}
+            pageSize={PAGE_SIZE}
+            status={recalcStatus}
+            usersById={usersById}
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/components/savings-strip.tsx
+++ b/src/components/savings-strip.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { fmtCost } from "@/lib/format";
 
 /**
@@ -28,20 +29,40 @@ import { fmtCost } from "@/lib/format";
 export function SavingsStrip({
   title,
   subtitle,
+  href,
 }: {
   title: string;
   subtitle: string;
+  /** Optional deep-link target — wraps the strip in a Next `<Link>` when
+   * set. Used to drill into Settings → Pricing → Audit history (#733) for
+   * managers; member viewers don't get the link so they don't land on a 404. */
+  href?: string;
 }) {
-  return (
-    <div
-      role="status"
-      className="flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 text-sm"
-    >
+  const inner = (
+    <>
       <span aria-hidden className="text-emerald-300">
         ●
       </span>
       <span className="font-semibold text-emerald-200">{title}</span>
       <span className="text-zinc-400">{subtitle}</span>
+    </>
+  );
+  const className =
+    "flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-4 py-3 text-sm";
+  if (href) {
+    return (
+      <Link
+        href={href}
+        role="status"
+        className={`${className} transition-colors hover:bg-emerald-500/10`}
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return (
+    <div role="status" className={className}>
+      {inner}
     </div>
   );
 }

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -755,13 +755,20 @@ export async function getCostByModel(
   if (error) throw error;
 
   return ((data ?? []) as ModelCostRow[])
-    .map((r) => ({
-      provider: r.provider,
-      model: r.model,
-      cost_cents: Number(r.cost_cents),
-      input_tokens: Number(r.input_tokens ?? 0),
-      output_tokens: Number(r.output_tokens ?? 0),
-    }))
+    .map((r) => {
+      const effective = Number(r.cost_cents);
+      return {
+        provider: r.provider,
+        model: r.model,
+        cost_cents: effective,
+        // Pre-022 the RPC didn't surface `_ingested`; fall back to effective so
+        // the "List / Effective" tooltip stays hidden on deployments running
+        // ahead of migration 022 rather than rendering "$X / $X" everywhere.
+        cost_cents_ingested: Number(r.cost_cents_ingested ?? effective),
+        input_tokens: Number(r.input_tokens ?? 0),
+        output_tokens: Number(r.output_tokens ?? 0),
+      };
+    })
     .filter((m) => m.cost_cents > 0 || m.input_tokens + m.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
@@ -770,6 +777,7 @@ interface ModelCostRow {
   provider: string;
   model: string;
   cost_cents: number | string;
+  cost_cents_ingested?: number | string;
   input_tokens?: number | string;
   output_tokens?: number | string;
 }
@@ -797,12 +805,16 @@ export async function getCostByRepo(
   if (error) throw error;
 
   return ((data ?? []) as RepoCostRow[])
-    .map((r) => ({
-      repo_id: r.repo_id,
-      cost_cents: Number(r.cost_cents),
-      input_tokens: Number(r.input_tokens ?? 0),
-      output_tokens: Number(r.output_tokens ?? 0),
-    }))
+    .map((r) => {
+      const effective = Number(r.cost_cents);
+      return {
+        repo_id: r.repo_id,
+        cost_cents: effective,
+        cost_cents_ingested: Number(r.cost_cents_ingested ?? effective),
+        input_tokens: Number(r.input_tokens ?? 0),
+        output_tokens: Number(r.output_tokens ?? 0),
+      };
+    })
     .filter((r) => r.cost_cents > 0 || r.input_tokens + r.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
@@ -810,6 +822,7 @@ export async function getCostByRepo(
 interface RepoCostRow {
   repo_id: string;
   cost_cents: number | string;
+  cost_cents_ingested?: number | string;
   input_tokens?: number | string;
   output_tokens?: number | string;
 }
@@ -837,13 +850,17 @@ export async function getCostByBranch(
   if (error) throw error;
 
   return ((data ?? []) as BranchCostRow[])
-    .map((r) => ({
-      repo_id: r.repo_id,
-      git_branch: r.git_branch,
-      cost_cents: Number(r.cost_cents),
-      input_tokens: Number(r.input_tokens ?? 0),
-      output_tokens: Number(r.output_tokens ?? 0),
-    }))
+    .map((r) => {
+      const effective = Number(r.cost_cents);
+      return {
+        repo_id: r.repo_id,
+        git_branch: r.git_branch,
+        cost_cents: effective,
+        cost_cents_ingested: Number(r.cost_cents_ingested ?? effective),
+        input_tokens: Number(r.input_tokens ?? 0),
+        output_tokens: Number(r.output_tokens ?? 0),
+      };
+    })
     .filter((b) => b.cost_cents > 0 || b.input_tokens + b.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
@@ -852,6 +869,7 @@ interface BranchCostRow {
   repo_id: string;
   git_branch: string;
   cost_cents: number | string;
+  cost_cents_ingested?: number | string;
   input_tokens?: number | string;
   output_tokens?: number | string;
 }
@@ -879,12 +897,16 @@ export async function getCostByTicket(
   if (error) throw error;
 
   return ((data ?? []) as TicketCostRow[])
-    .map((r) => ({
-      ticket: r.ticket,
-      cost_cents: Number(r.cost_cents),
-      input_tokens: Number(r.input_tokens ?? 0),
-      output_tokens: Number(r.output_tokens ?? 0),
-    }))
+    .map((r) => {
+      const effective = Number(r.cost_cents);
+      return {
+        ticket: r.ticket,
+        cost_cents: effective,
+        cost_cents_ingested: Number(r.cost_cents_ingested ?? effective),
+        input_tokens: Number(r.input_tokens ?? 0),
+        output_tokens: Number(r.output_tokens ?? 0),
+      };
+    })
     .filter((t) => t.cost_cents > 0 || t.input_tokens + t.output_tokens > 0)
     .sort((a, b) => b.cost_cents - a.cost_cents);
 }
@@ -892,6 +914,7 @@ export async function getCostByTicket(
 interface TicketCostRow {
   ticket: string;
   cost_cents: number | string;
+  cost_cents_ingested?: number | string;
   input_tokens?: number | string;
   output_tokens?: number | string;
 }
@@ -1359,6 +1382,69 @@ export async function getOrgHasActivePriceList(
     .maybeSingle();
   if (error) return false;
   return data !== null;
+}
+
+/**
+ * Page of `recalculation_runs` rows for the Settings → Pricing audit-history
+ * tab (#733). Each row is one invocation of the recalc engine (#728); the
+ * rows are immutable. We support a simple offset window because the table is
+ * small (one row per admin click) and the surface paginates 50 at a time.
+ *
+ * `status` narrows by `recalculation_runs.status`. Pass `null` to include
+ * every run. The page also returns `total` so the UI can size the pager
+ * without a second round-trip — `count: "exact"` is cheap on this table.
+ */
+export interface RecalculationRunRow {
+  id: number;
+  startedAt: string;
+  finishedAt: string | null;
+  status: string;
+  scopeFromDate: string | null;
+  scopeToDate: string | null;
+  priceListIds: number[];
+  rowsProcessed: number | null;
+  rowsChanged: number | null;
+  beforeTotalCents: number | null;
+  afterTotalCents: number | null;
+  triggeredBy: string | null;
+}
+
+export async function getRecalculationRuns(
+  orgId: string,
+  options: { status: string | null; limit: number; offset: number }
+): Promise<{ rows: RecalculationRunRow[]; total: number }> {
+  const admin = createAdminClient();
+  let query = admin
+    .from("recalculation_runs")
+    .select(
+      "id, started_at, finished_at, status, scope_from_date, scope_to_date, price_list_ids, rows_processed, rows_changed, before_total_cents, after_total_cents, triggered_by",
+      { count: "exact" }
+    )
+    .eq("org_id", orgId)
+    .order("started_at", { ascending: false })
+    .range(options.offset, options.offset + options.limit - 1);
+  if (options.status) query = query.eq("status", options.status);
+
+  const { data, count, error } = await query;
+  if (error) throw error;
+
+  const rows: RecalculationRunRow[] = (data ?? []).map((r) => ({
+    id: r.id as number,
+    startedAt: r.started_at as string,
+    finishedAt: (r.finished_at as string | null) ?? null,
+    status: (r.status as string) ?? "",
+    scopeFromDate: (r.scope_from_date as string | null) ?? null,
+    scopeToDate: (r.scope_to_date as string | null) ?? null,
+    priceListIds: ((r.price_list_ids as number[] | null) ?? []).map(Number),
+    rowsProcessed: r.rows_processed == null ? null : Number(r.rows_processed),
+    rowsChanged: r.rows_changed == null ? null : Number(r.rows_changed),
+    beforeTotalCents:
+      r.before_total_cents == null ? null : Number(r.before_total_cents),
+    afterTotalCents:
+      r.after_total_cents == null ? null : Number(r.after_total_cents),
+    triggeredBy: (r.triggered_by as string | null) ?? null,
+  }));
+  return { rows, total: count ?? 0 };
 }
 
 /**

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { fmtDelta, formatDuration, formatProvider, repoName } from "./format";
+import {
+  buildCostCellTooltip,
+  fmtDelta,
+  formatDuration,
+  formatProvider,
+  repoName,
+} from "./format";
 
 describe("formatDuration (#88)", () => {
   it("uses duration_ms when provided", () => {
@@ -114,5 +120,27 @@ describe("formatProvider (#168)", () => {
     expect(formatProvider(null)).toBe("-");
     expect(formatProvider(undefined)).toBe("-");
     expect(formatProvider("")).toBe("-");
+  });
+});
+
+describe("buildCostCellTooltip (#733)", () => {
+  it("returns undefined when ingested equals effective", () => {
+    expect(buildCostCellTooltip(1000, 1000)).toBeUndefined();
+    expect(buildCostCellTooltip(0, 0)).toBeUndefined();
+  });
+
+  it("returns 'List / Effective' when team pricing changed the cost", () => {
+    expect(buildCostCellTooltip(500_00, 350_00)).toBe(
+      "List: $500.00 / Effective: $350.00"
+    );
+  });
+
+  it("treats sub-cent rounding drift as equal so a $0.001 gap doesn't render a misleading tooltip", () => {
+    expect(buildCostCellTooltip(1000.5, 1000.0)).toBeUndefined();
+  });
+
+  it("returns undefined for non-finite inputs rather than rendering NaN", () => {
+    expect(buildCostCellTooltip(Number.NaN, 100)).toBeUndefined();
+    expect(buildCostCellTooltip(100, Number.POSITIVE_INFINITY)).toBeUndefined();
   });
 });

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -11,6 +11,25 @@ export function fmtCost(cents: number): string {
   return `$${dollars.toFixed(2)}`;
 }
 
+/**
+ * Detail-table cost-cell tooltip text (#733). Returns `undefined` when
+ * effective equals ingested (no team pricing applied to this row) so the
+ * caller can drop the `title` attribute entirely — a `title=""` would render
+ * an empty hover bubble in some browsers. We tolerate tiny rounding drift:
+ * recalc resolves prices per-token-type and rejoins, so a $0.01 gap on a
+ * multi-row aggregation is meaningless to a viewer.
+ */
+export function buildCostCellTooltip(
+  ingestedCents: number,
+  effectiveCents: number
+): string | undefined {
+  if (!Number.isFinite(ingestedCents) || !Number.isFinite(effectiveCents)) {
+    return undefined;
+  }
+  if (Math.abs(ingestedCents - effectiveCents) < 1) return undefined;
+  return `List: ${fmtCost(ingestedCents)} / Effective: ${fmtCost(effectiveCents)}`;
+}
+
 /** Format a number with locale-aware grouping. */
 export function fmtNum(n: number): string {
   if (n === 0) return "0";

--- a/supabase/migrations/022_breakdown_dual_cost.sql
+++ b/supabase/migrations/022_breakdown_dual_cost.sql
@@ -1,0 +1,171 @@
+-- #733: thread the dual `cost_cents_*` columns through the breakdown RPCs so
+-- the Models / Repos / detail tables can render the "List: $X / Effective:
+-- $Y" hover tooltip on each row. Migration 020 already extended the Overview
+-- RPCs; this migration extends the rest of the dashboard's breakdown queries
+-- with `cost_cents_ingested` siblings.
+--
+-- The existing `cost_cents` columns continue to expose the **effective** lens
+-- (per the alias established in migration 019) so every consumer that doesn't
+-- care about the gap keeps working unchanged. The new column is additive.
+--
+-- Postgres rule: `CREATE OR REPLACE FUNCTION` cannot change a `RETURNS TABLE`
+-- column list, so each function is dropped and re-created. The DROP/CREATE
+-- pairs stay inside this single migration so a fresh project never observes
+-- an intermediate signature.
+
+-- ============================================================
+-- 1. dashboard_cost_by_model
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_model(TEXT[], DATE, DATE, TEXT[]);
+
+CREATE FUNCTION public.dashboard_cost_by_model(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    provider              TEXT,
+    model                 TEXT,
+    cost_cents            NUMERIC,
+    cost_cents_ingested   NUMERIC,
+    input_tokens          BIGINT,
+    output_tokens         BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        provider,
+        model,
+        SUM(cost_cents_effective)        AS cost_cents,
+        SUM(cost_cents_ingested)         AS cost_cents_ingested,
+        SUM(input_tokens)::BIGINT        AS input_tokens,
+        SUM(output_tokens)::BIGINT       AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY provider, model;
+$$;
+
+-- ============================================================
+-- 2. dashboard_cost_by_repo
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_repo(TEXT[], DATE, DATE, TEXT[]);
+
+CREATE FUNCTION public.dashboard_cost_by_repo(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    repo_id               TEXT,
+    cost_cents            NUMERIC,
+    cost_cents_ingested   NUMERIC,
+    input_tokens          BIGINT,
+    output_tokens         BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        repo_id,
+        SUM(cost_cents_effective)        AS cost_cents,
+        SUM(cost_cents_ingested)         AS cost_cents_ingested,
+        SUM(input_tokens)::BIGINT        AS input_tokens,
+        SUM(output_tokens)::BIGINT       AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY repo_id;
+$$;
+
+-- ============================================================
+-- 3. dashboard_cost_by_branch
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_branch(TEXT[], DATE, DATE, TEXT[]);
+
+CREATE FUNCTION public.dashboard_cost_by_branch(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    repo_id               TEXT,
+    git_branch            TEXT,
+    cost_cents            NUMERIC,
+    cost_cents_ingested   NUMERIC,
+    input_tokens          BIGINT,
+    output_tokens         BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        repo_id,
+        git_branch,
+        SUM(cost_cents_effective)        AS cost_cents,
+        SUM(cost_cents_ingested)         AS cost_cents_ingested,
+        SUM(input_tokens)::BIGINT        AS input_tokens,
+        SUM(output_tokens)::BIGINT       AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY repo_id, git_branch;
+$$;
+
+-- ============================================================
+-- 4. dashboard_cost_by_ticket
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.dashboard_cost_by_ticket(TEXT[], DATE, DATE, TEXT[]);
+
+CREATE FUNCTION public.dashboard_cost_by_ticket(
+    p_device_ids  TEXT[],
+    p_bucket_from DATE,
+    p_bucket_to   DATE,
+    p_surfaces    TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+    ticket                TEXT,
+    cost_cents            NUMERIC,
+    cost_cents_ingested   NUMERIC,
+    input_tokens          BIGINT,
+    output_tokens         BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT
+        ticket,
+        SUM(cost_cents_effective)        AS cost_cents,
+        SUM(cost_cents_ingested)         AS cost_cents_ingested,
+        SUM(input_tokens)::BIGINT        AS input_tokens,
+        SUM(output_tokens)::BIGINT       AS output_tokens
+    FROM daily_rollups
+    WHERE device_id = ANY(p_device_ids)
+      AND bucket_day BETWEEN p_bucket_from AND p_bucket_to
+      AND ticket IS NOT NULL
+      AND (p_surfaces IS NULL OR cardinality(p_surfaces) = 0
+           OR surface = ANY(p_surfaces))
+    GROUP BY ticket;
+$$;


### PR DESCRIPTION
Closes the remaining acceptance items from siropkin/budi#733 left after the savings-strip / cost-lens toggle work (#235).

## Summary
- **Settings → Pricing → Audit history** — new card on the manager pricing settings page that lists every `recalculation_runs` row for the org, with a status filter (`all` / `running` / `succeeded` / `failed`) and 50-row offset pagination. Filter + page state live in the URL (`?recalc_status=`, `?recalc_page=#audit-history`) so the savings strip on `/dashboard` can deep-link into a specific filter view.
- **Per-row cost tooltips** — Sessions, Session detail, Models, and Repos detail tables render `List: $X / Effective: $Y` on hover whenever team pricing produced a delta. Shared via the new `buildCostCellTooltip` helper so the rendering is consistent (and silently hidden when ingested == effective so we don't paint "$X / $X" everywhere).
- **Migration `022_breakdown_dual_cost.sql`** — adds a `cost_cents_ingested` sibling column to `dashboard_cost_by_{model,repo,branch,ticket}` so the breakdown rows carry both lenses. Migration 020 already covered the Overview RPCs; this fills in the per-breakdown surfaces.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run test` — 358 tests passing, includes new coverage for `buildCostCellTooltip`, the audit history search-param parsers, and the audit history render path (empty state, single page, paginated, missing user lookup)
- [ ] Manual: upload a price list, run recalc, confirm the audit history card lists the run and the cost cells render the dual tooltip
- [ ] Manual: confirm the savings strip on `/dashboard` deep-links into Settings → Pricing → Audit history for managers (and stays non-clickable for members)

🤖 Generated with [Claude Code](https://claude.com/claude-code)