### PR TITLE
feat(login): add self-hosted, free, no-signup messaging (#313)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -58,6 +58,17 @@ export default function LoginPage() {
           <p className="mt-1 text-sm text-zinc-400">
             Team-wide AI cost visibility
           </p>
+          <p className="mt-3 text-sm text-zinc-300">
+            Free, self-hosted, no signup needed.{" "}
+            <a
+              href="https://getbudi.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 underline-offset-2 hover:text-blue-300 hover:underline"
+            >
+              Learn more
+            </a>
+          </p>
         </div>
 
         {error && (


### PR DESCRIPTION
Closes #313.

## Summary
- Adds a "Free, self-hosted, no signup needed." line under the Budi Cloud headline on `/login`.
- Inlines a "Learn more" link to https://getbudi.dev so visitors can read the self-hosted story before signing in.

## Test plan
- [ ] `npm run dev` and confirm the new copy + link render correctly on `/login`
- [ ] Click "Learn more" — opens https://getbudi.dev in a new tab with `noopener noreferrer`
- [ ] OAuth + magic-link flows still work unchanged
- [ ] `npm run lint` and `npx tsc --noEmit` are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)