### PR TITLE
fix(ingest): accept v2 rollup with renamed cost fields (siropkin/budi#749 follow-up)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -1526,4 +1526,97 @@ describe("POST /v1/ingest — schema_version compatibility (#749)", () => {
     expect(body.error).toMatch(/Unsupported schema_version: 99/);
     expect(body.error).toMatch(/1, 2/);
   });
+
+  // siropkin/budi#741 didn't just bump schema_version — it also renamed the
+  // legacy `cost_cents` column on the daily-rollup wire struct into a dual
+  // `cost_cents_ingested` / `cost_cents_effective` pair. The original #749
+  // schema-version-acceptance fix wasn't sufficient on its own; the
+  // validator + row builder also have to handle either shape. This pins
+  // both halves of the contract so the next v8.4.x daemon doesn't silently
+  // get 422'd again.
+  it("accepts a v2 rollup carrying the renamed cost fields (no cost_cents)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const v2Rollup = {
+      bucket_day: "2026-04-14",
+      role: "assistant",
+      provider: "claude_code",
+      model: "claude-sonnet-4-5",
+      repo_id: "repo_x",
+      git_branch: "refs/heads/main",
+      ticket: null,
+      message_count: 1,
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
+      // Note: NO `cost_cents` field — only the dual pair. This is exactly
+      // what v8.4.3+ daemons ship after #741.
+      cost_cents_ingested: 12.5,
+      cost_cents_effective: 9.75,
+      surface: "terminal",
+    };
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 2,
+        payload: {
+          daily_rollups: [v2Rollup],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const stored = fake.rows("daily_rollups");
+    expect(stored).toHaveLength(1);
+    // Effective is the value every read surface displays; ingested is the
+    // immutable original. Both must round-trip exactly so the dashboard's
+    // delta widget can compare them.
+    expect(stored[0].cost_cents_effective).toBe(9.75);
+    expect(stored[0].cost_cents_ingested).toBe(12.5);
+  });
+
+  // v1 envelopes only know about `cost_cents`. The cloud must still write
+  // both columns from that single value per ADR-0094 §1 so pre-v8.4.3
+  // daemons keep working after the rename lands.
+  it("accepts a v1 rollup with only legacy cost_cents and populates both columns", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const v1Rollup = {
+      bucket_day: "2026-04-14",
+      role: "assistant",
+      provider: "claude_code",
+      model: "claude-sonnet-4-5",
+      repo_id: "repo_x",
+      git_branch: "refs/heads/main",
+      ticket: null,
+      message_count: 1,
+      input_tokens: 1,
+      output_tokens: 1,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 0,
+      cost_cents: 4.25,
+    };
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 1,
+        payload: {
+          daily_rollups: [v1Rollup],
+          session_summaries: [],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const stored = fake.rows("daily_rollups");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].cost_cents_ingested).toBe(4.25);
+    expect(stored[0].cost_cents_effective).toBe(4.25);
+  });
 });

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -19,7 +19,15 @@ export interface IngestDailyRollup {
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
-  cost_cents: number;
+  // v1 envelopes ship `cost_cents`; v2 envelopes (post siropkin/budi#741)
+  // split it into `cost_cents_ingested` (LiteLLM-priced at ingest, immutable)
+  // and `cost_cents_effective` (what every read surface displays, rewritten
+  // by the team-pricing recompute). Mark all three optional on the wire so
+  // both shapes parse; `rollupIngestedCents` / `rollupEffectiveCents` below
+  // resolve which value to use per row.
+  cost_cents?: number;
+  cost_cents_ingested?: number;
+  cost_cents_effective?: number;
   // Surface dimension (#187): which IDE / CLI drove the daemon for this
   // rollup — `vscode`, `cursor`, `jetbrains`, `terminal`, … Optional because
   // older daemons (pre siropkin/budi#701) don't emit it; missing values land
@@ -27,6 +35,29 @@ export interface IngestDailyRollup {
   // and the dashboard can render them in the unfiltered "where is the team
   // working?" chart on Overview.
   surface?: string | null;
+}
+
+/**
+ * Pick the canonical "what was Budi's cost at ingest" value from either
+ * envelope shape. v2 envelopes (siropkin/budi#741 onward) split the legacy
+ * `cost_cents` column into a dual `_ingested` / `_effective` pair; this
+ * helper hides the rename from the rest of the route. Returns `undefined`
+ * when neither field is present so the validator surfaces the missing-field
+ * 422 the same way it did before.
+ */
+export function rollupIngestedCents(r: IngestDailyRollup): number | undefined {
+  if (r.cost_cents_ingested !== undefined) return r.cost_cents_ingested;
+  return r.cost_cents;
+}
+
+/**
+ * Pick the "what every surface displays" value. v2 envelopes carry it
+ * explicitly; v1 envelopes only know about `cost_cents`, which by ADR-0094
+ * §1 is identical to `_ingested` until a team price list rewrites it.
+ */
+export function rollupEffectiveCents(r: IngestDailyRollup): number | undefined {
+  if (r.cost_cents_effective !== undefined) return r.cost_cents_effective;
+  return rollupIngestedCents(r);
 }
 
 /**
@@ -108,7 +139,6 @@ const ROLLUP_METRIC_FIELDS = [
   "output_tokens",
   "cache_creation_tokens",
   "cache_read_tokens",
-  "cost_cents",
 ] as const satisfies ReadonlyArray<keyof IngestDailyRollup>;
 
 const SESSION_METRIC_FIELDS = [
@@ -137,6 +167,19 @@ export function validateIngestMetrics(
       if (!isValidNonNegativeNumber(r[f])) {
         return `daily_rollups[${i}].${f} must be a finite, non-negative number`;
       }
+    }
+    // Cost lives under different field names depending on envelope shape
+    // (`cost_cents` for v1, `cost_cents_ingested` / `cost_cents_effective`
+    // for v2). Resolve through the helper so neither shape regresses; the
+    // legacy error message keeps the old field name for backward parity.
+    if (!isValidNonNegativeNumber(rollupIngestedCents(r))) {
+      return `daily_rollups[${i}].cost_cents must be a finite, non-negative number`;
+    }
+    if (
+      r.cost_cents_effective !== undefined &&
+      !isValidNonNegativeNumber(r.cost_cents_effective)
+    ) {
+      return `daily_rollups[${i}].cost_cents_effective must be a finite, non-negative number`;
     }
   }
   for (let i = 0; i < sessions.length; i++) {
@@ -320,16 +363,19 @@ export function buildRollupRows(
       r.cache_read_tokens,
       METRIC_CAPS.cache_read_tokens
     ),
-    // #231: write both cost columns. The daemon-uploaded value lives in
-    // `_ingested`; the dashboard-facing value lives in `_effective`. Until the
-    // recalculation engine (#233) rewrites `_effective` from a team price
-    // list, the two columns are equal on every freshly-ingested row.
+    // #231: write both cost columns. v1 envelopes ship `cost_cents` only —
+    // both columns are populated from that single field per ADR-0094 §1
+    // (`_effective` defaults to `_ingested` until the recalculation engine
+    // rewrites it). v2 envelopes (siropkin/budi#741) carry the columns
+    // separately, so the daemon's locally-recomputed `_effective` survives
+    // the round-trip and the cloud's audit history reflects the same number
+    // the user sees in `budi stats`.
     cost_cents_ingested: safeNonNegativeNumber(
-      r.cost_cents,
+      rollupIngestedCents(r),
       METRIC_CAPS.cost_cents
     ),
     cost_cents_effective: safeNonNegativeNumber(
-      r.cost_cents,
+      rollupEffectiveCents(r),
       METRIC_CAPS.cost_cents
     ),
     surface: normalizeSurface(r.surface),


### PR DESCRIPTION
## Summary

Follow-up to #253. The schema-version-acceptance fix was necessary but insufficient — siropkin/budi#741 also **renamed** the daily-rollup wire field from `cost_cents` into a dual `cost_cents_ingested` + `cost_cents_effective` pair. The validator + row builder still strictly read `cost_cents`, so every v8.4.3+ daemon's envelope failed the metric validator with a different 422 path:

> daily_rollups[0].cost_cents must be a finite, non-negative number

The daemon's cloud-sync worker conflates every 422 into a generic "schema mismatch" message, which masked the actual cause until I traced the request through the daemon code path.

## Changes

- `IngestDailyRollup` accepts either `cost_cents` (v1) or `cost_cents_ingested` + `cost_cents_effective` (v2).
- New `rollupIngestedCents` / `rollupEffectiveCents` helpers resolve which field to use per envelope shape.
- v1 envelopes (`cost_cents`-only) populate both columns from the single value per ADR-0094 §1 (`_effective` defaults to `_ingested` until the recalculation engine rewrites it).
- v2 envelopes carry the daemon's locally-recomputed `_effective` separately so the dashboard's delta widget reflects the same number `budi stats` shows.
- Two regression tests pin both halves of the contract.

## Test plan

- [x] `pnpm test` — 363 passed (2 new regression tests)
- [x] `pnpm typecheck` — clean
- [ ] Post-merge: confirm a v8.4.4 daemon's `budi cloud sync` returns success against `app.getbudi.dev`.

Closes siropkin/budi#749 (final).