### PR TITLE
fix(team): stack page title above filter toolbar on mobile (#260)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ next-env.d.ts
 
 # supabase local
 supabase/.temp/
+
+# local smoke-test screenshots
+.smoke-test/

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -93,7 +93,7 @@ export default async function TeamPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h1 className="text-xl font-bold">Team</h1>
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
Closes #260.

## Summary
\`/dashboard/team\` was the only remaining dashboard page using \`flex items-center justify-between\` on the header. At < sm widths, the wrapping filter toolbar collided with the "Team" h1.

Switch to the same \`flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between\` pattern used by Overview, Models, Repos, Devices, and Sessions.

Also gitignores the local \`.smoke-test/\` scratch dir.

## Test plan
- [x] \`npm test\`, \`npm run build\`
- [ ] Visual: \`/dashboard/team\` at 390px — title on its own row above the toolbar, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)