### PR TITLE
feat(sessions): render session title on list + detail (#256)

### DIFF
--- a/src/app/dashboard/sessions/[id]/page.test.tsx
+++ b/src/app/dashboard/sessions/[id]/page.test.tsx
@@ -79,6 +79,7 @@ const SESSION = {
   main_model: "claude-opus-4-7-20260101",
   owner_name: "Jane Smith",
   surface: "vscode",
+  title: null,
 };
 
 beforeEach(() => {
@@ -313,6 +314,33 @@ describe("dashboard/sessions/[id] /page", () => {
     const text = extractText(node);
     expect(text).toContain("Copilot Chat");
     expect(text).not.toContain("copilot_chat");
+  });
+
+  it("renders the session title as the primary handle when present (#256)", async () => {
+    // v8.5.0+ daemons (siropkin/budi#779) populate session_summaries.title
+    // from the parser's session_title tag. For jetbrains rows that's the
+    // IntelliJ project name (`Verkada-Web`); for unresolved fallback rows
+    // it's the session-type label (`chat-agent`). The detail page promotes
+    // the title to the page h1 and demotes the opaque session-id hash.
+    dal.getSessionDetail.mockResolvedValue({
+      ...SESSION,
+      title: "Verkada-Web",
+    });
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Verkada-Web");
+    // The hash still renders so a viewer can copy it for support.
+    expect(text).toContain("sess_v");
+  });
+
+  it("falls back to the session hash as the header when title is null (#256)", async () => {
+    // Pre-8.5.0 sessions (and Cursor / Claude Code rows that don't emit a
+    // title) keep the legacy `Session <hash>` header. Pin it so a refactor
+    // that drops the null branch doesn't blank the header.
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Session");
+    expect(text).toContain("sess_v");
   });
 
   it("annotates output-only sessions so a `0` input-token count reads as a known May-2026+ Copilot Chat state, not missing data (#168)", async () => {

--- a/src/app/dashboard/sessions/[id]/page.tsx
+++ b/src/app/dashboard/sessions/[id]/page.tsx
@@ -89,16 +89,36 @@ export default async function SessionDetailPage({
         </Link>
         {/* Session id is a long opaque string; truncate so the header stays
             scannable on narrow widths and surface the full id via the title
-            attribute for copy-paste. */}
-        <h1
-          className="mt-2 truncate text-xl font-bold"
-          title={`Session ${sessionId}`}
-        >
-          Session{" "}
-          <span className="font-mono text-base font-medium text-zinc-300">
-            {sessionId}
-          </span>
-        </h1>
+            attribute for copy-paste. When the daemon resolves a session title
+            (#256), surface it as the primary handle and demote the hash to a
+            subtitle — the title (e.g. `Verkada-Web`, `chat-agent`) is the most
+            human-readable thing on the page. */}
+        {session.title ? (
+          <>
+            <h1
+              className="mt-2 truncate text-xl font-bold"
+              title={session.title}
+            >
+              {session.title}
+            </h1>
+            <p
+              className="mt-1 truncate font-mono text-xs text-zinc-500"
+              title={sessionId}
+            >
+              {sessionId}
+            </p>
+          </>
+        ) : (
+          <h1
+            className="mt-2 truncate text-xl font-bold"
+            title={`Session ${sessionId}`}
+          >
+            Session{" "}
+            <span className="font-mono text-base font-medium text-zinc-300">
+              {sessionId}
+            </span>
+          </h1>
+        )}
       </div>
 
       {/*

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -79,6 +79,9 @@ beforeEach(() => {
         main_model: "claude-opus-4-7-20260101",
         owner_name: "Ivan",
         surface: "vscode",
+        // v8.5.0+ jetbrains row carries an IntelliJ project name as title
+        // (siropkin/budi#779). The list must surface it (#256).
+        title: "Verkada-Web",
       },
       {
         // Older daemon (#140): no main_model on the wire, column NULL in the
@@ -127,6 +130,7 @@ describe("dashboard/sessions /page", () => {
     // the unit toggle on the cost column conveys the same signal.
     for (const col of [
       "Member",
+      "Title",
       "Provider",
       "Model",
       "Started",
@@ -147,6 +151,10 @@ describe("dashboard/sessions /page", () => {
     // Manager attribution (#138): each row reads as "<member> ran <provider>".
     expect(text).toContain("Ivan");
     expect(text).toContain("Jane");
+    // Session title (#256): the populated row shows its title; the row
+    // without a title renders an em-dash placeholder.
+    expect(text).toContain("Verkada-Web");
+    expect(text).toContain("—");
   });
 
   it("hides the Member column for non-manager (member) viewers (#138)", async () => {

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -188,6 +188,14 @@ export default async function SessionsPage({
                             {formatTimestamp(s.started_at)}
                           </span>
                         </div>
+                        {s.title && (
+                          <div
+                            className="truncate text-xs text-zinc-300"
+                            title={s.title}
+                          >
+                            {s.title}
+                          </div>
+                        )}
                         <div className="flex items-center gap-2 text-xs text-zinc-400">
                           <span className="truncate">
                             {s.main_model ? formatModelName(s.main_model) : "-"}
@@ -229,6 +237,9 @@ export default async function SessionsPage({
                           Member
                         </th>
                       )}
+                      <th className="pr-3 pb-2 font-medium whitespace-nowrap">
+                        Title
+                      </th>
                       <th className="pr-3 pb-2 font-medium whitespace-nowrap">
                         Provider
                       </th>
@@ -278,6 +289,17 @@ export default async function SessionsPage({
                               </Link>
                             </td>
                           )}
+                          <td
+                            className="text-zinc-300"
+                            title={s.title ?? undefined}
+                          >
+                            <Link
+                              href={href}
+                              className="block max-w-[20ch] truncate py-2 pr-3 whitespace-nowrap"
+                            >
+                              {s.title ?? "—"}
+                            </Link>
+                          </td>
                           <td
                             className="text-zinc-300"
                             title={formatProvider(s.provider)}

--- a/src/lib/dal.ts
+++ b/src/lib/dal.ts
@@ -1176,6 +1176,12 @@ export interface SessionRow {
   // started emitting `primary_model`, and for sessions with zero scored
   // messages — render as em-dash in those cases.
   main_model: string | null;
+  // Free-form session title (#255). Sources include the daemon's parsed
+  // `session_title` tag (siropkin/budi#779) — typically an IntelliJ project
+  // name (`Verkada-Web`) or session-type label (`chat-agent`). NULL for
+  // pre-8.5.0 rows and for surfaces that don't emit a title; render as a
+  // muted dash in those cases.
+  title: string | null;
   // Resolved owner label for the device this session ran on (#138). Only
   // populated for manager viewers; null for member viewers (every row is
   // theirs) and for sessions whose device→user mapping cannot be resolved.


### PR DESCRIPTION
Closes #256. Builds on #255 (column + ingest) and the v8.5.0 daemon (siropkin/budi#779).

## Summary
- DAL: \`SessionRow.title: string | null\` (the \`SELECT *\` already returns it).
- Sessions list (desktop): new "Title" column between Member and Provider, max-w-20ch truncate + \`title\`-attribute tooltip, em-dash for null.
- Sessions list (mobile card): when title is present, render it as a second line beneath Member/Started. Skipped entirely when null so layout height is stable.
- Session detail: when title is set, the title is the page h1 and the opaque session hash demotes to a font-mono subtitle. Falls back to the existing \`Session <hash>\` header when title is null.

## Test plan
- [x] \`npm test\` (369/369 — +2 new detail-page tests, list-page test extended)
- [x] \`npm run build\`
- [ ] After deploy: \`app.getbudi.dev/dashboard/sessions?surface=jetbrains&days=all\` shows real titles on jetbrains rows (\`Verkada-Web\`, etc. once daemon v8.5.0 lands); pre-8.5.0 rows render the em-dash placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)