### PR TITLE
fix(pricing): space Rows changed / Before → After audit columns

### DIFF
--- a/src/app/dashboard/settings/pricing/audit-history-table.tsx
+++ b/src/app/dashboard/settings/pricing/audit-history-table.tsx
@@ -153,7 +153,7 @@ export function AuditHistoryTable({
                 <th className="pb-2 font-medium">Triggered by</th>
                 <th className="pb-2 font-medium">Scope</th>
                 <th className="pb-2 text-right font-medium">Rows changed</th>
-                <th className="pb-2 font-medium">Before → After</th>
+                <th className="pb-2 pl-6 font-medium">Before → After</th>
                 <th className="pb-2 font-medium">Status</th>
               </tr>
             </thead>
@@ -209,7 +209,7 @@ export function AuditHistoryTable({
                       {run.rowsChanged ?? "—"}
                     </td>
                     <td
-                      className={`py-2 tabular-nums ${
+                      className={`py-2 pl-6 tabular-nums ${
                         delta.tone === "down"
                           ? "text-emerald-300"
                           : delta.tone === "up"


### PR DESCRIPTION
## Summary
- The audit-history table's right-aligned **Rows changed** column had no horizontal padding from the left-aligned **Before → After** column, causing values to visually merge (e.g. \`0\$953.89 → \$953.89\`) and the header to render as \`Rows changedBefore → After\`.
- Added \`pl-6\` to the **Before → After** \`<th>\` and corresponding \`<td>\` to restore a clear column gap.

## Test plan
- [ ] Open Settings → Pricing → Audit history; confirm \`Rows changed\` value and \`Before → After\` value no longer touch.
- [ ] Header row shows two distinct labels with a visible gap.
- [ ] Other columns (Started / Triggered by / Scope / Status) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)