### PR TITLE
tests(lib): cover untested src/lib/* utilities

### DIFF
--- a/src/lib/cost-lens.test.ts
+++ b/src/lib/cost-lens.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  COST_LENSES,
+  COST_LENS_STORAGE_KEY,
+  DEFAULT_COST_LENS,
+  parseCostLens,
+} from "./cost-lens";
+
+/**
+ * #282: lock in the `?lens=` parser contract. The Overview cost chart reads
+ * this on every render, and a regression that flips the fallback from
+ * `effective` → `list` (or vice-versa) would silently change which column
+ * the chart draws for every viewer who lands without a query string.
+ */
+
+describe("parseCostLens", () => {
+  it('returns "list" only for the exact literal', () => {
+    expect(parseCostLens("list")).toBe("list");
+  });
+
+  it('returns "effective" for the matching literal', () => {
+    expect(parseCostLens("effective")).toBe("effective");
+  });
+
+  it("falls back to the default for missing/empty input", () => {
+    expect(parseCostLens(null)).toBe(DEFAULT_COST_LENS);
+    expect(parseCostLens(undefined)).toBe(DEFAULT_COST_LENS);
+    expect(parseCostLens("")).toBe(DEFAULT_COST_LENS);
+  });
+
+  it("falls back to the default for unknown values without throwing", () => {
+    expect(parseCostLens("garbage")).toBe(DEFAULT_COST_LENS);
+    expect(parseCostLens("LIST")).toBe(DEFAULT_COST_LENS);
+    expect(parseCostLens(" list ")).toBe(DEFAULT_COST_LENS);
+  });
+});
+
+describe("cost-lens constants", () => {
+  it("exposes both lenses with the wire values the parser accepts", () => {
+    expect(COST_LENSES.map((l) => l.value).sort()).toEqual([
+      "effective",
+      "list",
+    ]);
+  });
+
+  it("uses a namespaced storage key so it never collides with another widget", () => {
+    expect(COST_LENS_STORAGE_KEY).toMatch(/^budi\./);
+  });
+
+  it("defaults to the effective column the rest of the dashboard reads", () => {
+    expect(DEFAULT_COST_LENS).toBe("effective");
+  });
+});

--- a/src/lib/periods.test.ts
+++ b/src/lib/periods.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { ALL_PERIOD_VALUE, DEFAULT_PERIOD_DAYS, PERIODS } from "./periods";
+
+/**
+ * #282: keep the shared `?days=` contract honest. The dashboard, the
+ * statusline, and any future server-side selector all read this list, so
+ * accidentally reordering it or dropping `All` would shuffle the chip row
+ * for every viewer.
+ */
+
+describe("periods contract", () => {
+  it("exposes 1d / 7d / 30d / All in that left-to-right order", () => {
+    expect(PERIODS.map((p) => p.value)).toEqual(["1", "7", "30", "all"]);
+    expect(PERIODS.map((p) => p.label)).toEqual(["1d", "7d", "30d", "All"]);
+  });
+
+  it("uses the documented sentinel for the lifetime window", () => {
+    expect(ALL_PERIOD_VALUE).toBe("all");
+    expect(PERIODS.at(-1)?.value).toBe(ALL_PERIOD_VALUE);
+  });
+
+  it("defaults to 7 days — matches the local `budi stats` landing window", () => {
+    expect(DEFAULT_PERIOD_DAYS).toBe(7);
+    expect(PERIODS.some((p) => p.value === String(DEFAULT_PERIOD_DAYS))).toBe(
+      true
+    );
+  });
+});

--- a/src/lib/supabase/admin.test.ts
+++ b/src/lib/supabase/admin.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * #282: pin the service-role client contract. The ingest path + admin
+ * actions go through this factory, and a regression that silently keeps
+ * the auth-refresh timer alive would leak handles in every serverless
+ * invocation. We mock `@supabase/supabase-js` so the test never spins up a
+ * real client (and never touches the network).
+ */
+
+const createClient = vi.fn();
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: unknown[]) => {
+    createClient(...args);
+    return { __mock: true };
+  },
+}));
+
+beforeEach(() => {
+  createClient.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+});
+
+describe("createAdminClient", () => {
+  it("forwards the URL + service-role key with autoRefresh disabled", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-secret";
+
+    const { createAdminClient } = await import("./admin");
+    createAdminClient();
+
+    expect(createClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "service-role-secret",
+      { auth: { autoRefreshToken: false, persistSession: false } }
+    );
+  });
+
+  it("throws when the URL env var is missing", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-secret";
+    const { createAdminClient } = await import("./admin");
+    expect(() => createAdminClient()).toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
+  });
+
+  it("throws when the service-role key is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    const { createAdminClient } = await import("./admin");
+    expect(() => createAdminClient()).toThrow(/SUPABASE_SERVICE_ROLE_KEY/);
+  });
+});

