### PR TITLE
cleanup(deps): bump typescript 5 → 6 (#303)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-config-next": "16.2.6",
         "prettier": "^3.8.3",
         "tailwindcss": "^4.3.0",
-        "typescript": "^5",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.4"
       }
     },
@@ -7617,9 +7617,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-next": "16.2.6",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.3.0",
-    "typescript": "^5",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.4"
   }
 }


### PR DESCRIPTION
Closes #303

## Summary
- Bump `typescript` devDep from `^5` to `^6.0.3` (latest stable).

## Verification
All gates pass against the new compiler with no source changes required:

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (all 22 routes built)
- [x] `npm test` — 447/447 vitest tests pass

No tightening of inference or removed-deprecation surfaced anything new in the current source tree, so this is a zero-touch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)