### PR TITLE
ci(gates): split lint/format/typecheck/test into independent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Each lint/format/type/test gate is its own job so branch protection can
+  # require them independently (#290). `fail-fast: false` means a single
+  # failure doesn't cancel the others — reviewers see every problem at once.
+  checks:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: format
+            command: format:check
+          - name: lint
+            command: lint
+          - name: typecheck
+            command: typecheck
+          - name: test
+            command: test:coverage
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ${{ matrix.name }}
+        # Coverage baseline established in #281. The summary is printed for
+        # visibility; coverage is not yet a hard fail-gate beyond the floor
+        # configured in vitest.config.ts.
+        run: npm run ${{ matrix.command }}
+
   build:
+    name: build
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
@@ -28,24 +69,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Format check
-        run: npm run format:check
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Test (with coverage)
-        # Baseline established in #281. The summary is printed in PRs for visibility,
-        # but coverage is not yet a hard fail-gate beyond the floor configured in
-        # vitest.config.ts. Hard CI gates are handled in #290.
-        run: npm run test:coverage
 
       - name: Build
         run: npm run build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,19 @@ npm run format:check && npm run lint && npm run typecheck && npm test
 
 If any of these fail in CI, the PR is blocked.
 
+### Optional: run the gates automatically on every commit
+
+If you'd like the four gates to run locally before every commit, drop the snippet below into `.git/hooks/pre-commit` and `chmod +x` it. The hook stays in your checkout only — we deliberately don't ship a husky-style framework so contributors can opt in (or out) per machine.
+
+```bash
+#!/usr/bin/env bash
+set -e
+npm run format:check
+npm run lint
+npm run typecheck
+npm test
+```
+
 ## Pull request conventions
 
 - **Branch off `main`.** No long-lived feature branches.


### PR DESCRIPTION
## Summary

- Splits the previously bundled `build` job into independent jobs per gate (`format`, `lint`, `typecheck`, `test`) using a matrix with `fail-fast: false`. Each check is now independently requireable in branch protection, and reviewers see every failing gate on a PR instead of only the first one.
- Keeps the Next.js `build` and `migrations` jobs separate.
- Adds an opt-in `.git/hooks/pre-commit` snippet to `CONTRIBUTING.md` so contributors can run the same four gates locally without forcing a husky-style framework on every checkout.

## Follow-up for the maintainer

Branch protection on `main` is currently disabled. To actually make these checks block merge, configure the rule via _Settings → Branches → Add rule for `main`_ and mark these required:

- `format`
- `lint`
- `typecheck`
- `test`
- `build`
- `migrations`

Without that rule, the workflow runs but doesn't block — same as today.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the new `ci.yml`
- [x] `npm run format:check` clean locally
- [ ] CI runs on this PR and surfaces five independent jobs (`format`, `lint`, `typecheck`, `test`, `build`) plus `migrations`

Closes #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)