### PR TITLE
fix(ingest): accept schema_version 1 and 2 (siropkin/budi#749)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -1411,3 +1411,119 @@ describe("POST /v1/ingest — surface round-trip (#204)", () => {
     expect((capped.surface as string).length).toBe(64);
   });
 });
+
+// Regression for siropkin/budi#749: the daemon bumped schema_version from 1
+// to 2 in #741 (to signal that `surface` is part of the wire). The cloud was
+// still hard-coded to expect v1, so every v8.4.3 daemon's sync was rejected
+// with HTTP 422. Both versions must round-trip; v3+ must still be rejected so
+// that a future genuine wire break is caught loudly.
+describe("POST /v1/ingest — schema_version compatibility (#749)", () => {
+  function seedUser() {
+    fake.seed("orgs", [{ id: "org_test", name: "test" }]);
+    fake.seed("users", [
+      {
+        id: "usr_test",
+        org_id: "org_test",
+        role: "manager",
+        api_key: "budi_testkey",
+        display_name: "Test",
+        email: "t@example.com",
+      },
+    ]);
+  }
+
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const baseRollup = {
+    bucket_day: "2026-04-14",
+    role: "assistant",
+    provider: "claude_code",
+    model: "claude-sonnet-4-5",
+    repo_id: "repo_x",
+    git_branch: "refs/heads/main",
+    ticket: null,
+    message_count: 1,
+    input_tokens: 1,
+    output_tokens: 1,
+    cache_creation_tokens: 0,
+    cache_read_tokens: 0,
+    cost_cents: 100,
+  };
+
+  const envelopeShell = {
+    device_id: "11111111-1111-4111-8111-111111111111",
+    org_id: "org_test",
+    synced_at: "2026-04-15T12:00:00Z",
+  };
+
+  it("accepts a v1 envelope (pre-#741 daemon, no surface field)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 1,
+        payload: {
+          daily_rollups: [baseRollup],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const stored = fake.rows("daily_rollups");
+    expect(stored).toHaveLength(1);
+  });
+
+  it("accepts a v2 envelope (v8.4.3+ daemon) and round-trips surface", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 2,
+        payload: {
+          daily_rollups: [{ ...baseRollup, surface: "jetbrains" }],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const stored = fake.rows("daily_rollups");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].surface).toBe("jetbrains");
+  });
+
+  it("rejects an unknown schema_version with 422", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 99,
+        payload: {
+          daily_rollups: [baseRollup],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/Unsupported schema_version: 99/);
+    expect(body.error).toMatch(/1, 2/);
+  });
+});

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -24,7 +24,12 @@ const MAX_BODY_BYTES = 1024 * 1024;
 // the daily_rollups insert pressure, not just a one-line edit.
 const RATE_LIMIT = { limit: 60, windowSeconds: 60 } as const;
 
-const CURRENT_SCHEMA_VERSION = 1;
+// Accept both v1 (pre-#741 daemons) and v2 (v8.4.3+ daemons that include
+// `surface` on rollup/session wire structs). v2 is a strict superset of v1:
+// `surface` is optional in the row builders, so older payloads remain valid.
+// See siropkin/budi#749 — bumping the daemon's schema_version without widening
+// the server's accepted set broke cloud sync for every v8.4.3 upgrader.
+const SUPPORTED_SCHEMA_VERSIONS = new Set([1, 2]);
 
 // Cap the stored label so a malformed envelope can't flood the devices table.
 // 128 chars is comfortably above any sane hostname or user-chosen nickname.
@@ -105,8 +110,9 @@ async function authenticateApiKey(
  * Returns an error message or null if valid.
  */
 function validateEnvelope(body: SyncEnvelope): string | null {
-  if (body.schema_version !== CURRENT_SCHEMA_VERSION) {
-    return `Unsupported schema_version: ${body.schema_version}. Expected ${CURRENT_SCHEMA_VERSION}.`;
+  if (!SUPPORTED_SCHEMA_VERSIONS.has(body.schema_version)) {
+    const supported = [...SUPPORTED_SCHEMA_VERSIONS].join(", ");
+    return `Unsupported schema_version: ${body.schema_version}. Expected one of: ${supported}.`;
   }
   if (!body.device_id || typeof body.device_id !== "string") {
     return "Missing or invalid device_id";


### PR DESCRIPTION
## Summary

- Widen the ingest validator to accept both `schema_version: 1` (pre-#741 daemons) and `schema_version: 2` (v8.4.3+ daemons that include `surface` on rollup/session wire structs).
- Adds regression coverage for v1 acceptance, v2 acceptance with `surface` round-trip, and rejection of unknown versions.

## Why

siropkin/budi#741 bumped the daemon's `schema_version` 1→2 to signal that `surface` is now part of the wire, but the cloud validator was still strictly comparing against 1. Every v8.4.3 daemon's sync was rejected with HTTP 422 and a misleading "update budi" hint — telling the user the cure is the disease.

`surface` is purely additive on the wire and the existing row builders already tolerate its absence, so v1 and v2 envelopes both round-trip safely. No daemon change required.

Closes siropkin/budi#749

## Test plan

- [x] `pnpm test` — 361 passed (3 new regression tests)
- [x] `pnpm typecheck` — clean
- [ ] Manual: post-merge, confirm a v8.4.3 daemon stops emitting `schema mismatch (422)` in `~/Library/Logs/budi-daemon.log`