### PR TITLE
fix(pricing): card layout for price-lists + audit-history on mobile (#258)

### DIFF
--- a/src/app/dashboard/settings/pricing/audit-history-table.tsx
+++ b/src/app/dashboard/settings/pricing/audit-history-table.tsx
@@ -145,8 +145,12 @@ export function AuditHistoryTable({
           {status === "all" ? " yet" : ` with status "${status}"`}.
         </p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
+        <>
+          {/* Table on sm+; below `sm` render each run as a stacked card so the
+              six columns don't collapse into each other at 390px. Mirrors the
+              members-list pattern in src/app/dashboard/settings/page.tsx
+              (#258). */}
+          <table className="hidden w-full text-sm sm:table">
             <thead>
               <tr className="border-b border-white/10 text-left text-zinc-400">
                 <th className="pb-2 font-medium">Started</th>
@@ -227,7 +231,52 @@ export function AuditHistoryTable({
               })}
             </tbody>
           </table>
-        </div>
+          <ul className="divide-y divide-white/5 text-sm sm:hidden">
+            {runs.map((run) => {
+              const delta = formatDelta(
+                run.beforeTotalCents,
+                run.afterTotalCents
+              );
+              const trigger = run.triggeredBy
+                ? (usersById.get(run.triggeredBy) ?? run.triggeredBy)
+                : "—";
+              return (
+                <li key={run.id} className="space-y-2 py-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate text-zinc-200">
+                      {formatStarted(run.startedAt)}
+                    </span>
+                    <StatusBadge status={run.status} />
+                  </div>
+                  <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+                    <dt className="text-zinc-500">Triggered by</dt>
+                    <dd className="truncate text-zinc-300">{trigger}</dd>
+                    <dt className="text-zinc-500">Scope</dt>
+                    <dd className="text-zinc-300">
+                      {formatScope(run.scopeFromDate, run.scopeToDate)}
+                    </dd>
+                    <dt className="text-zinc-500">Rows changed</dt>
+                    <dd className="text-zinc-300 tabular-nums">
+                      {run.rowsChanged ?? "—"}
+                    </dd>
+                    <dt className="text-zinc-500">Before → After</dt>
+                    <dd
+                      className={`tabular-nums ${
+                        delta.tone === "down"
+                          ? "text-emerald-300"
+                          : delta.tone === "up"
+                            ? "text-amber-300"
+                            : "text-zinc-300"
+                      }`}
+                    >
+                      {delta.label}
+                    </dd>
+                  </dl>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
 
       {total > pageSize && (

--- a/src/app/dashboard/settings/pricing/price-lists-table.tsx
+++ b/src/app/dashboard/settings/pricing/price-lists-table.tsx
@@ -66,64 +66,88 @@ export function PriceListsTable({ lists }: { lists: PriceListRow[] }) {
     );
   }
 
+  function renderActions(l: PriceListRow) {
+    if (l.status !== "draft") return null;
+    return (
+      <div className="flex items-center justify-end gap-2">
+        <button
+          onClick={() => handleActivate(l.id)}
+          disabled={isPending && busyId === l.id}
+          className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+        >
+          {isPending && busyId === l.id ? "Activating…" : "Activate"}
+        </button>
+        <button
+          onClick={() => handleDiscard(l.id)}
+          disabled={isPending && busyId === l.id}
+          className="rounded-md bg-white/10 px-3 py-1 text-xs font-medium text-zinc-200 transition-colors hover:bg-white/15 disabled:opacity-50"
+        >
+          Discard
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
       {error && <p className="text-sm text-red-400">{error}</p>}
 
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-white/10 text-left text-zinc-400">
-              <th className="pb-2 font-medium">Name</th>
-              <th className="pb-2 font-medium">Status</th>
-              <th className="pb-2 font-medium">Effective from</th>
-              <th className="pb-2 font-medium">Source file</th>
-              <th className="pb-2 font-medium">Uploaded by</th>
-              <th className="pb-2 font-medium text-right">Actions</th>
+      {/* Table on sm+; below `sm` render each list as a stacked card so the
+          5 + actions columns don't overlap at 390px. Mirrors the members-list
+          pattern in src/app/dashboard/settings/page.tsx (#258). */}
+      <table className="hidden w-full text-sm sm:table">
+        <thead>
+          <tr className="border-b border-white/10 text-left text-zinc-400">
+            <th className="pb-2 font-medium">Name</th>
+            <th className="pb-2 font-medium">Status</th>
+            <th className="pb-2 font-medium">Effective from</th>
+            <th className="pb-2 font-medium">Source file</th>
+            <th className="pb-2 font-medium">Uploaded by</th>
+            <th className="pb-2 text-right font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lists.map((l) => (
+            <tr key={l.id} className="border-b border-white/5">
+              <td className="py-2 text-zinc-200">{l.name}</td>
+              <td className="py-2">
+                <StatusBadge status={l.status} />
+              </td>
+              <td className="py-2 text-zinc-400">
+                {l.effectiveFrom}
+                {l.effectiveTo ? ` → ${l.effectiveTo}` : ""}
+              </td>
+              <td className="py-2 text-zinc-400">{l.sourceFileName ?? "—"}</td>
+              <td className="py-2 text-zinc-400">{l.uploadedBy ?? "—"}</td>
+              <td className="py-2 text-right">{renderActions(l)}</td>
             </tr>
-          </thead>
-          <tbody>
-            {lists.map((l) => (
-              <tr key={l.id} className="border-b border-white/5">
-                <td className="py-2 text-zinc-200">{l.name}</td>
-                <td className="py-2">
-                  <StatusBadge status={l.status} />
-                </td>
-                <td className="py-2 text-zinc-400">
-                  {l.effectiveFrom}
-                  {l.effectiveTo ? ` → ${l.effectiveTo}` : ""}
-                </td>
-                <td className="py-2 text-zinc-400">
-                  {l.sourceFileName ?? "—"}
-                </td>
-                <td className="py-2 text-zinc-400">{l.uploadedBy ?? "—"}</td>
-                <td className="py-2 text-right">
-                  {l.status === "draft" && (
-                    <div className="flex items-center justify-end gap-2">
-                      <button
-                        onClick={() => handleActivate(l.id)}
-                        disabled={isPending && busyId === l.id}
-                        className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
-                      >
-                        {isPending && busyId === l.id
-                          ? "Activating…"
-                          : "Activate"}
-                      </button>
-                      <button
-                        onClick={() => handleDiscard(l.id)}
-                        disabled={isPending && busyId === l.id}
-                        className="rounded-md bg-white/10 px-3 py-1 text-xs font-medium text-zinc-200 transition-colors hover:bg-white/15 disabled:opacity-50"
-                      >
-                        Discard
-                      </button>
-                    </div>
-                  )}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+          ))}
+        </tbody>
+      </table>
+      <ul className="divide-y divide-white/5 text-sm sm:hidden">
+        {lists.map((l) => (
+          <li key={l.id} className="space-y-2 py-3">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate text-zinc-200">{l.name}</span>
+              <StatusBadge status={l.status} />
+            </div>
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+              <dt className="text-zinc-500">Effective</dt>
+              <dd className="text-zinc-300">
+                {l.effectiveFrom}
+                {l.effectiveTo ? ` → ${l.effectiveTo}` : ""}
+              </dd>
+              <dt className="text-zinc-500">Source file</dt>
+              <dd className="truncate text-zinc-300">
+                {l.sourceFileName ?? "—"}
+              </dd>
+              <dt className="text-zinc-500">Uploaded by</dt>
+              <dd className="truncate text-zinc-300">{l.uploadedBy ?? "—"}</dd>
+            </dl>
+            {l.status === "draft" && renderActions(l)}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
Closes #258.

## Summary
- Apply the existing `hidden ... sm:table` + `<ul ... sm:hidden>` pattern (canonical members-list at `src/app/dashboard/settings/page.tsx`) to both `price-lists-table.tsx` and `audit-history-table.tsx`.
- Below `sm`, each row collapses into a stacked card: title + status badge on top, the remaining columns as a key/value `<dl>`. Actions stay attached to draft rows.
- Removes the now-unused `<div className=\"overflow-x-auto\">` table wrappers — they didn't work in practice because the layout's flex chain swallowed the would-be scrollbar.

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Visual: `/dashboard/settings/pricing` at 390px viewport — both tables render as readable cards, no overlap; at ≥ sm, layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)