### PR TITLE
fix(repos): contain right-column tables to fix desktop overflow (#257)

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -162,7 +162,7 @@ export default async function ReposPage({
                   unit={unit}
                 />
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 sm:overflow-x-auto">
                 <table className="hidden w-full text-sm sm:table">
                   <thead>
                     <tr className="border-b border-white/10 text-left text-zinc-400">
@@ -274,7 +274,7 @@ export default async function ReposPage({
                   unit={unit}
                 />
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 sm:overflow-x-auto">
                 <table className="hidden w-full text-sm sm:table">
                   <thead>
                     <tr className="border-b border-white/10 text-left text-zinc-400">
@@ -396,7 +396,7 @@ export default async function ReposPage({
                   unit={unit}
                 />
               </div>
-              <div className="min-w-0">
+              <div className="min-w-0 sm:overflow-x-auto">
                 <table className="hidden w-full text-sm sm:table">
                   <thead>
                     <tr className="border-b border-white/10 text-left text-zinc-400">


### PR DESCRIPTION
Closes #257.

## Summary
Each of the three sections on `/dashboard/repos` (Cost by Project / Branch / Ticket) renders a chart + table in a 2-col grid. The right column was `min-w-0` only, so the auto-sized table grew past its column when a project/branch name was long, producing a horizontal scrollbar on `<main>` (~64px overflow at 1440px viewport per the ticket).

Add `sm:overflow-x-auto` to the table-side wrappers so the table scrolls inside its column at `sm+`. The `<sm>` mobile `<ul>` layout is unaffected.

## Test plan
- [x] \`npm test\` (366/366)
- [x] \`npm run build\`
- [ ] Visual: \`/dashboard/repos\` at 1440px shows no horizontal scrollbar on \`<main>\`. Tables with long content scroll within their own column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)