### PR TITLE
feat(auth): auto-create default workspace on first login (#314)

### DIFF
--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -16,15 +16,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 type Row = Record<string, unknown>;
 
 class FakeAdmin {
-  rows: Row[] = [];
+  tables: Record<string, Row[]> = {};
 
-  seed(rows: Row[]) {
-    this.rows = [...rows];
+  seed(rows: Row[], table: string = "users") {
+    this.tables[table] = [...rows];
   }
 
-  from(_table: string) {
-    void _table;
-    return new FakeQuery(this.rows);
+  from(table: string) {
+    if (!this.tables[table]) this.tables[table] = [];
+    return new FakeQuery(this.tables[table]);
+  }
+
+  // Backwards-compatible shorthand for the original tests that only ever
+  // inspected the `users` table directly.
+  get rows(): Row[] {
+    return this.tables.users ?? [];
   }
 }
 
@@ -101,7 +107,7 @@ vi.mock("@/lib/supabase/server", () => ({
 vi.mock("server-only", () => ({}));
 
 beforeEach(() => {
-  admin.seed([]);
+  admin.tables = {};
   mockUser = {
     id: "user_abc",
     email: "bon@example.com",
@@ -147,16 +153,31 @@ describe("/auth/callback — invite-link round-trip (#62)", () => {
     expect(location).toBe(`${ORIGIN}/invite/tok_xyz`);
   });
 
-  it("still sends a brand-new user with no next to /setup", async () => {
+  it("auto-creates a default workspace for a brand-new user with no next (#314)", async () => {
     const location = await runCallback("?code=abc");
-    expect(location).toBe(`${ORIGIN}/setup`);
+    expect(location).toBe(`${ORIGIN}/dashboard`);
+
+    // The user row exists and is linked to a freshly-minted org named
+    // "Your workspace". Manager role is required so they can manage the org
+    // they just got handed.
+    expect(admin.rows).toHaveLength(1);
+    expect(admin.rows[0].role).toBe("manager");
+    expect(admin.rows[0].org_id).toMatch(/^org_/);
+    const orgs = admin.tables.orgs ?? [];
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0].name).toBe("Your workspace");
+    expect(orgs[0].id).toBe(admin.rows[0].org_id);
   });
 
-  it("still sends an existing orgless user with no next to /setup", async () => {
+  it("auto-creates a default workspace for an existing orgless user with no next (#314)", async () => {
     admin.seed([{ id: "user_abc", org_id: null, display_name: "Bon" }]);
 
     const location = await runCallback("?code=abc");
-    expect(location).toBe(`${ORIGIN}/setup`);
+    expect(location).toBe(`${ORIGIN}/dashboard`);
+    expect(admin.rows[0].org_id).toMatch(/^org_/);
+    const orgs = admin.tables.orgs ?? [];
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0].name).toBe("Your workspace");
   });
 
   it("sends an existing user with an org to ?next when it's safe", async () => {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,8 +1,41 @@
 import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isInvitePath, isSafeNextPath } from "@/lib/auth-redirect";
 import { randomBytes } from "crypto";
+
+const DEFAULT_WORKSPACE_NAME = "Your workspace";
+
+/**
+ * Create a default workspace ("Your workspace") and link the user to it as
+ * manager. The workspace has no special flags — it's identical to one the
+ * user would create themselves through settings, so rename/delete/invite all
+ * work the same (issue #314).
+ *
+ * Callers must ensure the user is not arriving via an invite link; in that
+ * case the invite page assigns the org instead and short-circuiting here
+ * would silently break the invite (issue #62).
+ */
+async function createDefaultWorkspace(
+  admin: SupabaseClient,
+  userId: string
+): Promise<{ error: string | null }> {
+  const orgId = `org_${randomBytes(12).toString("base64url")}`;
+  const { error: orgError } = await admin.from("orgs").insert({
+    id: orgId,
+    name: DEFAULT_WORKSPACE_NAME,
+  });
+  if (orgError) return { error: orgError.message };
+
+  const { error: userError } = await admin
+    .from("users")
+    .update({ org_id: orgId, role: "manager" })
+    .eq("id", userId);
+  if (userError) return { error: userError.message };
+
+  return { error: null };
+}
 
 /**
  * OAuth callback handler for Supabase Auth.
@@ -10,10 +43,9 @@ import { randomBytes } from "crypto";
  *
  * The `?next=<path>` query param is preserved across the auth round-trip
  * by `buildAuthCallbackUrl` on the login page. When `next` points at an
- * invite link, this handler must NOT short-circuit to `/setup`: the invite
- * page is responsible for joining the user to the inviter's org. Sending
- * a brand-new user to `/setup` first would auto-provision a personal org
- * and silently break the invite (issue #62).
+ * invite link, this handler must NOT auto-provision a workspace: the invite
+ * page is responsible for joining the user to the inviter's org. Creating
+ * one here first would silently break the invite (issue #62).
  */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -80,8 +112,20 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${origin}${next}`);
     }
 
-    // New user with no org — redirect to setup
-    return NextResponse.redirect(`${origin}/setup`);
+    // Auto-provision a default workspace so first-time users skip the
+    // org-creation step entirely (issue #314).
+    const { error: workspaceError } = await createDefaultWorkspace(
+      admin,
+      user.id
+    );
+    if (workspaceError) {
+      console.error("Failed to create default workspace:", workspaceError);
+      return NextResponse.redirect(
+        `${origin}/login?error=workspace_creation_failed`
+      );
+    }
+
+    return NextResponse.redirect(`${origin}${next}`);
   }
 
   // Existing user — update email/display_name if changed
@@ -100,12 +144,23 @@ export async function GET(request: Request) {
   }
 
   // If user has no org, send them to the invite page when they came via
-  // one — otherwise to setup so they can create their own org.
+  // one — otherwise auto-provision a default workspace so they never end up
+  // stranded on a setup screen (issue #314).
   if (!existingUser.org_id) {
     if (cameFromInvite) {
       return NextResponse.redirect(`${origin}${next}`);
     }
-    return NextResponse.redirect(`${origin}/setup`);
+    const { error: workspaceError } = await createDefaultWorkspace(
+      admin,
+      user.id
+    );
+    if (workspaceError) {
+      console.error("Failed to create default workspace:", workspaceError);
+      return NextResponse.redirect(
+        `${origin}/login?error=workspace_creation_failed`
+      );
+    }
+    return NextResponse.redirect(`${origin}${next}`);
   }
 
   return NextResponse.redirect(`${origin}${next}`);


### PR DESCRIPTION
Closes #314.

## Summary
- Auth callback now auto-creates a workspace named **"Your workspace"** for first-time users and links them as `manager`, instead of routing them to `/setup`.
- Same auto-provisioning runs for an existing orgless user (e.g. someone who left their previous org), so nobody gets stranded on the setup screen.
- The workspace has no special flags — it's identical to a user-created org, so rename / delete / invite / leave all work the same.
- Invite-link round-trip (#62) is preserved: when `next` points at `/invite/<token>`, the invite page is still the one to assign the org.

## Test plan
- [x] `npm test` — full suite green (447/447); updated `route.test.ts` to pin the new redirect target and assert the org row is created with the expected name.
- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: log in with a fresh Supabase account and confirm landing on `/dashboard` with a "Your workspace" org instead of `/setup`.
- [ ] Manual: log in via an invite link and confirm the invitee still joins the inviter's org (no personal workspace created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)