--- a/src/lib/supabase/client.test.ts
+++ b/src/lib/supabase/client.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * #282: pin the browser-side factory contract. Every "use client" component
+ * that needs a fresh, RLS-respecting client goes through this — a regression
+ * that silently swallowed the missing-env guard would surface as a confusing
+ * runtime error inside an event handler instead of at boot.
+ */
+
+const createBrowserClient = vi.fn();
+
+vi.mock("@supabase/ssr", () => ({
+  createBrowserClient: (...args: unknown[]) => {
+    createBrowserClient(...args);
+    return { __mock: true };
+  },
+}));
+
+beforeEach(() => {
+  createBrowserClient.mockClear();
+});
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+});
+
+describe("createClient (browser)", () => {
+  it("forwards the URL + anon key to @supabase/ssr", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+
+    const { createClient } = await import("./client");
+    createClient();
+
+    expect(createBrowserClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "anon-key"
+    );
+  });
+
+  it("throws when the URL env var is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    const { createClient } = await import("./client");
+    expect(() => createClient()).toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
+  });
+
+  it("throws when the anon key env var is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    const { createClient } = await import("./client");
+    expect(() => createClient()).toThrow(/NEXT_PUBLIC_SUPABASE_ANON_KEY/);
+  });
+});

--- a/src/lib/supabase/server.test.ts
+++ b/src/lib/supabase/server.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * #282: pin the server-side factory contract — including the cookie-bridge
+ * wiring that `@supabase/ssr` uses to refresh sessions on the proxy. A
+ * regression here would either drop refreshed cookies on the floor (silent
+ * sign-out) or throw inside Server Components where `cookies().set()` isn't
+ * allowed (the `try { … } catch {}` guard exists for that case).
+ */
+
+const createServerClient = vi.fn();
+const cookieStore: Array<{
+  name: string;
+  value: string;
+  options?: unknown;
+}> = [];
+
+vi.mock("@supabase/ssr", () => ({
+  createServerClient: (url: string, key: string, init: unknown) => {
+    createServerClient(url, key, init);
+    return { __mock: true };
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    getAll() {
+      return cookieStore.map((c) => ({ name: c.name, value: c.value }));
+    },
+    set(name: string, value: string, options?: unknown) {
+      cookieStore.push({ name, value, options });
+    },
+  }),
+}));
+
+beforeEach(() => {
+  createServerClient.mockClear();
+  cookieStore.length = 0;
+});
+
+afterEach(() => {
+  delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+  delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+});
+
+describe("createClient (server)", () => {
+  it("forwards the URL + anon key and a cookies bridge", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    cookieStore.push({ name: "sb-access-token", value: "abc" });
+
+    const { createClient } = await import("./server");
+    await createClient();
+
+    expect(createServerClient).toHaveBeenCalledTimes(1);
+    const call = createServerClient.mock.calls[0]!;
+    const [url, key, init] = call as [string, string, { cookies: unknown }];
+    expect(url).toBe("https://example.supabase.co");
+    expect(key).toBe("anon-key");
+    expect(init.cookies).toMatchObject({
+      getAll: expect.any(Function),
+      setAll: expect.any(Function),
+    });
+  });
+
+  it("getAll() returns the current request cookies", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    cookieStore.push({ name: "sb-access-token", value: "abc" });
+
+    const { createClient } = await import("./server");
+    await createClient();
+
+    const init = createServerClient.mock.calls[0]![2] as {
+      cookies: { getAll: () => Array<{ name: string; value: string }> };
+    };
+    expect(init.cookies.getAll()).toEqual([
+      { name: "sb-access-token", value: "abc" },
+    ]);
+  });
+
+  it("setAll() forwards refreshed cookies into the Next.js cookie store", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+
+    const { createClient } = await import("./server");
+    await createClient();
+
+    const init = createServerClient.mock.calls[0]![2] as {
+      cookies: {
+        setAll: (
+          xs: Array<{ name: string; value: string; options: unknown }>
+        ) => void;
+      };
+    };
+    init.cookies.setAll([
+      { name: "sb-access-token", value: "fresh", options: { httpOnly: true } },
+    ]);
+    expect(cookieStore).toContainEqual({
+      name: "sb-access-token",
+      value: "fresh",
+      options: { httpOnly: true },
+    });
+  });
+
+  it("setAll() swallows the Server-Component write error so reads don't crash", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+
+    // Re-import with a cookies mock whose `set` throws — mimics calling the
+    // factory from a Server Component context, where the proxy is expected
+    // to handle session refresh instead.
+    vi.resetModules();
+    vi.doMock("next/headers", () => ({
+      cookies: async () => ({
+        getAll() {
+          return [];
+        },
+        set() {
+          throw new Error("Cookies cannot be set in a Server Component");
+        },
+      }),
+    }));
+
+    const { createClient } = await import("./server");
+    await createClient();
+
+    const init = createServerClient.mock.calls.at(-1)![2] as {
+      cookies: {
+        setAll: (
+          xs: Array<{ name: string; value: string; options: unknown }>
+        ) => void;
+      };
+    };
+    expect(() =>
+      init.cookies.setAll([
+        { name: "sb-access-token", value: "fresh", options: {} },
+      ])
+    ).not.toThrow();
+
+    vi.doUnmock("next/headers");
+  });
+
+  it("throws when the URL env var is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "anon-key";
+    const { createClient } = await import("./server");
+    await expect(createClient()).rejects.toThrow(/NEXT_PUBLIC_SUPABASE_URL/);
+  });
+
+  it("throws when the anon key env var is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    const { createClient } = await import("./server");
+    await expect(createClient()).rejects.toThrow(
+      /NEXT_PUBLIC_SUPABASE_ANON_KEY/
+    );
+  });
+});

