### PR TITLE
feat(charts): flip bar value labels inside saturated bars (#261)

### DIFF
--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -75,20 +75,54 @@ describe("CostBarChart", () => {
     ).toBeDefined();
     const labelListProps = labelList!.props as {
       dataKey: string;
-      position: string;
-      formatter: (v: unknown) => string | number;
+      content: (props: Record<string, unknown>) => ReactElement;
     };
     // Both axes are now keyed off the unit-projected `value` field so the
     // toggle doesn't have to re-key the bar element on switch (#128).
     expect(labelListProps.dataKey).toBe("value");
-    expect(labelListProps.position).toBe("right");
 
-    // Default unit is dollars, so the formatter must round-trip cents into
-    // the fmtCost form and the missing-suffix regression from #41 stays put.
-    const formatter = labelListProps.formatter;
-    expect(formatter).toBeTypeOf("function");
-    expect(formatter(3000)).toBe(fmtCost(3000));
-    expect(formatter(81)).toBe(fmtCost(81));
+    // Default unit is dollars, so the content renderer must produce a <text>
+    // node whose children is the fmtCost string. Exercises the
+    // outside-the-bar branch (small value relative to the leader).
+    const content = labelListProps.content;
+    expect(content).toBeTypeOf("function");
+    const outside = content({
+      x: 100,
+      y: 10,
+      width: 30,
+      height: 20,
+      value: 81,
+    });
+    expect(outside.type).toBe("text");
+    expect((outside.props as { children: string }).children).toBe(fmtCost(81));
+    expect((outside.props as { textAnchor: string }).textAnchor).toBe("start");
+  });
+
+  it("flips the value label inside the bar when it nears the right edge (#261)", () => {
+    const saturating = [
+      { label: "leader", cost_cents: 1000, tokens: 0 },
+      { label: "tiny", cost_cents: 10, tokens: 0 },
+    ];
+    const tree = CostBarChart({ data: saturating, emptyLabel: "unused" });
+    const nodes = Array.from(walk(tree));
+    const labelList = nodes.find((n) => n.type === LabelList);
+    const content = (
+      labelList!.props as {
+        content: (props: Record<string, unknown>) => ReactElement;
+      }
+    ).content;
+
+    // Leader is 100% of the max — ratio 1.0 >= 0.85 — render inside the bar
+    // (white text, end-anchored at the right edge).
+    const inside = content({ x: 0, y: 0, width: 200, height: 20, value: 1000 });
+    expect((inside.props as { textAnchor: string }).textAnchor).toBe("end");
+    expect((inside.props as { fill: string }).fill).toBe("#ffffff");
+
+    // Tiny is 1% of the max — render outside the bar (gray text, start-anchored
+    // just past the bar's right edge).
+    const outside = content({ x: 0, y: 0, width: 2, height: 20, value: 10 });
+    expect((outside.props as { textAnchor: string }).textAnchor).toBe("start");
+    expect((outside.props as { fill: string }).fill).toBe("#71717a");
   });
 
   it("renders token totals when unit='tokens' (#128)", () => {
@@ -101,12 +135,24 @@ describe("CostBarChart", () => {
 
     const labelList = nodes.find((n) => n.type === LabelList);
     expect(labelList).toBeDefined();
-    const formatter = (
-      labelList!.props as { formatter: (v: unknown) => string | number }
-    ).formatter;
-    // Token mode formats with fmtNum (no $).
-    expect(formatter(5_000_000)).toBe(fmtNum(5_000_000));
-    expect(formatter(3_500_000)).toBe(fmtNum(3_500_000));
+    const content = (
+      labelList!.props as {
+        content: (props: Record<string, unknown>) => ReactElement;
+      }
+    ).content;
+    // Token mode formats with fmtNum (no $). Exercise the outside-the-bar
+    // branch on the smaller of the two rows so the assertion isn't sensitive
+    // to the flip-inside threshold.
+    const tinyLabel = content({
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 20,
+      value: 3_500_000,
+    });
+    expect((tinyLabel.props as { children: string }).children).toBe(
+      fmtNum(3_500_000)
+    );
 
     // Sort order follows the projected token value, not cost — alpha leads
     // because 5M > 3.5M, even though both have positive cost.

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -123,6 +123,14 @@ export function CostBarChart({
   }));
 
   const height = barChartHeight(sorted.length);
+  // Largest bar drives the "should we flip the value label inside?" decision
+  // (#261). Comparing per-bar value to maxValue is a stable proxy for the
+  // pixel-width ratio because recharts maps value→pixel linearly across the
+  // plot area. Bars at ≥ FLIP_INSIDE_RATIO of the max would otherwise push
+  // their value label past the chart's right edge (visibly clipped on 390px
+  // viewports).
+  const maxValue = sorted[0]?.value ?? 0;
+  const FLIP_INSIDE_RATIO = 0.85;
 
   return (
     <ResponsiveContainer width="100%" height={height}>
@@ -201,10 +209,59 @@ export function CostBarChart({
         >
           <LabelList
             dataKey="value"
-            position="right"
-            fill="#71717a"
-            fontSize={12}
-            formatter={(v) => fmt(Number(v))}
+            content={(props) => {
+              // recharts passes a recharts-internal label-props object whose
+              // x/y/width/height are number | string | undefined. They're
+              // numbers in practice for vertical Bar layout but we still
+              // narrow defensively.
+              const p = props as {
+                x?: number | string;
+                y?: number | string;
+                width?: number | string;
+                height?: number | string;
+                value?: number | string;
+                index?: number;
+              };
+              const x = typeof p.x === "number" ? p.x : Number(p.x ?? 0);
+              const y = typeof p.y === "number" ? p.y : Number(p.y ?? 0);
+              const width =
+                typeof p.width === "number" ? p.width : Number(p.width ?? 0);
+              const height =
+                typeof p.height === "number" ? p.height : Number(p.height ?? 0);
+              const value = Number(p.value ?? 0);
+              const text = fmt(value);
+              const flipInside =
+                maxValue > 0 && value / maxValue >= FLIP_INSIDE_RATIO;
+              if (flipInside) {
+                // Anchor inside the bar at the right edge so the label stays
+                // visible even when the bar saturates the plot area. White
+                // sits cleanly on the blue fill (`#3b82f6`).
+                return (
+                  <text
+                    x={x + width - 6}
+                    y={y + height / 2}
+                    dy={4}
+                    textAnchor="end"
+                    fill="#ffffff"
+                    fontSize={12}
+                  >
+                    {text}
+                  </text>
+                );
+              }
+              return (
+                <text
+                  x={x + width + 4}
+                  y={y + height / 2}
+                  dy={4}
+                  textAnchor="start"
+                  fill="#71717a"
+                  fontSize={12}
+                >
+                  {text}
+                </text>
+              );
+            }}
           />
         </Bar>
       </BarChart>


### PR DESCRIPTION
Closes #261.

## Summary
\`CostBarChart\` underlies the horizontal bar charts on /team, /models, /repos, and /devices. When a bar nears the right edge of the plot area, its outside-anchored value label was clipped — most visible at 390px where the leading bar usually saturates.

Replace the static \`<LabelList position=\"right\">\` with a custom \`content\` renderer:
- If \`value / maxValue >= 0.85\`, render the label INSIDE the bar (white text, end-anchored at the right edge).
- Else keep the existing outside placement (gray text just past the bar's right edge).

Per-bar value vs. max-value is a stable proxy for the pixel-width ratio because recharts maps value → pixel linearly across the plot area. Below saturation the chart looks unchanged.

## Test plan
- [x] \`npm test\` (367/367 — added a new \"flip inside\" assertion; updated two existing tests to exercise the content renderer)
- [x] \`npm run build\`
- [ ] Visual: \`/dashboard/team\`, \`/models\`, \`/repos\`, \`/devices\` at 390px — leading bars' \`\$X\` labels stay legible (now inside the blue bar in white). Smaller bars unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)