### PR TITLE
docs(soul): pin server-action vs route-handler convention (#279)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -100,6 +100,17 @@ All dashboard pages live under `/dashboard`:
 - `src/proxy.ts` — Next.js 16 proxy (formerly middleware): refreshes the Supabase session and gates `/dashboard/*`
 - `supabase/migrations/` — Postgres schema migrations (apply in order)
 
+## Server actions vs route handlers
+
+Picking the wrong surface for a mutation or read drifts the boundary between in-app code and the daemon contract — so we pin the rule explicitly (#279):
+
+- **RSC reads → DAL directly.** Server Components import from `src/lib/dal.ts`. No HTTP hop, no route handler, no server action.
+- **In-app form mutations → server actions in `src/app/actions/`.** Anything called from a `<form action={…}>` or button in our own pages (org/team/pricing settings, sign-out, etc.) belongs here. Re-verify the caller's role on the server — JSX gating is not a security boundary (`pricing.ts`, `org.ts`).
+- **External callers → route handlers in `src/app/api/`.** "External" means anything that is not one of our own RSCs/forms: the budi daemon, the browser-side reporting APIs, our own client-side polling code. The versioned daemon contract lives under `/api/v1/*` (`ingest`, `ingest/status`, `pricing/active`, `whoami`) — bump the major when the wire shape changes; ADR-0083 §7 in the main repo is the source of truth. Unversioned local utilities sit at `/api/<name>` (`csp-report`, `freshness`).
+- **Fixed-URL protocol callbacks are the only exception** to "route handlers live under `/api/`". Supabase's OAuth round-trip lands on `/auth/callback`, so `src/app/auth/callback/route.ts` stays where the provider expects it.
+
+If a new file would violate this rule, move it before merging — don't bend the rule to fit a special case.
+
 ## Dev notes
 
 - **Read the privacy contract before adding fields**: every new column on an ingest table must be justified against ADR-0083. If it's a prompt, a file path, an email, or a raw payload, it does not belong here — stop and push back.


### PR DESCRIPTION
Closes #279.

## Summary

Catalogs every file under `src/app/actions/` and `src/app/api/`, then writes the rule down in `SOUL.md` so future PRs don't drift the boundary between in-app code and the daemon contract.

## The rule

Added a new `## Server actions vs route handlers` section to `SOUL.md` (between **Key directories** and **Dev notes**):

- **RSC reads → DAL directly.** Server Components import from `src/lib/dal.ts`. No HTTP hop, no route handler, no server action.
- **In-app form mutations → server actions in `src/app/actions/`.** Anything called from a `<form action={…}>` or button in our own pages. Re-verify role server-side (JSX gating is not a security boundary).
- **External callers → route handlers in `src/app/api/`.** The versioned daemon contract lives under `/api/v1/*`; unversioned local utilities sit at `/api/<name>`.
- **Fixed-URL protocol callbacks** (like Supabase's `/auth/callback`) are the only allowed exception to "route handlers under `/api/`".

## Catalog

**`src/app/actions/`** — all `"use server"` files, all driven by in-app `<form>` / button callers:

| File | Purpose | Callers (in-app) |
| --- | --- | --- |
| `auth.ts` | `signOut()` | `components/user-menu.tsx` |
| `org.ts` | `createOrg`, `generateInviteToken`, `deleteOrganization`, `leaveOrganization`, `switchOrganization`, `updateMemberRole` | `setup/form.tsx`, `dashboard/settings/*`, `invite/[token]/cross-org-switch.tsx` |
| `pricing.ts` | `savePricingDefaults`, `previewPricingCsv`, `commitPricingDraft`, `activatePricingList`, `discardPricingDraft` | `dashboard/settings/pricing/*` |
| `org-cascade.ts` | exports the `ORG_CASCADE_ORDER` constant only — not itself a server action file (`"use server"` modules can only export async functions); lives here so the test can pin the SQL function order from one place | `actions/org.ts`, `actions/org.test.ts` |

**`src/app/api/`** — all route handlers, all hit by external (non-RSC) callers:

| Path | Purpose | Caller |
| --- | --- | --- |
| `POST /api/csp-report` | CSP violation report sink (#180) | browser Reporting API |
| `GET /api/freshness` | dashboard header polls `lastRollupAt` (#133/#179) | our own client-side polling |
| `POST /api/v1/ingest` | sync envelope receiver (ADR-0083 §7) | budi daemon |
| `GET /api/v1/ingest/status` | watermark + record counts | budi daemon |
| `GET /api/v1/pricing/active` | per-org active price list (#234) | budi daemon |
| `GET /api/v1/whoami` | bootstrap for `budi cloud init` (#179) | budi daemon / CLI |

**Exception** (called out in the new section):

| Path | Why it's not under `/api/` |
| --- | --- |
| `GET /auth/callback` | Supabase OAuth registers this exact URL with the IdP — moving it would break sign-in |

## Violations

**None.** Every existing `"use server"` file and every existing route handler already lines up with the rule. No follow-up tickets needed — if that changes, the rule explicitly says to move the file before merging.

## Test plan

- [x] `npm run format:check`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] no code touched, docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)