### PR TITLE
fix(api): 401 ingest/whoami/status when caller's org was deleted (#274)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -1722,3 +1722,55 @@ describe("POST /v1/ingest — session title (#255)", () => {
     expect((rows[0].title as string).length).toBe(STRING_CAPS.title);
   });
 });
+
+// Regression coverage for #274: after Settings → Danger zone → Delete
+// organization, the cascade wipes the `users` row that held the api_key, so
+// the lookup above already fails. The org-existence guard is defense-in-depth
+// — if a future bug, partial cascade, or schema migration ever left a stale
+// `users` row pointing at a vanished org, ingest must still 401 so the local
+// daemon flips to AuthFailure and stops syncing into a dead org_id.
+describe("POST /v1/ingest — orphan key after delete-org (#274)", () => {
+  function mkReq(body: Record<string, unknown>): Request {
+    return new Request("http://localhost/v1/ingest", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer budi_orphan",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const envelope = {
+    schema_version: 1,
+    device_id: "11111111-1111-4111-8111-111111111111",
+    org_id: "org_deleted",
+    synced_at: "2026-04-15T12:00:00Z",
+    payload: { daily_rollups: [], session_summaries: [] },
+  };
+
+  it("401s when the user's org no longer exists", async () => {
+    fake.seed("orgs", []); // org was deleted
+    fake.seed("users", [
+      {
+        id: "usr_orphan",
+        org_id: "org_deleted",
+        role: "manager",
+        api_key: "budi_orphan",
+      },
+    ]);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      mkReq(envelope) as unknown as Parameters<typeof POST>[0]
+    );
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
+    // No rollup, session, or device row should have been created under the
+    // orphan org_id. The 401 must short-circuit before any write.
+    expect(fake.rows("daily_rollups")).toHaveLength(0);
+    expect(fake.rows("session_summaries")).toHaveLength(0);
+    expect(fake.rows("devices")).toHaveLength(0);
+  });
+});

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -86,6 +86,12 @@ function normalizeLabel(raw: unknown): string | null | undefined {
 /**
  * Authenticate the request via Bearer token.
  * Returns the user row or null if auth fails.
+ *
+ * #274: when `org_id` is set we double-check that the org still exists.
+ * `deleteOrganization` cascades through the `users` table, so in the normal
+ * path the api_key lookup above already fails. The org-existence guard is
+ * defense-in-depth: a partial cascade or stale user row pointing at a
+ * vanished org must not keep landing new rollups under a deleted org_id.
  */
 async function authenticateApiKey(
   supabase: ReturnType<typeof createAdminClient>,
@@ -103,6 +109,16 @@ async function authenticateApiKey(
     .single();
 
   if (error || !data) return null;
+
+  if (data.org_id) {
+    const { data: org } = await supabase
+      .from("orgs")
+      .select("id")
+      .eq("id", data.org_id)
+      .single();
+    if (!org) return null;
+  }
+
   return data;
 }
 

--- a/src/app/api/v1/ingest/status/route.test.ts
+++ b/src/app/api/v1/ingest/status/route.test.ts
@@ -111,6 +111,7 @@ const callerOrg = "org_caller";
 const callerUserId = "usr_caller";
 
 function seedCaller() {
+  fake.seed("orgs", [{ id: callerOrg, name: "Caller Org" }]);
   fake.seed("users", [
     { id: callerUserId, org_id: callerOrg, api_key: callerKey },
   ]);
@@ -207,5 +208,20 @@ describe("GET /v1/ingest/status (#182)", () => {
     const unknownBody = await unknownRes.json();
     const foreignBody = await foreignRes.json();
     expect(unknownBody).toEqual(foreignBody);
+  });
+
+  it("returns 401 when the caller's org was deleted (#274)", async () => {
+    // Defense-in-depth for the orphan-key case: a stale users row pointing
+    // at a vanished org must not keep the `status` endpoint reporting a
+    // happy watermark. The local daemon needs an unambiguous 401 to flip
+    // out of `ready` and surface a re-link prompt.
+    fake.seed("orgs", []); // org was deleted
+    fake.seed("users", [
+      { id: callerUserId, org_id: callerOrg, api_key: callerKey },
+    ]);
+
+    const res = await callStatus("dev_anything");
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
   });
 });

--- a/src/app/api/v1/ingest/status/route.ts
+++ b/src/app/api/v1/ingest/status/route.ts
@@ -56,6 +56,21 @@ export async function GET(request: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  // #274: defense-in-depth — a stale `users` row pointing at a deleted org
+  // must not keep authenticating status polls. `deleteOrganization` already
+  // wipes the user row, but a partial cascade shouldn't leak a "ready" badge
+  // from a dead org.
+  if (user.org_id) {
+    const { data: org } = await supabase
+      .from("orgs")
+      .select("id")
+      .eq("id", user.org_id)
+      .single();
+    if (!org) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
   // --- Get device_id from query param ---
   const deviceId = request.nextUrl.searchParams.get("device_id");
   if (!deviceId) {

--- a/src/app/api/v1/whoami/route.test.ts
+++ b/src/app/api/v1/whoami/route.test.ts
@@ -12,15 +12,22 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 type Row = Record<string, unknown>;
 
 class FakeSupabase {
-  private rows: Row[] = [];
+  private tables = new Map<string, Row[]>();
 
-  seed(rows: Row[]) {
-    this.rows = [...rows];
+  seed(rowsOrTable: Row[] | string, maybeRows?: Row[]) {
+    // Overloaded for backward compatibility with the original single-table
+    // form (`seed(rows)` seeded `users`). New form `seed("orgs", rows)` is
+    // used by the #274 org-existence guard tests, which need both tables.
+    if (typeof rowsOrTable === "string") {
+      this.tables.set(rowsOrTable, [...(maybeRows ?? [])]);
+    } else {
+      this.tables.set("users", [...rowsOrTable]);
+    }
   }
 
-  from(_table: string) {
-    void _table;
-    return new FakeQuery(this.rows);
+  from(table: string) {
+    if (!this.tables.has(table)) this.tables.set(table, []);
+    return new FakeQuery(this.tables.get(table)!);
   }
 
   // #179: route handler now consults `rate_limit_check` before/after auth.
@@ -67,18 +74,21 @@ vi.mock("@/lib/supabase/admin", () => ({
 }));
 
 beforeEach(() => {
-  fake.seed([]);
+  fake.seed("users", []);
+  fake.seed("orgs", []);
 });
+
+function seedUserWithOrg(user: Row, org: Row) {
+  fake.seed("users", [user]);
+  fake.seed("orgs", [org]);
+}
 
 describe("GET /v1/whoami (#541)", () => {
   it("returns the org_id for a valid budi_* key", async () => {
-    fake.seed([
-      {
-        id: "usr_test",
-        org_id: "org_xEvtA",
-        api_key: "budi_testkey",
-      },
-    ]);
+    seedUserWithOrg(
+      { id: "usr_test", org_id: "org_xEvtA", api_key: "budi_testkey" },
+      { id: "org_xEvtA", name: "Acme" }
+    );
 
     const { GET } = await import("./route");
     const req = new Request("http://localhost/v1/whoami", {
@@ -120,13 +130,10 @@ describe("GET /v1/whoami (#541)", () => {
   });
 
   it("401s when the api_key has no matching user row", async () => {
-    fake.seed([
-      {
-        id: "usr_other",
-        org_id: "org_other",
-        api_key: "budi_other",
-      },
-    ]);
+    seedUserWithOrg(
+      { id: "usr_other", org_id: "org_other", api_key: "budi_other" },
+      { id: "org_other", name: "Other" }
+    );
 
     const { GET } = await import("./route");
     const req = new Request("http://localhost/v1/whoami", {
@@ -137,16 +144,32 @@ describe("GET /v1/whoami (#541)", () => {
     expect((await res.json()).error).toBe("Unauthorized");
   });
 
+  it("401s when the user's org no longer exists (#274)", async () => {
+    // Regression: after delete-org, a stale `users` row pointing at a
+    // vanished org must not keep authenticating ingest. Even if the cascade
+    // somehow left the row behind, the org-existence guard returns 401 so
+    // the local daemon flips to `AuthFailure` and stops syncing.
+    fake.seed("users", [
+      { id: "usr_orphan", org_id: "org_deleted", api_key: "budi_orphan" },
+    ]);
+    fake.seed("orgs", []); // org was deleted
+
+    const { GET } = await import("./route");
+    const req = new Request("http://localhost/v1/whoami", {
+      headers: { authorization: "Bearer budi_orphan" },
+    });
+    const res = await GET(req as unknown as Parameters<typeof GET>[0]);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
+  });
+
   it("never echoes the api_key in the response", async () => {
     // Defense-in-depth: even an authenticated response should only
     // surface `org_id`; the key itself must never come back on the wire.
-    fake.seed([
-      {
-        id: "usr_test",
-        org_id: "org_xEvtA",
-        api_key: "budi_testkey",
-      },
-    ]);
+    seedUserWithOrg(
+      { id: "usr_test", org_id: "org_xEvtA", api_key: "budi_testkey" },
+      { id: "org_xEvtA", name: "Acme" }
+    );
 
     const { GET } = await import("./route");
     const req = new Request("http://localhost/v1/whoami", {

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -17,6 +17,12 @@ const RATE_LIMIT = { limit: 20, windowSeconds: 60 } as const;
  * Returns the user row or null if auth fails. Mirrors the shape used by
  * `/v1/ingest/route.ts::authenticateApiKey`; intentionally duplicated so
  * each endpoint stays grep-able on its own.
+ *
+ * #274: when `org_id` is set we double-check that the org still exists.
+ * `deleteOrganization` cascades through the `users` table, so in the normal
+ * path the api_key lookup above already fails. The org-existence guard is
+ * defense-in-depth: a partial cascade, future schema change, or stale row
+ * pointing at a vanished org must not keep authenticating ingest.
  */
 async function authenticateApiKey(
   supabase: ReturnType<typeof createAdminClient>,
@@ -34,6 +40,16 @@ async function authenticateApiKey(
     .single();
 
   if (error || !data) return null;
+
+  if (data.org_id) {
+    const { data: org } = await supabase
+      .from("orgs")
+      .select("id")
+      .eq("id", data.org_id)
+      .single();
+    if (!org) return null;
+  }
+
   return data;
 }
 


### PR DESCRIPTION
## Summary

Closes #274.

- Adds an org-existence guard to `/v1/whoami`, `/v1/ingest`, and `/v1/ingest/status`: after the `users.api_key` lookup, if the caller's `org_id` is set we verify the `orgs` row still exists. If it doesn't, the request 401s.
- In the normal flow, `deleteOrganization` cascades through `users` first (the api_key lives on `users`, not a separate table), so the api_key lookup already misses. The new guard is defense-in-depth: a partial cascade, future schema change, or other bug that leaves a stale user row pointing at a vanished org must still produce a 401 so the local daemon flips to `AuthFailure` and stops syncing into a dead `org_id`.
- Tests: regression coverage on all three routes plus updates to the existing whoami/status fakes to seed the `orgs` table.

## Test plan

- [x] `npm test` — 378/378 pass
- [x] `npm run lint` clean
- [ ] After deploy: `curl -H "Authorization: Bearer budi_<dead-key>" .../v1/whoami` returns 401
- [ ] After deploy: `curl -XPOST -H "Authorization: Bearer budi_<dead-key>" .../v1/ingest` returns 401 (no rollups land under the deleted `org_id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)