### PR TITLE
refactor(dashboard): extract <ResponsiveTable> primitive (#270)

### DIFF
--- a/src/app/dashboard/repos/page.tsx
+++ b/src/app/dashboard/repos/page.tsx
@@ -22,6 +22,7 @@ import { parseSurfaceParam } from "@/lib/surface";
 import { CostBarChart } from "@/components/charts/cost-bar-chart";
 import { COST_BAR_CHART_MAX_ITEMS } from "@/components/charts/cost-bar-chart-config";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { ResponsiveTable } from "@/components/responsive-table";
 
 export default async function ReposPage({
   searchParams,
@@ -162,83 +163,83 @@ export default async function ReposPage({
                   unit={unit}
                 />
               </div>
-              <div className="min-w-0 sm:overflow-x-auto">
-                <table className="hidden w-full text-sm sm:table">
-                  <thead>
-                    <tr className="border-b border-white/10 text-left text-zinc-400">
-                      <th className="pb-2 font-medium">Project</th>
-                      <th className="pb-2 pl-4 text-right font-medium">In</th>
-                      <th className="pb-2 pl-4 text-right font-medium">Out</th>
-                      <th className="pb-2 pl-4 text-right font-medium">
-                        {valueWord}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {repoRows.map((r, i) => (
-                      <tr key={i} className="border-b border-white/5">
-                        <td className="py-2 text-zinc-200">{r.label}</td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
-                          {fmtNum(r.input_tokens)}
-                        </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
-                          {fmtNum(r.output_tokens)}
-                        </td>
-                        <td
-                          className="py-2 pl-4 text-right tabular-nums text-zinc-300"
-                          title={
-                            isTokens
-                              ? undefined
-                              : buildCostCellTooltip(
-                                  r.cost_cents_ingested,
-                                  r.cost_cents
-                                )
-                          }
-                        >
-                          {fmtValue(
-                            r.cost_cents,
-                            r.input_tokens + r.output_tokens
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-                <ul className="divide-y divide-white/5 text-sm sm:hidden">
-                  {repoRows.map((r, i) => (
-                    <li key={i} className="flex flex-col gap-1 py-2">
-                      <div className="flex items-center justify-between gap-3">
-                        <span
-                          className="min-w-0 flex-1 truncate text-zinc-200"
-                          title={r.label}
-                        >
-                          {r.label}
-                        </span>
-                        <span
-                          className="shrink-0 tabular-nums text-zinc-300"
-                          title={
-                            isTokens
-                              ? undefined
-                              : buildCostCellTooltip(
-                                  r.cost_cents_ingested,
-                                  r.cost_cents
-                                )
-                          }
-                        >
-                          {fmtValue(
-                            r.cost_cents,
-                            r.input_tokens + r.output_tokens
-                          )}
-                        </span>
-                      </div>
-                      <div className="text-xs tabular-nums text-zinc-500">
-                        in {fmtNum(r.input_tokens)} · out{" "}
-                        {fmtNum(r.output_tokens)}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+              <ResponsiveTable
+                columns={[
+                  {
+                    key: "label",
+                    header: "Project",
+                    cellClassName: "text-zinc-200",
+                    render: (r) => r.label,
+                  },
+                  {
+                    key: "in",
+                    header: "In",
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-400",
+                    render: (r) => fmtNum(r.input_tokens),
+                  },
+                  {
+                    key: "out",
+                    header: "Out",
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-400",
+                    render: (r) => fmtNum(r.output_tokens),
+                  },
+                  {
+                    key: "value",
+                    header: valueWord,
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-300",
+                    cellTitle: (r) =>
+                      isTokens
+                        ? undefined
+                        : buildCostCellTooltip(
+                            r.cost_cents_ingested,
+                            r.cost_cents
+                          ),
+                    render: (r) =>
+                      fmtValue(r.cost_cents, r.input_tokens + r.output_tokens),
+                  },
+                ]}
+                rows={repoRows}
+                rowKey={(_, i) => i}
+                mobileItemClassName="flex flex-col gap-1 py-2"
+                mobileCard={(r) => (
+                  <>
+                    <div className="flex items-center justify-between gap-3">
+                      <span
+                        className="min-w-0 flex-1 truncate text-zinc-200"
+                        title={r.label}
+                      >
+                        {r.label}
+                      </span>
+                      <span
+                        className="shrink-0 tabular-nums text-zinc-300"
+                        title={
+                          isTokens
+                            ? undefined
+                            : buildCostCellTooltip(
+                                r.cost_cents_ingested,
+                                r.cost_cents
+                              )
+                        }
+                      >
+                        {fmtValue(
+                          r.cost_cents,
+                          r.input_tokens + r.output_tokens
+                        )}
+                      </span>
+                    </div>
+                    <div className="text-xs tabular-nums text-zinc-500">
+                      in {fmtNum(r.input_tokens)} · out{" "}
+                      {fmtNum(r.output_tokens)}
+                    </div>
+                  </>
+                )}
+              />
             </div>
           )}
           <p className="mt-3 text-xs text-zinc-500">
@@ -274,99 +275,97 @@ export default async function ReposPage({
                   unit={unit}
                 />
               </div>
-              <div className="min-w-0 sm:overflow-x-auto">
-                <table className="hidden w-full text-sm sm:table">
-                  <thead>
-                    <tr className="border-b border-white/10 text-left text-zinc-400">
-                      <th className="pb-2 font-medium">Project</th>
-                      <th className="pb-2 font-medium">Branch</th>
-                      <th className="pb-2 pl-4 text-right font-medium">In</th>
-                      <th className="pb-2 pl-4 text-right font-medium">Out</th>
-                      <th className="pb-2 pl-4 text-right font-medium">
-                        {valueWord}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {branchRows.map((b, i) => (
-                      <tr key={i} className="border-b border-white/5">
-                        <td className="py-2 text-zinc-200">
-                          <div
-                            className="max-w-[14rem] truncate"
-                            title={b.project}
-                          >
-                            {b.project}
-                          </div>
-                        </td>
-                        <td className="py-2 text-zinc-200">
-                          <div
-                            className="max-w-[18rem] truncate"
-                            title={b.branch}
-                          >
-                            {b.branch}
-                          </div>
-                        </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
-                          {fmtNum(b.input_tokens)}
-                        </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
-                          {fmtNum(b.output_tokens)}
-                        </td>
-                        <td
-                          className="py-2 pl-4 text-right tabular-nums text-zinc-300"
-                          title={
-                            isTokens
-                              ? undefined
-                              : buildCostCellTooltip(
-                                  b.cost_cents_ingested,
-                                  b.cost_cents
-                                )
-                          }
-                        >
-                          {fmtValue(
-                            b.cost_cents,
-                            b.input_tokens + b.output_tokens
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-                <ul className="divide-y divide-white/5 text-sm sm:hidden">
-                  {branchRows.map((b, i) => (
-                    <li key={i} className="flex flex-col gap-1 py-2">
-                      <div className="flex items-center justify-between gap-3">
-                        <span
-                          className="min-w-0 flex-1 truncate text-zinc-200"
-                          title={`${b.project} / ${b.branch}`}
-                        >
-                          {b.project} / {b.branch}
-                        </span>
-                        <span
-                          className="shrink-0 tabular-nums text-zinc-300"
-                          title={
-                            isTokens
-                              ? undefined
-                              : buildCostCellTooltip(
-                                  b.cost_cents_ingested,
-                                  b.cost_cents
-                                )
-                          }
-                        >
-                          {fmtValue(
-                            b.cost_cents,
-                            b.input_tokens + b.output_tokens
-                          )}
-                        </span>
+              <ResponsiveTable
+                columns={[
+                  {
+                    key: "project",
+                    header: "Project",
+                    cellClassName: "text-zinc-200",
+                    render: (b) => (
+                      <div className="max-w-[14rem] truncate" title={b.project}>
+                        {b.project}
                       </div>
-                      <div className="text-xs tabular-nums text-zinc-500">
-                        in {fmtNum(b.input_tokens)} · out{" "}
-                        {fmtNum(b.output_tokens)}
+                    ),
+                  },
+                  {
+                    key: "branch",
+                    header: "Branch",
+                    cellClassName: "text-zinc-200",
+                    render: (b) => (
+                      <div className="max-w-[18rem] truncate" title={b.branch}>
+                        {b.branch}
                       </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+                    ),
+                  },
+                  {
+                    key: "in",
+                    header: "In",
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-400",
+                    render: (b) => fmtNum(b.input_tokens),
+                  },
+                  {
+                    key: "out",
+                    header: "Out",
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-400",
+                    render: (b) => fmtNum(b.output_tokens),
+                  },
+                  {
+                    key: "value",
+                    header: valueWord,
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-300",
+                    cellTitle: (b) =>
+                      isTokens
+                        ? undefined
+                        : buildCostCellTooltip(
+                            b.cost_cents_ingested,
+                            b.cost_cents
+                          ),
+                    render: (b) =>
+                      fmtValue(b.cost_cents, b.input_tokens + b.output_tokens),
+                  },
+                ]}
+                rows={branchRows}
+                rowKey={(_, i) => i}
+                mobileItemClassName="flex flex-col gap-1 py-2"
+                mobileCard={(b) => (
+                  <>
+                    <div className="flex items-center justify-between gap-3">
+                      <span
+                        className="min-w-0 flex-1 truncate text-zinc-200"
+                        title={`${b.project} / ${b.branch}`}
+                      >
+                        {b.project} / {b.branch}
+                      </span>
+                      <span
+                        className="shrink-0 tabular-nums text-zinc-300"
+                        title={
+                          isTokens
+                            ? undefined
+                            : buildCostCellTooltip(
+                                b.cost_cents_ingested,
+                                b.cost_cents
+                              )
+                        }
+                      >
+                        {fmtValue(
+                          b.cost_cents,
+                          b.input_tokens + b.output_tokens
+                        )}
+                      </span>
+                    </div>
+                    <div className="text-xs tabular-nums text-zinc-500">
+                      in {fmtNum(b.input_tokens)} · out{" "}
+                      {fmtNum(b.output_tokens)}
+                    </div>
+                  </>
+                )}
+              />
             </div>
           )}
         </CardContent>
@@ -396,83 +395,83 @@ export default async function ReposPage({
                   unit={unit}
                 />
               </div>
-              <div className="min-w-0 sm:overflow-x-auto">
-                <table className="hidden w-full text-sm sm:table">
-                  <thead>
-                    <tr className="border-b border-white/10 text-left text-zinc-400">
-                      <th className="pb-2 font-medium">Ticket</th>
-                      <th className="pb-2 pl-4 text-right font-medium">In</th>
-                      <th className="pb-2 pl-4 text-right font-medium">Out</th>
-                      <th className="pb-2 pl-4 text-right font-medium">
-                        {valueWord}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {ticketRows.map((t, i) => (
-                      <tr key={i} className="border-b border-white/5">
-                        <td className="py-2 text-zinc-200">{t.ticket}</td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
-                          {fmtNum(t.input_tokens)}
-                        </td>
-                        <td className="py-2 pl-4 text-right tabular-nums text-zinc-400">
-                          {fmtNum(t.output_tokens)}
-                        </td>
-                        <td
-                          className="py-2 pl-4 text-right tabular-nums text-zinc-300"
-                          title={
-                            isTokens
-                              ? undefined
-                              : buildCostCellTooltip(
-                                  t.cost_cents_ingested,
-                                  t.cost_cents
-                                )
-                          }
-                        >
-                          {fmtValue(
-                            t.cost_cents,
-                            t.input_tokens + t.output_tokens
-                          )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-                <ul className="divide-y divide-white/5 text-sm sm:hidden">
-                  {ticketRows.map((t, i) => (
-                    <li key={i} className="flex flex-col gap-1 py-2">
-                      <div className="flex items-center justify-between gap-3">
-                        <span
-                          className="min-w-0 flex-1 truncate text-zinc-200"
-                          title={t.ticket}
-                        >
-                          {t.ticket}
-                        </span>
-                        <span
-                          className="shrink-0 tabular-nums text-zinc-300"
-                          title={
-                            isTokens
-                              ? undefined
-                              : buildCostCellTooltip(
-                                  t.cost_cents_ingested,
-                                  t.cost_cents
-                                )
-                          }
-                        >
-                          {fmtValue(
-                            t.cost_cents,
-                            t.input_tokens + t.output_tokens
-                          )}
-                        </span>
-                      </div>
-                      <div className="text-xs tabular-nums text-zinc-500">
-                        in {fmtNum(t.input_tokens)} · out{" "}
-                        {fmtNum(t.output_tokens)}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              </div>
+              <ResponsiveTable
+                columns={[
+                  {
+                    key: "ticket",
+                    header: "Ticket",
+                    cellClassName: "text-zinc-200",
+                    render: (t) => t.ticket,
+                  },
+                  {
+                    key: "in",
+                    header: "In",
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-400",
+                    render: (t) => fmtNum(t.input_tokens),
+                  },
+                  {
+                    key: "out",
+                    header: "Out",
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-400",
+                    render: (t) => fmtNum(t.output_tokens),
+                  },
+                  {
+                    key: "value",
+                    header: valueWord,
+                    align: "right",
+                    headerClassName: "pl-4",
+                    cellClassName: "pl-4 tabular-nums text-zinc-300",
+                    cellTitle: (t) =>
+                      isTokens
+                        ? undefined
+                        : buildCostCellTooltip(
+                            t.cost_cents_ingested,
+                            t.cost_cents
+                          ),
+                    render: (t) =>
+                      fmtValue(t.cost_cents, t.input_tokens + t.output_tokens),
+                  },
+                ]}
+                rows={ticketRows}
+                rowKey={(_, i) => i}
+                mobileItemClassName="flex flex-col gap-1 py-2"
+                mobileCard={(t) => (
+                  <>
+                    <div className="flex items-center justify-between gap-3">
+                      <span
+                        className="min-w-0 flex-1 truncate text-zinc-200"
+                        title={t.ticket}
+                      >
+                        {t.ticket}
+                      </span>
+                      <span
+                        className="shrink-0 tabular-nums text-zinc-300"
+                        title={
+                          isTokens
+                            ? undefined
+                            : buildCostCellTooltip(
+                                t.cost_cents_ingested,
+                                t.cost_cents
+                              )
+                        }
+                      >
+                        {fmtValue(
+                          t.cost_cents,
+                          t.input_tokens + t.output_tokens
+                        )}
+                      </span>
+                    </div>
+                    <div className="text-xs tabular-nums text-zinc-500">
+                      in {fmtNum(t.input_tokens)} · out{" "}
+                      {fmtNum(t.output_tokens)}
+                    </div>
+                  </>
+                )}
+              />
             </div>
           )}
         </CardContent>

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -2,6 +2,10 @@ import Link from "next/link";
 import { getCurrentUser, getOrgMembers } from "@/lib/dal";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/responsive-table";
 import { ApiKeySection } from "./api-key-section";
 import { CopyButton } from "./copy-button";
 import { InviteSection } from "./invite-section";
@@ -21,6 +25,28 @@ export default async function SettingsPage() {
 
   const members = await getOrgMembers(user.org_id);
   const canEditRoles = user.role === "manager";
+  type Member = (typeof members)[number];
+  const memberColumns: ResponsiveColumn<Member>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cellClassName: "text-zinc-200",
+      render: (m) => m.display_name || "-",
+    },
+    {
+      key: "email",
+      header: "Email",
+      cellClassName: "text-zinc-400",
+      render: (m) => m.email || "-",
+    },
+    {
+      key: "role",
+      header: "Role",
+      render: (m) => (
+        <RoleCell userId={m.id} initialRole={m.role} canEdit={canEditRoles} />
+      ),
+    },
+  ];
 
   return (
     <div className="space-y-6">
@@ -57,59 +83,29 @@ export default async function SettingsPage() {
           {members.length === 0 ? (
             <p className="text-sm text-zinc-500">No members yet</p>
           ) : (
-            <>
-              {/* Table on sm+ stays the same; below `sm` render each member
-                  as a stacked card (name+role pill on the first row, email
-                  on the second) so the cluster doesn't overflow horizontally
-                  at phone widths. */}
-              <table className="hidden w-full text-sm sm:table">
-                <thead>
-                  <tr className="border-b border-white/10 text-left text-zinc-400">
-                    <th className="pb-2 font-medium">Name</th>
-                    <th className="pb-2 font-medium">Email</th>
-                    <th className="pb-2 font-medium">Role</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {members.map((m) => (
-                    <tr key={m.id} className="border-b border-white/5">
-                      <td className="py-2 text-zinc-200">
-                        {m.display_name || "-"}
-                      </td>
-                      <td className="py-2 text-zinc-400">{m.email || "-"}</td>
-                      <td className="py-2">
-                        <RoleCell
-                          userId={m.id}
-                          initialRole={m.role}
-                          canEdit={canEditRoles}
-                        />
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              <ul className="divide-y divide-white/5 text-sm sm:hidden">
-                {members.map((m) => (
-                  <li key={m.id} className="space-y-1 py-3">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="truncate text-zinc-200">
-                        {m.display_name || "-"}
-                      </span>
-                      <RoleCell
-                        userId={m.id}
-                        initialRole={m.role}
-                        canEdit={canEditRoles}
-                      />
-                    </div>
-                    {m.email && (
-                      <p className="truncate text-xs text-zinc-500">
-                        {m.email}
-                      </p>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </>
+            <ResponsiveTable
+              columns={memberColumns}
+              rows={members}
+              rowKey={(m) => m.id}
+              mobileItemClassName="space-y-1 py-3"
+              mobileCard={(m) => (
+                <>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate text-zinc-200">
+                      {m.display_name || "-"}
+                    </span>
+                    <RoleCell
+                      userId={m.id}
+                      initialRole={m.role}
+                      canEdit={canEditRoles}
+                    />
+                  </div>
+                  {m.email && (
+                    <p className="truncate text-xs text-zinc-500">{m.email}</p>
+                  )}
+                </>
+              )}
+            />
           )}
         </CardContent>
       </Card>

--- a/src/app/dashboard/settings/pricing/audit-history-table.tsx
+++ b/src/app/dashboard/settings/pricing/audit-history-table.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
 import type { RecalculationRunRow } from "@/lib/dal";
 import { fmtCost } from "@/lib/format";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/responsive-table";
 
 /**
  * Settings → Pricing → Audit history (#733). Renders the org's
@@ -113,6 +117,87 @@ export function AuditHistoryTable({
   const showingFrom = total === 0 ? 0 : (page - 1) * pageSize + 1;
   const showingTo = Math.min(page * pageSize, total);
 
+  const triggerLabel = (run: RecalculationRunRow): string => {
+    if (!run.triggeredBy) return "—";
+    return usersById.get(run.triggeredBy) ?? run.triggeredBy;
+  };
+
+  const deltaToneClass = (tone: "up" | "down" | "flat"): string => {
+    if (tone === "down") return "text-emerald-300";
+    if (tone === "up") return "text-amber-300";
+    return "text-zinc-300";
+  };
+
+  const columns: ResponsiveColumn<RecalculationRunRow>[] = [
+    {
+      key: "started",
+      header: "Started",
+      cellClassName: "text-zinc-200",
+      render: (run) => (
+        <details>
+          <summary className="cursor-pointer list-none whitespace-nowrap">
+            <span aria-hidden className="mr-1 text-zinc-500">
+              ▸
+            </span>
+            {formatStarted(run.startedAt)}
+          </summary>
+          <dl className="mt-2 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs text-zinc-400">
+            <dt>Run id</dt>
+            <dd className="font-mono text-zinc-300">{run.id}</dd>
+            <dt>Finished</dt>
+            <dd className="text-zinc-300">
+              {run.finishedAt ? formatStarted(run.finishedAt) : "—"}
+            </dd>
+            <dt>Active price lists</dt>
+            <dd className="text-zinc-300">
+              {run.priceListIds.length === 0
+                ? "—"
+                : run.priceListIds.join(", ")}
+            </dd>
+            <dt>Rows processed</dt>
+            <dd className="text-zinc-300">{run.rowsProcessed ?? "—"}</dd>
+          </dl>
+        </details>
+      ),
+    },
+    {
+      key: "trigger",
+      header: "Triggered by",
+      cellClassName: "text-zinc-300",
+      render: (run) => triggerLabel(run),
+    },
+    {
+      key: "scope",
+      header: "Scope",
+      cellClassName: "text-zinc-400",
+      render: (run) => formatScope(run.scopeFromDate, run.scopeToDate),
+    },
+    {
+      key: "rows-changed",
+      header: "Rows changed",
+      align: "right",
+      cellClassName: "tabular-nums text-zinc-200",
+      render: (run) => run.rowsChanged ?? "—",
+    },
+    {
+      key: "delta",
+      header: "Before → After",
+      headerClassName: "pl-6",
+      cellClassName: "pl-6 tabular-nums",
+      render: (run) => {
+        const delta = formatDelta(run.beforeTotalCents, run.afterTotalCents);
+        return (
+          <span className={deltaToneClass(delta.tone)}>{delta.label}</span>
+        );
+      },
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (run) => <StatusBadge status={run.status} />,
+    },
+  ];
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
@@ -145,138 +230,47 @@ export function AuditHistoryTable({
           {status === "all" ? " yet" : ` with status "${status}"`}.
         </p>
       ) : (
-        <>
-          {/* Table on sm+; below `sm` render each run as a stacked card so the
-              six columns don't collapse into each other at 390px. Mirrors the
-              members-list pattern in src/app/dashboard/settings/page.tsx
-              (#258). */}
-          <table className="hidden w-full text-sm sm:table">
-            <thead>
-              <tr className="border-b border-white/10 text-left text-zinc-400">
-                <th className="pb-2 font-medium">Started</th>
-                <th className="pb-2 font-medium">Triggered by</th>
-                <th className="pb-2 font-medium">Scope</th>
-                <th className="pb-2 text-right font-medium">Rows changed</th>
-                <th className="pb-2 pl-6 font-medium">Before → After</th>
-                <th className="pb-2 font-medium">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {runs.map((run) => {
-                const delta = formatDelta(
-                  run.beforeTotalCents,
-                  run.afterTotalCents
-                );
-                const trigger = run.triggeredBy
-                  ? (usersById.get(run.triggeredBy) ?? run.triggeredBy)
-                  : "—";
-                return (
-                  <tr
-                    key={run.id}
-                    className="border-b border-white/5 align-top"
-                  >
-                    <td className="py-2 text-zinc-200">
-                      <details>
-                        <summary className="cursor-pointer list-none whitespace-nowrap">
-                          <span aria-hidden className="mr-1 text-zinc-500">
-                            ▸
-                          </span>
-                          {formatStarted(run.startedAt)}
-                        </summary>
-                        <dl className="mt-2 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs text-zinc-400">
-                          <dt>Run id</dt>
-                          <dd className="font-mono text-zinc-300">{run.id}</dd>
-                          <dt>Finished</dt>
-                          <dd className="text-zinc-300">
-                            {run.finishedAt
-                              ? formatStarted(run.finishedAt)
-                              : "—"}
-                          </dd>
-                          <dt>Active price lists</dt>
-                          <dd className="text-zinc-300">
-                            {run.priceListIds.length === 0
-                              ? "—"
-                              : run.priceListIds.join(", ")}
-                          </dd>
-                          <dt>Rows processed</dt>
-                          <dd className="text-zinc-300">
-                            {run.rowsProcessed ?? "—"}
-                          </dd>
-                        </dl>
-                      </details>
-                    </td>
-                    <td className="py-2 text-zinc-300">{trigger}</td>
-                    <td className="py-2 text-zinc-400">
-                      {formatScope(run.scopeFromDate, run.scopeToDate)}
-                    </td>
-                    <td className="py-2 text-right text-zinc-200 tabular-nums">
-                      {run.rowsChanged ?? "—"}
-                    </td>
-                    <td
-                      className={`py-2 pl-6 tabular-nums ${
-                        delta.tone === "down"
-                          ? "text-emerald-300"
-                          : delta.tone === "up"
-                            ? "text-amber-300"
-                            : "text-zinc-300"
-                      }`}
-                    >
-                      {delta.label}
-                    </td>
-                    <td className="py-2">
-                      <StatusBadge status={run.status} />
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          <ul className="divide-y divide-white/5 text-sm sm:hidden">
-            {runs.map((run) => {
-              const delta = formatDelta(
-                run.beforeTotalCents,
-                run.afterTotalCents
-              );
-              const trigger = run.triggeredBy
-                ? (usersById.get(run.triggeredBy) ?? run.triggeredBy)
-                : "—";
-              return (
-                <li key={run.id} className="space-y-2 py-3">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="truncate text-zinc-200">
-                      {formatStarted(run.startedAt)}
-                    </span>
-                    <StatusBadge status={run.status} />
-                  </div>
-                  <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
-                    <dt className="text-zinc-500">Triggered by</dt>
-                    <dd className="truncate text-zinc-300">{trigger}</dd>
-                    <dt className="text-zinc-500">Scope</dt>
-                    <dd className="text-zinc-300">
-                      {formatScope(run.scopeFromDate, run.scopeToDate)}
-                    </dd>
-                    <dt className="text-zinc-500">Rows changed</dt>
-                    <dd className="text-zinc-300 tabular-nums">
-                      {run.rowsChanged ?? "—"}
-                    </dd>
-                    <dt className="text-zinc-500">Before → After</dt>
-                    <dd
-                      className={`tabular-nums ${
-                        delta.tone === "down"
-                          ? "text-emerald-300"
-                          : delta.tone === "up"
-                            ? "text-amber-300"
-                            : "text-zinc-300"
-                      }`}
-                    >
-                      {delta.label}
-                    </dd>
-                  </dl>
-                </li>
-              );
-            })}
-          </ul>
-        </>
+        <ResponsiveTable
+          columns={columns}
+          rows={runs}
+          rowKey={(run) => run.id}
+          rowClassName="align-top"
+          mobileItemClassName="space-y-2 py-3"
+          mobileCard={(run) => {
+            const delta = formatDelta(
+              run.beforeTotalCents,
+              run.afterTotalCents
+            );
+            return (
+              <>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate text-zinc-200">
+                    {formatStarted(run.startedAt)}
+                  </span>
+                  <StatusBadge status={run.status} />
+                </div>
+                <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+                  <dt className="text-zinc-500">Triggered by</dt>
+                  <dd className="truncate text-zinc-300">
+                    {triggerLabel(run)}
+                  </dd>
+                  <dt className="text-zinc-500">Scope</dt>
+                  <dd className="text-zinc-300">
+                    {formatScope(run.scopeFromDate, run.scopeToDate)}
+                  </dd>
+                  <dt className="text-zinc-500">Rows changed</dt>
+                  <dd className="text-zinc-300 tabular-nums">
+                    {run.rowsChanged ?? "—"}
+                  </dd>
+                  <dt className="text-zinc-500">Before → After</dt>
+                  <dd className={`tabular-nums ${deltaToneClass(delta.tone)}`}>
+                    {delta.label}
+                  </dd>
+                </dl>
+              </>
+            );
+          }}
+        />
       )}
 
       {total > pageSize && (

--- a/src/app/dashboard/settings/pricing/price-lists-table.tsx
+++ b/src/app/dashboard/settings/pricing/price-lists-table.tsx
@@ -5,6 +5,10 @@ import {
   activatePricingList,
   discardPricingDraft,
 } from "@/app/actions/pricing";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/responsive-table";
 
 export type PriceListRow = {
   id: number;
@@ -31,6 +35,12 @@ function StatusBadge({ status }: { status: PriceListRow["status"] }) {
       {status}
     </span>
   );
+}
+
+function formatEffective(l: PriceListRow): string {
+  return l.effectiveTo
+    ? `${l.effectiveFrom} → ${l.effectiveTo}`
+    : l.effectiveFrom;
 }
 
 export function PriceListsTable({ lists }: { lists: PriceListRow[] }) {
@@ -88,55 +98,62 @@ export function PriceListsTable({ lists }: { lists: PriceListRow[] }) {
     );
   }
 
+  const columns: ResponsiveColumn<PriceListRow>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cellClassName: "text-zinc-200",
+      render: (l) => l.name,
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (l) => <StatusBadge status={l.status} />,
+    },
+    {
+      key: "effective",
+      header: "Effective from",
+      cellClassName: "text-zinc-400",
+      render: (l) => formatEffective(l),
+    },
+    {
+      key: "source",
+      header: "Source file",
+      cellClassName: "text-zinc-400",
+      render: (l) => l.sourceFileName ?? "—",
+    },
+    {
+      key: "uploaded-by",
+      header: "Uploaded by",
+      cellClassName: "text-zinc-400",
+      render: (l) => l.uploadedBy ?? "—",
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      align: "right",
+      render: (l) => renderActions(l),
+    },
+  ];
+
   return (
     <div className="space-y-3">
       {error && <p className="text-sm text-red-400">{error}</p>}
 
-      {/* Table on sm+; below `sm` render each list as a stacked card so the
-          5 + actions columns don't overlap at 390px. Mirrors the members-list
-          pattern in src/app/dashboard/settings/page.tsx (#258). */}
-      <table className="hidden w-full text-sm sm:table">
-        <thead>
-          <tr className="border-b border-white/10 text-left text-zinc-400">
-            <th className="pb-2 font-medium">Name</th>
-            <th className="pb-2 font-medium">Status</th>
-            <th className="pb-2 font-medium">Effective from</th>
-            <th className="pb-2 font-medium">Source file</th>
-            <th className="pb-2 font-medium">Uploaded by</th>
-            <th className="pb-2 text-right font-medium">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {lists.map((l) => (
-            <tr key={l.id} className="border-b border-white/5">
-              <td className="py-2 text-zinc-200">{l.name}</td>
-              <td className="py-2">
-                <StatusBadge status={l.status} />
-              </td>
-              <td className="py-2 text-zinc-400">
-                {l.effectiveFrom}
-                {l.effectiveTo ? ` → ${l.effectiveTo}` : ""}
-              </td>
-              <td className="py-2 text-zinc-400">{l.sourceFileName ?? "—"}</td>
-              <td className="py-2 text-zinc-400">{l.uploadedBy ?? "—"}</td>
-              <td className="py-2 text-right">{renderActions(l)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <ul className="divide-y divide-white/5 text-sm sm:hidden">
-        {lists.map((l) => (
-          <li key={l.id} className="space-y-2 py-3">
+      <ResponsiveTable
+        columns={columns}
+        rows={lists}
+        rowKey={(l) => l.id}
+        mobileItemClassName="space-y-2 py-3"
+        mobileCard={(l) => (
+          <>
             <div className="flex items-center justify-between gap-2">
               <span className="truncate text-zinc-200">{l.name}</span>
               <StatusBadge status={l.status} />
             </div>
             <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
               <dt className="text-zinc-500">Effective</dt>
-              <dd className="text-zinc-300">
-                {l.effectiveFrom}
-                {l.effectiveTo ? ` → ${l.effectiveTo}` : ""}
-              </dd>
+              <dd className="text-zinc-300">{formatEffective(l)}</dd>
               <dt className="text-zinc-500">Source file</dt>
               <dd className="truncate text-zinc-300">
                 {l.sourceFileName ?? "—"}
@@ -145,9 +162,9 @@ export function PriceListsTable({ lists }: { lists: PriceListRow[] }) {
               <dd className="truncate text-zinc-300">{l.uploadedBy ?? "—"}</dd>
             </dl>
             {l.status === "draft" && renderActions(l)}
-          </li>
-        ))}
-      </ul>
+          </>
+        )}
+      />
     </div>
   );
 }

--- a/src/components/responsive-table.test.tsx
+++ b/src/components/responsive-table.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/responsive-table";
+import { collectClassNames, extractText } from "@/test-utils/page-tree";
+
+type Row = { id: number; name: string; cost: number };
+
+const ROWS: Row[] = [
+  { id: 1, name: "alpha", cost: 100 },
+  { id: 2, name: "beta", cost: 250 },
+];
+
+const COLUMNS: ResponsiveColumn<Row>[] = [
+  { key: "name", header: "Name", render: (r) => r.name },
+  {
+    key: "cost",
+    header: "Cost",
+    align: "right",
+    cellClassName: "tabular-nums",
+    render: (r) => r.cost,
+  },
+];
+
+describe("ResponsiveTable", () => {
+  it("owns the desktop/mobile split — emits a sm: table and a sm:hidden card list so a 390px viewport gets the stacked layout (#270 gap 2)", () => {
+    const tree = ResponsiveTable({
+      columns: COLUMNS,
+      rows: ROWS,
+      rowKey: (r) => r.id,
+      mobileCard: (r) => r.name,
+    });
+    const classes = collectClassNames(tree).join(" ");
+    // Desktop: table hidden below sm, appears at sm+.
+    expect(classes).toContain("hidden w-full text-sm sm:table");
+    // Mobile: ul visible below sm, hidden at sm+.
+    expect(classes).toContain("divide-y divide-white/5 text-sm sm:hidden");
+  });
+
+  it("defaults the outer wrapper to `min-w-0 sm:overflow-x-auto` so the next call site can't reintroduce the desktop overflow from #257 (#270 gap 3)", () => {
+    const tree = ResponsiveTable({
+      columns: COLUMNS,
+      rows: ROWS,
+      rowKey: (r) => r.id,
+      mobileCard: (r) => r.name,
+    }) as { props: { className: string } };
+    expect(tree.props.className).toContain("min-w-0");
+    expect(tree.props.className).toContain("sm:overflow-x-auto");
+  });
+
+  it("lets a call site replace the wrapper class when the surrounding layout already guarantees overflow", () => {
+    const tree = ResponsiveTable({
+      columns: COLUMNS,
+      rows: ROWS,
+      rowKey: (r) => r.id,
+      mobileCard: (r) => r.name,
+      className: "relative",
+    }) as { props: { className: string } };
+    expect(tree.props.className).toBe("relative");
+  });
+
+  it("renders both desktop cells and mobile cards from the same rows so the two views can't diverge silently", () => {
+    const tree = ResponsiveTable({
+      columns: COLUMNS,
+      rows: ROWS,
+      rowKey: (r) => r.id,
+      mobileCard: (r) => `${r.name}-card`,
+    });
+    const text = extractText(tree);
+    // Desktop cell renders.
+    expect(text).toContain("alpha");
+    expect(text).toContain("250");
+    // Mobile card renders the dedicated card body.
+    expect(text).toContain("alpha-card");
+    expect(text).toContain("beta-card");
+  });
+
+  it("forwards `align: right` to both the header and the cell so numeric columns line up consistently", () => {
+    const tree = ResponsiveTable({
+      columns: COLUMNS,
+      rows: ROWS,
+      rowKey: (r) => r.id,
+      mobileCard: (r) => r.name,
+    });
+    const classes = collectClassNames(tree);
+    // Both the Cost <th> and its <td>s should pick up text-right.
+    const rightAligned = classes.filter((c) => c.includes("text-right"));
+    // 1 header + 2 cells = 3 occurrences.
+    expect(rightAligned.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/components/responsive-table.tsx
+++ b/src/components/responsive-table.tsx
@@ -1,0 +1,120 @@
+import type { ReactNode } from "react";
+import { clsx } from "clsx";
+
+/**
+ * Dashboard tables need two completely different layouts: a `<table>` at
+ * `sm:` and above, and a stacked card list (`<ul>`) below `sm` so the columns
+ * don't overlap at 390px. Five places re-implemented the split — members
+ * (settings), price-lists, audit-history, sessions, and the three repos
+ * tables (#270). This primitive owns the split so the next responsive-table
+ * lands in one place.
+ *
+ * Each call site passes a `columns` config for the desktop table and a
+ * `mobileCard` renderer for the stacked card body. The two views often surface
+ * different fields (cost-by-project shows 4 columns desktop but only label +
+ * total on mobile), so they're independent rather than auto-derived from
+ * columns.
+ *
+ * The outer wrapper defaults to `min-w-0 sm:overflow-x-auto` — gap 3 from the
+ * retro (#270): callers should not have to remember this for new tables. The
+ * default can be replaced via `className`.
+ */
+export type ResponsiveColumn<T> = {
+  /** Stable identifier for React keys. */
+  key: string;
+  header: ReactNode;
+  align?: "left" | "right";
+  /** Extra Tailwind classes appended to the `<th>`. */
+  headerClassName?: string;
+  /** Extra Tailwind classes appended to the `<td>`. */
+  cellClassName?: string;
+  /** Optional `title` attribute on the `<td>` — useful for truncated text. */
+  cellTitle?: (row: T) => string | undefined;
+  render: (row: T) => ReactNode;
+};
+
+export type ResponsiveTableProps<T> = {
+  columns: ResponsiveColumn<T>[];
+  rows: T[];
+  rowKey: (row: T, index: number) => string | number;
+  /** Body of the `<li>` for the mobile card. */
+  mobileCard: (row: T, index: number) => ReactNode;
+  /** Classes appended to each mobile `<li>`. Default `py-3`. */
+  mobileItemClassName?: string;
+  /** Extra classes appended to each desktop `<tr>` (e.g. `align-top`). */
+  rowClassName?: string;
+  /**
+   * Replaces the outer wrapper classes. The default
+   * `min-w-0 sm:overflow-x-auto` enforces gap 3 from #270 — pass an explicit
+   * value only when the surrounding layout already guarantees the overflow
+   * contract.
+   */
+  className?: string;
+};
+
+const DEFAULT_WRAPPER = "min-w-0 sm:overflow-x-auto";
+
+export function ResponsiveTable<T>({
+  columns,
+  rows,
+  rowKey,
+  mobileCard,
+  mobileItemClassName = "py-3",
+  rowClassName,
+  className = DEFAULT_WRAPPER,
+}: ResponsiveTableProps<T>) {
+  return (
+    <div className={className}>
+      <table className="hidden w-full text-sm sm:table">
+        <thead>
+          <tr className="border-b border-white/10 text-left text-zinc-400">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className={clsx(
+                  "pb-2 font-medium",
+                  col.align === "right" && "text-right",
+                  col.headerClassName
+                )}
+              >
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr
+              key={rowKey(row, i)}
+              className={clsx("border-b border-white/5", rowClassName)}
+            >
+              {columns.map((col) => {
+                const title = col.cellTitle?.(row);
+                return (
+                  <td
+                    key={col.key}
+                    className={clsx(
+                      "py-2",
+                      col.align === "right" && "text-right",
+                      col.cellClassName
+                    )}
+                    title={title}
+                  >
+                    {col.render(row)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <ul className="divide-y divide-white/5 text-sm sm:hidden">
+        {rows.map((row, i) => (
+          <li key={rowKey(row, i)} className={mobileItemClassName}>
+            {mobileCard(row, i)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/test-utils/page-tree.ts
+++ b/src/test-utils/page-tree.ts
@@ -65,6 +65,30 @@ function walk(node: Node, parts: string[], seen: WeakSet<object>): void {
   const el = node as ReactElement & {
     props?: Record<string, unknown> & { children?: unknown };
   };
+
+  // Drill into pure sync function components. Without this, any text rendered
+  // by a component's body (rather than passed through children/TEXT_PROPS) is
+  // invisible to the haystack — e.g. ResponsiveTable (#270), whose row content
+  // is produced by a `render(row)` callback inside the component's body.
+  // Components that use client-only hooks throw on bare invocation; the
+  // try/catch falls back to the regular children walk so existing coverage is
+  // preserved.
+  if (typeof el.type === "function" && el.props) {
+    try {
+      const result = (el.type as (p: unknown) => unknown)(el.props);
+      if (
+        result == null ||
+        typeof (result as { then?: unknown }).then !== "function"
+      ) {
+        walk(result, parts, seen);
+        return;
+      }
+      // async components fall through to the props-only walk below.
+    } catch {
+      // hook-using or otherwise non-invokable component — keep walking props.
+    }
+  }
+
   if (el.props) {
     for (const key of Object.keys(el.props)) {
       if (key === "children") continue;


### PR DESCRIPTION
## Summary

- Retro gap 2 from #270: extract `<ResponsiveTable>` and migrate the five canonical call sites (members list, price-lists, audit-history, and the three repos breakdowns) so the next responsive-table convention change costs one edit instead of N.
- Wrapper defaults to `min-w-0 sm:overflow-x-auto` so a new caller can't reintroduce the desktop overflow from #257 (gap 3).
- `extractText` test util now drills into pure sync function components so existing page-level coverage continues to see row content produced by `column.render(row)` callbacks.

## Out of scope

- `/dashboard/sessions` is **not** migrated here. Every desktop cell wraps in a per-cell `<Link>` that absorbs the cell padding, and the mobile card is a totally different 3-line layout — fitting it through this primitive would need a row-link helper that doesn't generalise from the other four call sites. Filing as a follow-up rather than overfitting the API on this pass.

## Test plan

- [x] `npm test` — 375 / 375 passing (existing page-level tests around the five migrated tables still cover the rendered output via the updated `extractText`).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] `npm run build` — production build succeeds.
- [ ] Manual check at 390px and at desktop widths for `/dashboard/settings`, `/dashboard/settings/pricing`, and `/dashboard/repos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)