--- a/src/lib/timezone.test.ts
+++ b/src/lib/timezone.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidTimeZone,
+  localDateInTimeZone,
+  utcBucketDayForLocalEnd,
+  utcBucketDayForLocalStart,
+  utcInstantForLocalEnd,
+  utcInstantForLocalStart,
+} from "./timezone";
+
+/**
+ * #282: cover the bucket-bound math that the cloud dashboard relies on to
+ * keep `?days=1` in sync with the user's wall-clock day. Regressing any of
+ * these helpers reintroduces the `bucket_day` drift fixed in #78 — silently
+ * dropping evening-local activity from the lifetime view.
+ */
+
+describe("isValidTimeZone", () => {
+  it("accepts well-known IANA zones", () => {
+    expect(isValidTimeZone("UTC")).toBe(true);
+    expect(isValidTimeZone("America/Los_Angeles")).toBe(true);
+    expect(isValidTimeZone("Asia/Tokyo")).toBe(true);
+  });
+
+  it("rejects empty / non-string / unknown values without throwing", () => {
+    expect(isValidTimeZone("")).toBe(false);
+    expect(isValidTimeZone("Not/A/Zone")).toBe(false);
+    // Cookie tampering: defensively coerced inputs must not crash.
+    expect(isValidTimeZone(undefined as unknown as string)).toBe(false);
+    expect(isValidTimeZone(null as unknown as string)).toBe(false);
+    expect(isValidTimeZone(123 as unknown as string)).toBe(false);
+  });
+});
+
+describe("localDateInTimeZone", () => {
+  it("formats the instant as the local calendar date", () => {
+    // Mid-day UTC: every zone agrees on the calendar date.
+    const instant = new Date("2024-01-15T12:00:00Z");
+    expect(localDateInTimeZone(instant, "UTC")).toBe("2024-01-15");
+    expect(localDateInTimeZone(instant, "America/Los_Angeles")).toBe(
+      "2024-01-15"
+    );
+    expect(localDateInTimeZone(instant, "Asia/Tokyo")).toBe("2024-01-15");
+  });
+
+  it("rolls back across the date boundary for zones west of UTC", () => {
+    // 03:00 UTC on the 15th is still 19:00 on the 14th in LA (PST).
+    const instant = new Date("2024-01-15T03:00:00Z");
+    expect(localDateInTimeZone(instant, "America/Los_Angeles")).toBe(
+      "2024-01-14"
+    );
+  });
+});
+
+describe("utcBucketDayForLocalStart", () => {
+  it("returns the same calendar date for UTC viewers", () => {
+    expect(utcBucketDayForLocalStart("2024-01-15", "UTC")).toBe("2024-01-15");
+  });
+
+  it("returns the same date for west-of-UTC zones (00:00 local is still that date in UTC)", () => {
+    // LA 2024-01-15 00:00 PST = 2024-01-15 08:00 UTC → bucket day 2024-01-15.
+    expect(utcBucketDayForLocalStart("2024-01-15", "America/Los_Angeles")).toBe(
+      "2024-01-15"
+    );
+  });
+
+  it("rolls back a day for east-of-UTC zones (00:00 local is the previous UTC day)", () => {
+    // Tokyo 2024-01-15 00:00 JST = 2024-01-14 15:00 UTC → bucket day 2024-01-14.
+    expect(utcBucketDayForLocalStart("2024-01-15", "Asia/Tokyo")).toBe(
+      "2024-01-14"
+    );
+  });
+
+  it("handles DST spring-forward without dropping a bucket", () => {
+    // 2024-03-10 is the US spring-forward; the day before is PST, the day
+    // after is PDT. Both must still resolve to a sane UTC bucket date.
+    expect(utcBucketDayForLocalStart("2024-03-09", "America/Los_Angeles")).toBe(
+      "2024-03-09"
+    );
+    expect(utcBucketDayForLocalStart("2024-03-11", "America/Los_Angeles")).toBe(
+      "2024-03-11"
+    );
+  });
+});
+
+describe("utcBucketDayForLocalEnd", () => {
+  it("returns the same date for UTC viewers", () => {
+    expect(utcBucketDayForLocalEnd("2024-01-15", "UTC")).toBe("2024-01-15");
+  });
+
+  it("rolls forward a day for west-of-UTC zones — the #78 case", () => {
+    // LA 2024-01-15 23:59:59.999 PST = 2024-01-16 07:59:59.999 UTC. Without
+    // this widening, the daemon's UTC-bucketed evening activity would fall
+    // outside `?days=1` for everyone west of UTC.
+    expect(utcBucketDayForLocalEnd("2024-01-15", "America/Los_Angeles")).toBe(
+      "2024-01-16"
+    );
+  });
+
+  it("returns the same date for east-of-UTC zones (23:59 local is still that date in UTC)", () => {
+    // Tokyo 2024-01-15 23:59:59.999 JST = 2024-01-15 14:59:59.999 UTC.
+    expect(utcBucketDayForLocalEnd("2024-01-15", "Asia/Tokyo")).toBe(
+      "2024-01-15"
+    );
+  });
+});
+
+describe("utcInstant helpers", () => {
+  it("anchor the start of the local day at 00:00:00.000 UTC", () => {
+    expect(utcInstantForLocalStart("2024-01-15", "UTC")).toBe(
+      "2024-01-15T00:00:00.000Z"
+    );
+    // LA midnight PST is 08:00 UTC.
+    expect(utcInstantForLocalStart("2024-01-15", "America/Los_Angeles")).toBe(
+      "2024-01-15T08:00:00.000Z"
+    );
+  });
+
+  it("anchor the end of the local day at 23:59:59.999 UTC", () => {
+    expect(utcInstantForLocalEnd("2024-01-15", "UTC")).toBe(
+      "2024-01-15T23:59:59.999Z"
+    );
+    // LA 23:59:59.999 PST is 07:59:59.999 UTC the next day.
+    expect(utcInstantForLocalEnd("2024-01-15", "America/Los_Angeles")).toBe(
+      "2024-01-16T07:59:59.999Z"
+    );
+  });
+
+  it("preserves the milliseconds component across the offset round-trip", () => {
+    // Regression guard for the `.999 → .998` floor mentioned in the source
+    // comment — the sec-aligned offset must not steal precision from the
+    // upper bound passed to session_summaries queries.
+    expect(utcInstantForLocalEnd("2024-01-15", "UTC")).toMatch(/\.999Z$/);
+    expect(utcInstantForLocalEnd("2024-01-15", "America/Los_Angeles")).toMatch(
+      /\.999Z$/
+    );
+  });
+});

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_UNIT, UNITS, UNITS_STORAGE_KEY, parseUnit } from "./units";
+
+/**
+ * #282: pin the `?units=` parser contract. The Overview / Repos / Team
+ * charts all read this on every render, and a regression that quietly
+ * flips the fallback would change every dollar axis on a no-query-string
+ * URL into a tokens axis (or vice versa).
+ */
+
+describe("parseUnit", () => {
+  it('returns "tokens" only for the exact literal', () => {
+    expect(parseUnit("tokens")).toBe("tokens");
+  });
+
+  it('returns "dollars" for the matching literal', () => {
+    expect(parseUnit("dollars")).toBe("dollars");
+  });
+
+  it("falls back to the default for missing/empty input", () => {
+    expect(parseUnit(null)).toBe(DEFAULT_UNIT);
+    expect(parseUnit(undefined)).toBe(DEFAULT_UNIT);
+    expect(parseUnit("")).toBe(DEFAULT_UNIT);
+  });
+
+  it("falls back to the default for unknown values without throwing", () => {
+    expect(parseUnit("euros")).toBe(DEFAULT_UNIT);
+    expect(parseUnit("TOKENS")).toBe(DEFAULT_UNIT);
+    expect(parseUnit(" tokens")).toBe(DEFAULT_UNIT);
+  });
+});
+
+describe("units constants", () => {
+  it("exposes both units with the wire values the parser accepts", () => {
+    expect(UNITS.map((u) => u.value).sort()).toEqual(["dollars", "tokens"]);
+  });
+
+  it("uses a namespaced storage key so it never collides with another widget", () => {
+    expect(UNITS_STORAGE_KEY).toMatch(/^budi\./);
+  });
+
+  it("defaults to dollars — the finance lens most viewers land on", () => {
+    expect(DEFAULT_UNIT).toBe("dollars");
+  });
+});

