### PR TITLE
Bake explicit GRANTs into new public-schema migrations (#306)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,9 @@ jobs:
             echo "applying $f"
             psql -v ON_ERROR_STOP=1 -f "$f"
           done
+
+      - name: Check public.* tables include GRANTs (#306)
+        # Supabase flips the Data API default on 2026-10-30; new public-schema
+        # tables become invisible to supabase-js/PostgREST/GraphQL without
+        # explicit grants. See SOUL.md and supabase/check-grants.sh.
+        run: bash supabase/check-grants.sh

--- a/SOUL.md
+++ b/SOUL.md
@@ -138,4 +138,17 @@ If a new file would violate this rule, move it before merging — don't bend the
 - **Lockfile**: commit `package-lock.json`. Deploys must be reproducible.
 - **Deployment**: Vercel for the app; GitHub Actions for the database. Production environment variables are set in the Vercel dashboard; local uses `.env.local`. Never commit real Supabase service-role keys.
 - **Migrations ship via CI, not by hand**: `.github/workflows/db-push.yml` runs `supabase db push --include-all` against the linked production project on every push to `main` that touches `supabase/migrations/**`. PRs that add a migration are dry-run against a fresh Postgres in `.github/workflows/ci.yml` to catch syntax / dependency errors at review time. Do **not** apply migrations through the Supabase SQL editor — that re-introduces the drift that broke the dashboard in #92/#94. If you must hand-apply (incident recovery), run `supabase migration repair` afterwards so `supabase migration list` shows `Local == Remote` again. Required GitHub Actions secrets: `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, `SUPABASE_PROJECT_REF`.
+- **New `public.*` tables must bake in explicit GRANTs** (#306): Supabase is flipping the Data API default on **2026-10-30** — after that, any new table in the `public` schema is invisible to `supabase-js`, PostgREST (`/rest/v1/`) and GraphQL (`/graphql/v1/`) until grants are issued (PostgREST returns `42501`). Existing tables keep their current grants — this is forward-only. Every new `CREATE TABLE public.<table>` migration must include the boilerplate below (drop the verbs the table doesn't need), plus `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and policies if the table is reachable from end users:
+
+  ```sql
+  grant select on public.<table> to anon;
+  grant select, insert, update, delete on public.<table> to authenticated;
+  grant select, insert, update, delete on public.<table> to service_role;
+
+  alter table public.<table> enable row level security;
+  -- + policies as needed
+  ```
+
+  CI enforces this in `.github/workflows/ci.yml` via `supabase/check-grants.sh`, which fails the PR if any `CREATE TABLE public.<table>` lacks a matching `GRANT ... ON public.<table>` in the same migration. The check only fires when the explicit `public.` prefix is used, so existing un-prefixed migrations are grandfathered. Before the 2026-10-30 enforcement date, run the Supabase **Security Advisor** once and confirm no existing tables are missing intended grants.
+
 - **Error surfaces**: when ingest is rejected (bad key, org mismatch, schema drift), surface a clear error in the dashboard's Settings page — the daemon will simply stop syncing on 401 and the dashboard is the only place a user will see why.

--- a/supabase/check-grants.sh
+++ b/supabase/check-grants.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Fail PRs that add a `CREATE TABLE public.x` without a matching `GRANT ... ON public.x`.
+# Background: Supabase flips the Data API default on 2026-10-30 — after that
+# date, new public-schema tables are invisible to supabase-js / PostgREST /
+# GraphQL until grants are issued (PostgREST returns 42501). See issue #306
+# and the migrations section of SOUL.md.
+set -euo pipefail
+
+shopt -s nocasematch
+
+migrations_dir="$(dirname "$0")/migrations"
+missing=0
+
+for f in "$migrations_dir"/*.sql; do
+  [ -e "$f" ] || continue
+
+  # Pull every `public.<name>` that appears as the target of CREATE TABLE.
+  # Handles `CREATE TABLE`, `CREATE TABLE IF NOT EXISTS`, and quoted identifiers.
+  tables=$(grep -ioE 'create[[:space:]]+table[[:space:]]+(if[[:space:]]+not[[:space:]]+exists[[:space:]]+)?public\.[a-zA-Z0-9_"]+' "$f" \
+    | sed -E 's/.*public\.//; s/"//g' \
+    | sort -u || true)
+
+  for t in $tables; do
+    if ! grep -iqE "grant[[:space:]]+[^;]+on[[:space:]]+(table[[:space:]]+)?public\.${t}([[:space:]]|;|$)" "$f"; then
+      echo "::error file=$f::CREATE TABLE public.${t} has no matching GRANT in the same migration (see SOUL.md / issue #306)"
+      missing=1
+    fi
+  done
+done
+
+if [ "$missing" -ne 0 ]; then
+  echo
+  echo "One or more new public-schema tables are missing GRANTs. Add the boilerplate from SOUL.md before merging."
+  exit 1
+fi
+
+echo "All public-schema CREATE TABLE statements have matching GRANTs."


### PR DESCRIPTION
Closes #306.

## Summary

- Document the GRANT convention for new `public.*` tables in `SOUL.md` so future contributors / agents follow it by default (Supabase Data API default flips on 2026-10-30; after that, new public tables are invisible to `supabase-js` / PostgREST / GraphQL without explicit grants).
- Add `supabase/check-grants.sh`, a lightweight CI guard that fails the PR when a migration contains `CREATE TABLE public.<x>` without a matching `GRANT ... ON public.<x>` in the same file. Wired into the `migrations` job in `.github/workflows/ci.yml`.
- Existing un-prefixed `CREATE TABLE <x>` migrations are grandfathered — the check only fires on the explicit `public.<x>` form the new convention requires.

The third checkbox in the issue (Supabase **Security Advisor** sweep) is a manual one-off to run closer to the 2026-10-30 enforcement date and is not part of this PR.

## Test plan

- [x] `bash supabase/check-grants.sh` passes against current migrations
- [x] Negative test: synthetic migration with `CREATE TABLE public.x` and no grant exits non-zero with a clear `::error` annotation
- [x] Positive test: same migration plus the SOUL.md boilerplate passes
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check` clean