### PR TITLE
chore: prune unused exports flagged by knip (#287)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreDependencies": ["server-only"]
+}

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -45,7 +45,7 @@ export interface IngestDailyRollup {
  * when neither field is present so the validator surfaces the missing-field
  * 422 the same way it did before.
  */
-export function rollupIngestedCents(r: IngestDailyRollup): number | undefined {
+function rollupIngestedCents(r: IngestDailyRollup): number | undefined {
   if (r.cost_cents_ingested !== undefined) return r.cost_cents_ingested;
   return r.cost_cents;
 }
@@ -55,7 +55,7 @@ export function rollupIngestedCents(r: IngestDailyRollup): number | undefined {
  * explicitly; v1 envelopes only know about `cost_cents`, which by ADR-0094
  * §1 is identical to `_ingested` until a team price list rewrites it.
  */
-export function rollupEffectiveCents(r: IngestDailyRollup): number | undefined {
+function rollupEffectiveCents(r: IngestDailyRollup): number | undefined {
   if (r.cost_cents_effective !== undefined) return r.cost_cents_effective;
   return rollupIngestedCents(r);
 }
@@ -118,7 +118,7 @@ export const METRIC_CAPS = {
  * NaN/-Infinity/negative value triggers a 422 — that's the daemon-pause
  * signal documented in ADR-0083 §7 — rather than landing as a silent zero.
  */
-export function isValidNonNegativeNumber(raw: unknown): raw is number {
+function isValidNonNegativeNumber(raw: unknown): raw is number {
   return typeof raw === "number" && Number.isFinite(raw) && raw >= 0;
 }
 

--- a/src/app/dashboard/settings/pricing/audit-history-table.tsx
+++ b/src/app/dashboard/settings/pricing/audit-history-table.tsx
@@ -24,7 +24,7 @@ export const PAGE_SIZE = 50;
  * the recalc engine actually writes (#728 — `running` while in-flight,
  * `succeeded` on commit) plus `failed` as a forward-looking option so a
  * future change to the engine doesn't require revisiting this UI. */
-export const STATUS_FILTER_OPTIONS = [
+const STATUS_FILTER_OPTIONS = [
   "all",
   "running",
   "succeeded",

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -176,28 +176,3 @@ export function deviceLabel(
   return `device ${suffix || id}`;
 }
 
-/**
- * Coarse "X ago" string for server-rendered last-seen timestamps. Deliberately
- * low-precision (minute granularity, no ticking) — the dashboard layout is
- * `force-dynamic` so each page load recomputes against a fresh `Date.now()`.
- */
-export function fmtRelative(
-  iso: string | null,
-  now: number = Date.now()
-): string {
-  if (!iso) return "never";
-  const diff = Math.max(0, now - Date.parse(iso));
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return "just now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  if (d < 7) return `${d}d ago`;
-  const w = Math.floor(d / 7);
-  if (w < 5) return `${w}w ago`;
-  const mo = Math.floor(d / 30);
-  if (mo < 12) return `${mo}mo ago`;
-  return `${Math.floor(d / 365)}y ago`;
-}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -175,4 +175,3 @@ export function deviceLabel(
   const suffix = id.replace(/^dev_/, "").slice(0, 8);
   return `device ${suffix || id}`;
 }
-

--- a/src/lib/pricing-csv.ts
+++ b/src/lib/pricing-csv.ts
@@ -21,9 +21,9 @@
  * database round-trip.
  */
 
-export type TokenType = "input" | "output" | "cache_read" | "cache_write";
+type TokenType = "input" | "output" | "cache_read" | "cache_write";
 
-export type ParsedPriceRow = {
+type ParsedPriceRow = {
   /** 1-indexed row number in the source file (header is row 1). */
   lineNumber: number;
   platform: string;
@@ -38,7 +38,7 @@ export type ParsedPriceRow = {
   raw: Record<string, string>;
 };
 
-export type ParseError = {
+type ParseError = {
   lineNumber: number;
   message: string;
 };


### PR DESCRIPTION
Closes #287.

## Initial `npx knip` report (raw)

```
Unlisted dependencies (12)
server-only  src/lib/dal/devices.ts:1:8
server-only  src/lib/dal/models.ts:1:8
server-only  src/lib/dal/overview.ts:1:8
server-only  src/lib/dal/pricing.ts:1:8
server-only  src/lib/dal/repos.ts:1:8
server-only  src/lib/dal/sessions.ts:1:8
server-only  src/lib/dal/surfaces.ts:1:8
server-only  src/lib/dal/sync.ts:1:8
server-only  src/lib/dal/team.ts:1:8
server-only  src/lib/dal/types.ts:1:8
server-only  src/lib/dal/user.ts:1:8
server-only  src/lib/viewer-timezone.ts:1:8

Unused exports (5)
rollupIngestedCents       function  src/app/api/v1/ingest/rows.ts:48:17
rollupEffectiveCents      function  src/app/api/v1/ingest/rows.ts:58:17
isValidNonNegativeNumber  function  src/app/api/v1/ingest/rows.ts:121:17
STATUS_FILTER_OPTIONS               src/app/dashboard/settings/pricing/audit-history-table.tsx:27:14
fmtRelative               function  src/lib/format.ts:184:17

Unused exported types (3)
TokenType       type  src/lib/pricing-csv.ts:24:13
ParsedPriceRow  type  src/lib/pricing-csv.ts:26:13
ParseError      type  src/lib/pricing-csv.ts:41:13
```

## What changed

For every flagged export I grepped the repo (incl. `*.test.ts(x)`) for static and string-literal imports — nothing references them outside their defining file. Internal callers stay; the helpers/types simply lose `export`.

- `src/app/api/v1/ingest/rows.ts` — drop `export` from `rollupIngestedCents`, `rollupEffectiveCents`, `isValidNonNegativeNumber` (only used inside this route handler).
- `src/app/dashboard/settings/pricing/audit-history-table.tsx` — drop `export` from `STATUS_FILTER_OPTIONS`. The derived `StatusFilter` type is still exported (used by `page.tsx` and the test).
- `src/lib/pricing-csv.ts` — drop `export` from `TokenType` / `ParsedPriceRow` / `ParseError`. The `ParseResult` wrapper that uses them stays exported.
- `src/lib/format.ts` — delete `fmtRelative` outright. Zero references anywhere.

## `server-only`

The 12 `server-only` warnings are Next.js's bundled virtual module — the compiler intercepts the import and it isn't a real installable dependency. Added a minimal `knip.json` with `"ignoreDependencies": ["server-only"]` so the report stays clean.

## Verification

- ` ${"`"}npx knip${"`"} ` — clean (no output) after changes.
- ` ${"`"}npm run typecheck${"`"} ` — passes.
- ` ${"`"}npm test${"`"} ` — 447 tests pass across 45 files.
- ` ${"`"}npm run lint${"`"} ` — clean.
- ` ${"`"}npm run build${"`"} ` — succeeds; route table unchanged (same 21 routes). Bundle is not larger.

## Done-when checklist (from #287)

- [x] `npx knip` (with our config) produces a clean report.
- [x] Bundle size from `npm run build` is the same or smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)