--- a/src/lib/use-media-query.test.ts
+++ b/src/lib/use-media-query.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #282: smoke test the `useMediaQuery` wiring without pulling in a DOM
+ * environment. The hook is small enough that mocking React's `useState` /
+ * `useEffect` exercises the contract that matters:
+ *
+ *   - it subscribes to `window.matchMedia(query)` once per query
+ *   - it pushes the initial `mql.matches` value through the setter
+ *   - it registers (and cleans up) a `change` listener
+ *
+ * Vitest runs in the `node` environment per `vitest.config.ts`, so we
+ * synthesize a `window.matchMedia` and mock `react` rather than installing
+ * `jsdom` / `happy-dom` for one hook.
+ */
+
+const setStateCalls: unknown[] = [];
+const effectCleanups: Array<() => void> = [];
+
+vi.mock("react", () => ({
+  useState<T>(initial: T) {
+    return [initial, (v: unknown) => setStateCalls.push(v)] as const;
+  },
+  useEffect(fn: () => void | (() => void)) {
+    const cleanup = fn();
+    if (typeof cleanup === "function") effectCleanups.push(cleanup);
+  },
+}));
+
+type Listener = () => void;
+
+function installMatchMedia(matches: boolean) {
+  const listeners: Listener[] = [];
+  const mql = {
+    matches,
+    addEventListener: vi.fn((_evt: string, cb: Listener) => listeners.push(cb)),
+    removeEventListener: vi.fn((_evt: string, cb: Listener) => {
+      const i = listeners.indexOf(cb);
+      if (i >= 0) listeners.splice(i, 1);
+    }),
+  };
+  const matchMedia = vi.fn((query: string) => {
+    void query;
+    return mql;
+  });
+  // The hook touches `window.matchMedia`. We attach to globalThis so the
+  // import-time `"use client"` directive is the only thing standing between
+  // this node-env test and the real browser API.
+  (
+    globalThis as unknown as { window: { matchMedia: typeof matchMedia } }
+  ).window = { matchMedia };
+  return { mql, matchMedia, listeners };
+}
+
+beforeEach(() => {
+  setStateCalls.length = 0;
+  effectCleanups.length = 0;
+});
+
+describe("useMediaQuery", () => {
+  it("queries matchMedia with the provided string and pushes the initial value", async () => {
+    const { matchMedia, mql } = installMatchMedia(true);
+    const { useMediaQuery } = await import("./use-media-query");
+
+    const initial = useMediaQuery("(min-width: 768px)");
+
+    // First render is SSR-safe — returns `false` until the effect runs.
+    expect(initial).toBe(false);
+    expect(matchMedia).toHaveBeenCalledWith("(min-width: 768px)");
+    // The effect pushed the real value through the setter.
+    expect(setStateCalls).toContain(true);
+    expect(mql.addEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function)
+    );
+  });
+
+  it("re-syncs when the media query starts unmatched", async () => {
+    const { matchMedia } = installMatchMedia(false);
+    const { useMediaQuery } = await import("./use-media-query");
+
+    useMediaQuery("(max-width: 480px)");
+
+    expect(matchMedia).toHaveBeenCalledWith("(max-width: 480px)");
+    expect(setStateCalls).toContain(false);
+  });
+
+  it("returns a cleanup that removes the change listener", async () => {
+    const { mql } = installMatchMedia(true);
+    const { useMediaQuery } = await import("./use-media-query");
+
+    useMediaQuery("(prefers-reduced-motion: reduce)");
+
+    expect(effectCleanups).toHaveLength(1);
+    effectCleanups[0]!();
+    expect(mql.removeEventListener).toHaveBeenCalledWith(
+      "change",
+      expect.any(Function)
+    );
+  });
+});

