### PR TITLE
feat(ingest): accept session_summaries.title (#255)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -1620,3 +1620,107 @@ describe("POST /v1/ingest — schema_version compatibility (#749)", () => {
     expect(stored[0].cost_cents_effective).toBe(4.25);
   });
 });
+
+// Regression coverage for #255: the v8.5.0 daemon ships a `title` field on
+// each session record (siropkin/budi#779). Cloud must accept the bumped
+// schema_version, persist the title verbatim on the row, and fall through to
+// NULL for older daemons / surfaces that don't emit it.
+describe("POST /v1/ingest — session title (#255)", () => {
+  function seedUser() {
+    fake.seed("orgs", [{ id: "org_test", name: "test" }]);
+    fake.seed("users", [
+      {
+        id: "usr_test",
+        org_id: "org_test",
+        role: "manager",
+        api_key: "budi_testkey",
+        display_name: "Test",
+        email: "t@example.com",
+      },
+    ]);
+  }
+
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_testkey",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const envelopeShell = {
+    device_id: "11111111-1111-4111-8111-111111111111",
+    org_id: "org_test",
+    synced_at: "2026-04-15T12:00:00Z",
+  };
+
+  const baseSession = {
+    session_id: "sess-titled",
+    provider: "jetbrains_copilot",
+    started_at: "2026-04-14T10:00:00Z",
+    ended_at: "2026-04-14T11:00:00Z",
+    duration_ms: 3_600_000,
+    repo_id: null,
+    git_branch: null,
+    ticket: null,
+    message_count: 1,
+    total_input_tokens: 1,
+    total_output_tokens: 1,
+    total_cost_cents: 1,
+  };
+
+  it("accepts a v3 envelope and persists session.title", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 3,
+        payload: {
+          daily_rollups: [],
+          session_summaries: [
+            { ...baseSession, title: "Verkada-Web" },
+          ],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const [stored] = fake.rows("session_summaries");
+    expect(stored.title).toBe("Verkada-Web");
+  });
+
+  it("falls back to null when title is omitted (forward compat with pre-8.5.0 daemons)", async () => {
+    seedUser();
+    const { POST } = await import("./route");
+
+    const res = await POST(
+      mkReq({
+        ...envelopeShell,
+        schema_version: 2,
+        payload: {
+          daily_rollups: [],
+          session_summaries: [baseSession],
+        },
+      }) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(200);
+    const [stored] = fake.rows("session_summaries");
+    expect(stored.title).toBeNull();
+  });
+
+  it("truncates an over-long title at STRING_CAPS.title", async () => {
+    const { buildSessionRows, STRING_CAPS } = await import("./rows");
+
+    const huge = "T".repeat(50_000);
+    const rows = buildSessionRows("dev_x", "2026-04-15T12:00:00Z", [
+      { ...baseSession, title: huge },
+    ]);
+    expect((rows[0].title as string).length).toBe(STRING_CAPS.title);
+  });
+});

--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -1682,9 +1682,7 @@ describe("POST /v1/ingest — session title (#255)", () => {
         schema_version: 3,
         payload: {
           daily_rollups: [],
-          session_summaries: [
-            { ...baseSession, title: "Verkada-Web" },
-          ],
+          session_summaries: [{ ...baseSession, title: "Verkada-Web" }],
         },
       }) as unknown as Parameters<typeof POST>[0]
     );

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -24,12 +24,13 @@ const MAX_BODY_BYTES = 1024 * 1024;
 // the daily_rollups insert pressure, not just a one-line edit.
 const RATE_LIMIT = { limit: 60, windowSeconds: 60 } as const;
 
