### PR TITLE
docs(soul): reconcile pages list and DAL path with current code (#285)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -79,10 +79,11 @@ All dashboard pages live under `/dashboard`:
 
 - `/dashboard` — org-wide Overview (totals, trends, daily activity)
 - `/dashboard/team` — per-member spend (managers see the full org; members see only their own row)
+- `/dashboard/devices` — per-device fleet view (counts, cost-per-device)
 - `/dashboard/models` — breakdown by model / provider
 - `/dashboard/repos` — breakdown by repo / branch / ticket
-- `/dashboard/sessions` — session list with health signals
-- `/dashboard/settings` — org info, the viewer's API key, members list, and (managers) invite link generation
+- `/dashboard/sessions` — session list with health signals; `/dashboard/sessions/[id]` for a single-session drill-down
+- `/dashboard/settings` — org info, the viewer's API key, members list, and (managers) invite link generation; nested `/dashboard/settings/pricing` for the org's price-list overrides
 
 ## Window contract and local→cloud linking
 
@@ -100,7 +101,7 @@ All dashboard pages live under `/dashboard`:
 - `src/components/layout/` — dashboard chrome (sidebar, user menu, sync freshness, timezone sync)
 - `src/components/charts/` — chart primitives reused across surfaces (`cost-bar-chart`)
 - `src/components/ui/` — generic primitives (card)
-- `src/lib/dal.ts` — data access layer; every dashboard query routes through here
+- `src/lib/dal/` — data access layer split by domain (`overview.ts`, `team.ts`, `devices.ts`, `models.ts`, `repos.ts`, `sessions.ts`, `pricing.ts`, `sync.ts`, `user.ts`, `surfaces.ts`, `types.ts`); re-exports from `index.ts`. Every dashboard query routes through here — import `from "@/lib/dal"`
 - `src/lib/supabase/` — Supabase clients (anon, server, admin/service-role)
 - `src/proxy.ts` — Next.js 16 proxy (formerly middleware): refreshes the Supabase session and gates `/dashboard/*`
 - `supabase/migrations/` — Postgres schema migrations (apply in order)


### PR DESCRIPTION
Closes #285.

## Summary

Walked every header in `SOUL.md` against the current code and fixed two pieces of drift. `AGENTS.md` and `CLAUDE.md` already point at `SOUL.md` as canonical, so no change needed there.

### Audit results — what was checked vs the code

| `SOUL.md` claim | Status | Notes |
| --- | --- | --- |
| \"This repo is the optional, opt-in cloud layer\" | ✅ current | matches `README.md` framing |
| `npm ci` / `npm run dev` / `npm test` / `npm run lint` etc. | ✅ current | scripts in `package.json` |
| Data the cloud receives (token counts, model names, hashed repo ids, branch names, ticket ids, session durations) | ✅ current | matches `src/app/api/v1/ingest/rows.ts` and ADR-0083 |
| Transport: HTTPS only / push-only / idempotent / watermark / Bearer auth | ✅ current | matches `src/app/api/v1/ingest/route.ts` (Bearer `budi_<key>`, UPSERTs, idempotent retries) |
| Team model (manager/member, daily, 90d, single-org, no SSO) | ✅ current | matches `README.md` |
| Ingest API: `POST /v1/ingest` returns 200/401/422/429/5xx | ✅ current | matches `route.ts` returns: 200, 401 (line 193, 230, 294), 422 (line 223), 429 (line 262) |
| `GET /v1/ingest/status?device_id=…` | ✅ current | `src/app/api/v1/ingest/status/` exists |
| Pages list | ❌ **drift** | missing `/dashboard/devices`, the `/dashboard/sessions/[id]` drill-down, and the `/dashboard/settings/pricing` nested page |
| Window contract: `1d`/`7d`/`30d`/`All`, `src/lib/periods.ts` | ✅ current | file exists |
| Local→cloud linking: `getSyncFreshness`, `LinkDaemonBanner`, `FirstSyncInProgressBanner` | ✅ current | grep confirms all three symbols live where SOUL says |
| Key directories | ❌ **drift** | `src/lib/dal.ts` is now a directory (`src/lib/dal/`) split by domain in #278 |
| \"Where do new components go?\" rule referencing `device-count-chart` | ✅ current | lives at `src/app/dashboard/devices/_components/device-count-chart.tsx` |
| `src/proxy.ts` (formerly middleware) | ✅ current | file exists; no `src/middleware.ts` |
| Migration policy / required GH Actions secrets / `.github/workflows/{ci,db-push}.yml` | ✅ current | both workflows present |
| `getVisibleDeviceIds` is the manager/member scoping helper | ✅ current | defined in `src/lib/dal/devices.ts` |
| ADR-0083 / ADR-0086 / ADR-0088 links | ✅ current | URLs unchanged in the main repo |

### Corrections in this PR

1. **Pages list** — added `/dashboard/devices`, called out the `/dashboard/sessions/[id]` drill-down, and noted the nested `/dashboard/settings/pricing`.
2. **Key directories** — changed `src/lib/dal.ts` to `src/lib/dal/` and listed the per-domain modules, with the import path (`@/lib/dal`) so the rule \"every dashboard query routes through here\" still has a single canonical answer.

### What I did not touch

- `README.md` — also missing \"Devices\" in its page list, but the ticket scope is SOUL/AGENTS/CLAUDE. Filing a follow-up if requested.
- The `// (see getSyncFreshness in dal.ts)` comment in `src/components/layout/sync-freshness.tsx` — out of scope for a docs PR; milestone rule is one concern per PR.
- `AGENTS.md` / `CLAUDE.md` — already 5-line pointers to `SOUL.md`; no reconciliation needed.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] Docs-only diff; behavior preserved (no test files modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)