--- a/src/lib/viewer-timezone.test.ts
+++ b/src/lib/viewer-timezone.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #282: lock in the viewer-timezone cookie contract. The dashboard pages
+ * call `getViewerTimeZone()` before composing the date-range filter, so a
+ * regression that silently treats an invalid cookie as "trusted" would
+ * reintroduce the #78 bucket-drift across the entire dashboard.
+ *
+ * `next/headers` is server-only, so we mock the cookies adapter and import
+ * the module lazily inside each test (matches the csp.test.ts pattern).
+ */
+
+const cookieStore = new Map<string, string>();
+
+// `viewer-timezone` declares `import "server-only"`, which Next.js ships as
+// an empty CJS module at runtime but isn't resolvable from a plain vitest
+// process. The mock keeps the import a no-op.
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/headers", () => ({
+  cookies: async () => ({
+    get(name: string) {
+      const value = cookieStore.get(name);
+      return value === undefined ? undefined : { name, value };
+    },
+  }),
+}));
+
+beforeEach(() => {
+  cookieStore.clear();
+});
+
+describe("getViewerTimeZone", () => {
+  it("returns the cookie value when it is a real IANA zone", async () => {
+    cookieStore.set("budi_tz", "America/Los_Angeles");
+    const { getViewerTimeZone } = await import("./viewer-timezone");
+    await expect(getViewerTimeZone()).resolves.toBe("America/Los_Angeles");
+  });
+
+  it("returns null when the cookie is missing — callers then fall back to UTC", async () => {
+    const { getViewerTimeZone } = await import("./viewer-timezone");
+    await expect(getViewerTimeZone()).resolves.toBeNull();
+  });
+
+  it("returns null when the cookie is present but not a valid zone", async () => {
+    // Defense against cookie tampering / a stale value from a runtime that
+    // accepted a zone our current runtime no longer knows.
+    cookieStore.set("budi_tz", "Not/A/Zone");
+    const { getViewerTimeZone } = await import("./viewer-timezone");
+    await expect(getViewerTimeZone()).resolves.toBeNull();
+  });
+
+  it("returns null when the cookie value is empty", async () => {
+    cookieStore.set("budi_tz", "");
+    const { getViewerTimeZone } = await import("./viewer-timezone");
+    await expect(getViewerTimeZone()).resolves.toBeNull();
+  });
+});
+
+describe("TIMEZONE_COOKIE", () => {
+  it("matches the name the browser-side <TimeZoneSync /> writes", async () => {
+    const { TIMEZONE_COOKIE } = await import("./viewer-timezone");
+    expect(TIMEZONE_COOKIE).toBe("budi_tz");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,10 +21,10 @@ export default defineConfig({
       // belongs to #290. The floor is rounded down from the measured baseline so trivial fluctuation
       // doesn't flake CI.
       thresholds: {
-        lines: 59,
-        statements: 57,
-        functions: 52,
-        branches: 51,
+        lines: 60,
+        statements: 58,
+        functions: 53,
+        branches: 52,
       },
     },
   },


### PR DESCRIPTION
## Summary
- Adds happy-path + edge-case tests for every `src/lib/*` module that lacked a companion `.test.ts`: `cost-lens`, `periods`, `timezone`, `units`, `use-media-query`, `viewer-timezone`, and the three `supabase/` clients. Each test file pairs with exactly one source file per the convention from #281.
- `useMediaQuery` is tested in the node environment by mocking `react`'s `useState`/`useEffect`, so the PR doesn't pull in jsdom/happy-dom for a single hook — matches the existing "no `@testing-library/react`" stance in `surface-filter.test.tsx`.
- Ratchets the #281 coverage floor since every dimension rose: lines 59→60, statements 57→58, functions 52→53, branches 51→52. The ratchet-only policy stays documented in `vitest.config.ts`.

| Dimension | Before | After |
|---|---|---|
| Statements | 57% | 58.28% |
| Branches | 51% | 52.34% |
| Functions | 52% | 53.67% |
| Lines | 59% | 60.3% |

Closes #282.

## Test plan
- [x] `npm test` — 431 tests pass (was 380)
- [x] `npm run test:coverage` — all four thresholds clear the new floor
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)