-// Accept both v1 (pre-#741 daemons) and v2 (v8.4.3+ daemons that include
-// `surface` on rollup/session wire structs). v2 is a strict superset of v1:
-// `surface` is optional in the row builders, so older payloads remain valid.
-// See siropkin/budi#749 — bumping the daemon's schema_version without widening
-// the server's accepted set broke cloud sync for every v8.4.3 upgrader.
-const SUPPORTED_SCHEMA_VERSIONS = new Set([1, 2]);
+// Accept v1 (pre-#741 daemons), v2 (v8.4.3+ daemons that added `surface`), and
+// v3 (v8.5.0+ daemons that added session `title` per siropkin/budi#779). Each
+// bump is a strict superset of the previous one: every new field is optional
+// in the row builders, so older payloads remain valid. See siropkin/budi#749 —
+// bumping the daemon's schema_version without widening the server's accepted
+// set broke cloud sync for every v8.4.3 upgrader.
+const SUPPORTED_SCHEMA_VERSIONS = new Set([1, 2, 3]);
 
 // Cap the stored label so a malformed envelope can't flood the devices table.
 // 128 chars is comfortably above any sane hostname or user-chosen nickname.

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -221,6 +221,10 @@ export const STRING_CAPS = {
   repo_id: 128,
   git_branch: 256,
   ticket: 64,
+  // #255: session.title carries the daemon's `session_title` tag — typically a
+  // project name (`Verkada-Web`) or session-type label (`chat-agent`), but the
+  // parser allows free-form values, so we cap generously.
+  title: 256,
 } as const;
 
 /**
@@ -305,6 +309,9 @@ export interface IngestSessionSummary {
   // because older daemons (< 8.3.16) don't emit it, and the daemon
   // legitimately omits it for sessions with zero scored messages.
   primary_model?: string | null;
+  // Session title (#255). Optional — older daemons (≤ 8.4.8) don't emit it;
+  // some surfaces (Cursor, Claude Code) may legitimately have no title.
+  title?: string | null;
   // Vitals (#99). Optional — older daemons (< 8.3.15) omit these, and budi-core
   // legitimately skips emission for sessions with too few assistant messages.
   vital_context_drag_state?: string | null;
@@ -440,6 +447,7 @@ export function buildSessionRows(
       METRIC_CAPS.total_cost_cents
     ),
     main_model: capString(s.primary_model ?? null, STRING_CAPS.model),
+    title: capString(s.title ?? null, STRING_CAPS.title),
     // Vitals (#99). Each field is normalized independently so a daemon that
     // emits e.g. only the overall state (or only some vitals) still lands the
     // partial signal — the dashboard already renders missing slots as a

--- a/supabase/migrations/023_session_title.sql
+++ b/supabase/migrations/023_session_title.sql
@@ -1,0 +1,9 @@
+-- session.title (#255): the daemon's session-title tag (siropkin/budi#779) lands
+-- as a free-form string on `session_summaries`. Sources include the parser's
+-- IntelliJ project name (`Verkada-Web`, `verkadalizer`), the session-type label
+-- (`chat-agent`, `chat-edit`), or any future free-form tag. Nullable: older
+-- daemons (≤ 8.4.8) don't send `title`, and Cursor / Claude Code sessions may
+-- have no title locally either. Matches the existing pattern for `repo_id`,
+-- `git_branch`, `ticket`. `IF NOT EXISTS` so re-applied migrations no-op.
+ALTER TABLE session_summaries
+    ADD COLUMN IF NOT EXISTS title TEXT;


### PR DESCRIPTION
Closes #255. Cross-repo blocker for siropkin/budi v8.5.0 release.

## Summary
- New migration `023_session_title.sql` adds a nullable `title TEXT` column to `session_summaries` (additive, idempotent via `IF NOT EXISTS`, mirrors `014_surface_dimension.sql`).
- `rows.ts`: `IngestSessionSummary.title?: string | null`, `STRING_CAPS.title = 256`, and `title` flows through `buildSessionRows` with the standard cap-and-default treatment.
- `route.ts`: `SUPPORTED_SCHEMA_VERSIONS` extended to `{1, 2, 3}` so the v8.5.0+ daemon (siropkin/budi#779) doesn't 422 on the bumped envelope.
- `route.test.ts`: positive (v3 envelope persists title), negative (omitted title falls through to null), and length-cap unit coverage.

## Note on validateEnvelope
`validateEnvelope` / `validateIngestMetrics` are permissive on unknown record fields — they shape-check known fields, not an allowlist. So strictly speaking, a v3 daemon's `title` would survive the validator anyway. The schema_version bump was the only hard wall (legacy v8.4.x cloud rejects unknown `schema_version: 3` outright per the #749 fix). The migration + row plumbing here makes the field actually persist so #256 can render it.

## Test plan
- [x] `npm test` (366 / 366 green, including 3 new title tests)
- [x] `npm run lint`
- [x] `npm run build`
- [ ] After Vercel deploys main: POST a minimal v3 envelope with `title=test` to production `/api/v1/ingest`, expect 200, confirm row in supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)