### PR TITLE
refactor(dashboard): shared <PageHeader> for the six dashboard pages (#270)

### DIFF
--- a/src/app/dashboard/devices/page.tsx
+++ b/src/app/dashboard/devices/page.tsx
@@ -12,6 +12,7 @@ import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
 import { deviceLabel, fmtCost, fmtNum } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -106,8 +107,7 @@ export default async function DevicesPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl font-bold">Devices</h1>
+      <PageHeader title="Devices">
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
@@ -116,7 +116,7 @@ export default async function DevicesPage({
             <PeriodSelector />
           </div>
         </Suspense>
-      </div>
+      </PageHeader>
 
       <Card>
         <CardHeader>

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -19,6 +19,7 @@ import {
   formatModelName,
   formatProvider,
 } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -111,8 +112,7 @@ export default async function ModelsPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl font-bold">Models</h1>
+      <PageHeader title="Models">
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
@@ -121,7 +121,7 @@ export default async function ModelsPage({
             <PeriodSelector />
           </div>
         </Suspense>
-      </div>
+      </PageHeader>
 
       <Card>
         <CardHeader>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -240,22 +240,16 @@ describe("dashboard /page (Overview)", () => {
     await expect(render()).rejects.toThrow("__DAL_BOOM__");
   });
 
-  it("mobile: header stacks below sm: and the filter cluster wraps so the time-range buttons cannot be clipped (#117)", async () => {
+  it("mobile: header stacks below sm: and the filter cluster wraps so the time-range buttons cannot be clipped (#117, #270)", async () => {
     const node = await render();
-    const classes = collectClassNames(node);
-    // Outer header row stacks vertically by default and only switches to a
-    // horizontal layout at the `sm` breakpoint — this is what keeps the
-    // title + team scope + period buttons from sharing one ~470px row on
-    // a 375px phone.
-    const stacked = classes.find(
-      (c) =>
-        c.includes("flex-col") &&
-        c.includes("sm:flex-row") &&
-        c.includes("sm:justify-between")
-    );
-    expect(stacked).toBeTruthy();
+    // The page mounts the shared <PageHeader>, which owns the
+    // `flex-col … sm:flex-row sm:justify-between` stacking. The classes
+    // themselves are covered by page-header.test.tsx — here we only pin
+    // that the page hasn't drifted back to an inline header div.
+    expect(containsElementType(node, "PageHeader")).toBe(true);
     // Inner filter cluster must opt into wrapping; without `flex-wrap` the
     // PeriodSelector's "All" button is what gets pushed off-screen.
+    const classes = collectClassNames(node);
     const wrapping = classes.find(
       (c) => c.includes("flex-wrap") && c.includes("items-center")
     );

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -27,6 +27,7 @@ import {
   formatModelName,
   repoName,
 } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
 import { StatCard } from "@/components/stat-card";
 import { TopBreakdownCard } from "@/components/top-breakdown-card";
 import { PeriodSelector } from "@/components/period-selector";
@@ -191,8 +192,7 @@ export default async function OverviewPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl font-bold">Overview</h1>
+      <PageHeader title="Overview">
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
@@ -201,7 +201,7 @@ export default async function OverviewPage({
             <PeriodSelector />
           </div>
         </Suspense>
-      </div>
+      </PageHeader>
 
       {showLinkBanner && <LinkDaemonBanner apiKey={user.api_key} />}
       {showFirstSyncBanner && <FirstSyncInProgressBanner />}

--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -13,6 +13,7 @@ import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
 import { buildCostCellTooltip, fmtCost, fmtNum, repoName } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -126,8 +127,7 @@ export default async function ReposPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl font-bold">Repos</h1>
+      <PageHeader title="Repos">
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
@@ -136,7 +136,7 @@ export default async function ReposPage({
             <PeriodSelector />
           </div>
         </Suspense>
-      </div>
+      </PageHeader>
 
       <Card>
         <CardHeader>

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -25,6 +25,7 @@ import {
   formatProvider,
   repoName,
 } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { UserFilter } from "@/components/user-filter";
@@ -122,8 +123,7 @@ export default async function SessionsPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl font-bold">Sessions</h1>
+      <PageHeader title="Sessions">
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <UserFilter members={members} role={user.role} />
@@ -132,7 +132,7 @@ export default async function SessionsPage({
             <PeriodSelector />
           </div>
         </Suspense>
-      </div>
+      </PageHeader>
 
       <Card>
         <CardHeader>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -13,6 +13,7 @@ import { getViewerTimeZone } from "@/lib/viewer-timezone";
 import { ALL_PERIOD_VALUE } from "@/lib/periods";
 import { parseUnit } from "@/lib/units";
 import { fmtCost, fmtNum } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
 import { PeriodSelector } from "@/components/period-selector";
 import { UnitsSelector } from "@/components/units-selector";
 import { SurfaceFilter } from "@/components/surface-filter";
@@ -93,8 +94,7 @@ export default async function TeamPage({
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl font-bold">Team</h1>
+      <PageHeader title="Team">
         <Suspense>
           <div className="flex flex-wrap items-center gap-3">
             <SurfaceFilter surfaces={knownSurfaces} />
@@ -102,7 +102,7 @@ export default async function TeamPage({
             <PeriodSelector />
           </div>
         </Suspense>
-      </div>
+      </PageHeader>
 
       <Card>
         <CardHeader>

--- a/src/components/page-header.test.tsx
+++ b/src/components/page-header.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { PageHeader } from "@/components/page-header";
+import { collectClassNames } from "@/test-utils/page-tree";
+
+describe("PageHeader", () => {
+  it("stacks below sm: and switches to a horizontal layout at sm — keeps the title + toolbar from sharing one ~470px row on a 375px phone (#117, #260)", () => {
+    const node = PageHeader({ title: "Overview", children: null });
+    const classes = collectClassNames(node);
+    const stacked = classes.find(
+      (c) =>
+        c.includes("flex-col") &&
+        c.includes("sm:flex-row") &&
+        c.includes("sm:justify-between")
+    );
+    expect(stacked).toBeTruthy();
+  });
+
+  it("renders the title as an h1.text-xl.font-bold so every dashboard page shares the same heading style", () => {
+    const node = PageHeader({ title: "Models" }) as {
+      props: { children: ReadonlyArray<{ type: string; props: unknown }> };
+    };
+    const h1 = node.props.children.find(
+      (child) => child && typeof child === "object" && child.type === "h1"
+    ) as { props: { className: string; children: string } } | undefined;
+    expect(h1).toBeTruthy();
+    expect(h1?.props.className).toContain("text-xl");
+    expect(h1?.props.className).toContain("font-bold");
+    expect(h1?.props.children).toBe("Models");
+  });
+
+  it("renders the toolbar children next to the title so each page can pass its own filter cluster", () => {
+    const toolbar = <div data-marker="TOOLBAR_SENTINEL" />;
+    const node = PageHeader({ title: "Repos", children: toolbar }) as {
+      props: { children: ReadonlyArray<unknown> };
+    };
+    expect(node.props.children).toContain(toolbar);
+  });
+});

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+export function PageHeader({
+  title,
+  children,
+}: {
+  title: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <h1 className="text-xl font-bold">{title}</h1>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts `<PageHeader title>` into `src/components/page-header.tsx`, owning the `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` responsive header row in one place.
- Migrates the six dashboard call sites — Overview, Models, Team, Devices, Sessions, Repos — to use it.
- Moves the mobile-stacking regression test (originally tied to #117) into `page-header.test.tsx`; the page-level Overview test now pins that `<PageHeader>` is mounted instead of grepping its className.

Closes the first systemic gap called out in #270 — the copy-paste pattern that let #260 drift in the first place.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (370 passing, including the new `PageHeader` unit tests)
- [x] `npm run format:check`