### PR TITLE
feat: rename 'Organization' → 'Workspace' in user-facing UI (#315)

### DIFF
--- a/src/app/actions/org.test.ts
+++ b/src/app/actions/org.test.ts
@@ -438,7 +438,7 @@ describe("deleteOrganization", () => {
 
     const result = await deleteOrganization(undefined, fd);
     expect(result).toEqual({
-      error: "Only managers can delete the organization",
+      error: "Only managers can delete the workspace",
     });
     expect(fake.rows("orgs")).toHaveLength(1);
     expect(fake.rows("users")).toHaveLength(2);
@@ -454,7 +454,7 @@ describe("deleteOrganization", () => {
 
     const result = await deleteOrganization(undefined, fd);
     expect(result).toEqual({
-      error: "Type the organization name exactly to confirm",
+      error: "Type the workspace name exactly to confirm",
     });
     expect(fake.rows("orgs")).toHaveLength(1);
     expect(fake.rows("daily_rollups")).toHaveLength(2);
@@ -526,7 +526,7 @@ describe("leaveOrganization", () => {
 
     const { leaveOrganization } = await loadActions();
     const result = await leaveOrganization();
-    expect(result).toEqual({ error: "Not a member of any organization" });
+    expect(result).toEqual({ error: "Not a member of any workspace" });
   });
 });
 
@@ -638,7 +638,7 @@ describe("updateMemberRole", () => {
     const result = await updateMemberRole("usr_outsider", "manager");
 
     expect(result).toEqual({
-      error: "User is not a member of your organization",
+      error: "User is not a member of your workspace",
     });
     const outsider = fake.rows("users").find((u) => u.id === "usr_outsider");
     expect(outsider?.role).toBe("member");
@@ -831,7 +831,7 @@ describe("switchOrganization", () => {
     );
 
     expect(result).toEqual({
-      error: "Invite link does not match the target organization",
+      error: "Invite link does not match the target workspace",
     });
     const alice = fake.rows("users").find((u) => u.id === "usr_alice");
     expect(alice?.org_id).toBe("org_other");
@@ -848,7 +848,7 @@ describe("switchOrganization", () => {
     );
 
     expect(result).toEqual({
-      error: "Type the organization name exactly to confirm",
+      error: "Type the workspace name exactly to confirm",
     });
     const alice = fake.rows("users").find((u) => u.id === "usr_alice");
     expect(alice?.org_id).toBe("org_other");

--- a/src/app/actions/org.ts
+++ b/src/app/actions/org.ts
@@ -11,7 +11,7 @@ export async function createOrg(
   formData: FormData
 ) {
   const name = formData.get("name") as string;
-  if (!name?.trim()) return { error: "Org name is required" };
+  if (!name?.trim()) return { error: "Workspace name is required" };
 
   const supabase = await createClient();
   const {
@@ -27,14 +27,14 @@ export async function createOrg(
     id: orgId,
     name: name.trim(),
   });
-  if (orgError) return { error: "Failed to create org" };
+  if (orgError) return { error: "Failed to create workspace" };
 
   // Link user to org as manager
   const { error: userError } = await admin
     .from("users")
     .update({ org_id: orgId, role: "manager" })
     .eq("id", user.id);
-  if (userError) return { error: "Failed to link user to org" };
+  if (userError) return { error: "Failed to link user to workspace" };
 
   redirect("/dashboard");
 }
@@ -106,9 +106,9 @@ export async function deleteOrganization(
     .eq("id", authUser.id)
     .single();
 
-  if (!me?.org_id) return { error: "No organization to delete" };
+  if (!me?.org_id) return { error: "No workspace to delete" };
   if (me.role !== "manager") {
-    return { error: "Only managers can delete the organization" };
+    return { error: "Only managers can delete the workspace" };
   }
 
   const { data: org } = await admin
@@ -116,10 +116,10 @@ export async function deleteOrganization(
     .select("id, name")
     .eq("id", me.org_id)
     .single();
-  if (!org) return { error: "Organization not found" };
+  if (!org) return { error: "Workspace not found" };
 
   if (confirm.trim() !== org.name) {
-    return { error: "Type the organization name exactly to confirm" };
+    return { error: "Type the workspace name exactly to confirm" };
   }
 
   const orgId = org.id as string;
@@ -134,7 +134,7 @@ export async function deleteOrganization(
     p_org_id: orgId,
   });
   if (rpcError) {
-    return { error: `Failed to delete organization: ${rpcError.message}` };
+    return { error: `Failed to delete workspace: ${rpcError.message}` };
   }
 
   await supabase.auth.signOut();
@@ -165,11 +165,11 @@ export async function leaveOrganization(): Promise<{ error: string } | void> {
     .eq("id", authUser.id)
     .single();
 
-  if (!me?.org_id) return { error: "Not a member of any organization" };
+  if (!me?.org_id) return { error: "Not a member of any workspace" };
   if (me.role === "manager") {
     return {
       error:
-        "Managers can't leave an organization. Delete it instead, or hand off ownership first.",
+        "Managers can't leave a workspace. Delete it instead, or hand off ownership first.",
     };
   }
 
@@ -194,7 +194,7 @@ export async function leaveOrganization(): Promise<{ error: string } | void> {
       .in("device_id", deviceIds);
     if (sessionsError) {
       return {
-        error: `Failed to leave organization: ${sessionsError.message}`,
+        error: `Failed to leave workspace: ${sessionsError.message}`,
       };
     }
     const { error: rollupsError } = await admin
@@ -202,14 +202,14 @@ export async function leaveOrganization(): Promise<{ error: string } | void> {
       .delete()
       .in("device_id", deviceIds);
     if (rollupsError) {
-      return { error: `Failed to leave organization: ${rollupsError.message}` };
+      return { error: `Failed to leave workspace: ${rollupsError.message}` };
     }
     const { error: devicesError } = await admin
       .from("devices")
       .delete()
       .eq("user_id", userId);
     if (devicesError) {
-      return { error: `Failed to leave organization: ${devicesError.message}` };
+      return { error: `Failed to leave workspace: ${devicesError.message}` };
     }
   }
 
@@ -218,7 +218,7 @@ export async function leaveOrganization(): Promise<{ error: string } | void> {
     .update({ org_id: null, role: "member" })
     .eq("id", userId);
   if (updateError) {
-    return { error: `Failed to leave organization: ${updateError.message}` };
+    return { error: `Failed to leave workspace: ${updateError.message}` };
   }
 
   await supabase.auth.signOut();
@@ -266,11 +266,11 @@ export async function switchOrganization(
     .eq("id", authUser.id)
     .single();
 
-  if (!me?.org_id) return { error: "Not a member of any organization" };
+  if (!me?.org_id) return { error: "Not a member of any workspace" };
   if (me.role === "manager") {
     return {
       error:
-        "Managers can't switch organizations. Delete this org or hand off ownership first.",
+        "Managers can't switch workspaces. Delete this workspace or hand off ownership first.",
     };
   }
 
@@ -285,10 +285,10 @@ export async function switchOrganization(
     return { error: "Invite link has expired" };
   }
   if (invite.org_id !== targetOrgId) {
-    return { error: "Invite link does not match the target organization" };
+    return { error: "Invite link does not match the target workspace" };
   }
   if (invite.org_id === me.org_id) {
-    return { error: "You are already a member of that organization" };
+    return { error: "You are already a member of that workspace" };
   }
 
   const { data: targetOrg } = await admin
@@ -296,17 +296,17 @@ export async function switchOrganization(
     .select("id, name")
     .eq("id", invite.org_id as string)
     .single();
-  if (!targetOrg) return { error: "Target organization not found" };
+  if (!targetOrg) return { error: "Target workspace not found" };
 
   if (confirm.trim() !== (targetOrg.name as string)) {
-    return { error: "Type the organization name exactly to confirm" };
+    return { error: "Type the workspace name exactly to confirm" };
   }
 
   const { error: updateError } = await admin
     .from("users")
     .update({ org_id: invite.org_id, role: invite.role })
     .eq("id", me.id as string);
-  if (updateError) return { error: "Failed to switch organization" };
+  if (updateError) return { error: "Failed to switch workspace" };
 
   // Audit row, same shape as a fresh join. Idempotent on (token, user) so a
   // re-click after the switch is a no-op rather than a duplicate-key error.
@@ -366,7 +366,7 @@ export async function updateMemberRole(
     .single();
 
   if (!target || target.org_id !== me.org_id) {
-    return { error: "User is not a member of your organization" };
+    return { error: "User is not a member of your workspace" };
   }
 
   if (target.role === newRole) return { ok: true };

--- a/src/app/actions/pricing.ts
+++ b/src/app/actions/pricing.ts
@@ -37,8 +37,7 @@ async function requireManager(): Promise<
     .eq("id", authUser.id)
     .single();
 
-  if (!me?.org_id)
-    return { ok: false, error: "Not a member of any workspace" };
+  if (!me?.org_id) return { ok: false, error: "Not a member of any workspace" };
   if (me.role !== "manager") {
     return { ok: false, error: "Only managers can manage pricing" };
   }

--- a/src/app/actions/pricing.ts
+++ b/src/app/actions/pricing.ts
@@ -38,7 +38,7 @@ async function requireManager(): Promise<
     .single();
 
   if (!me?.org_id)
-    return { ok: false, error: "Not a member of any organization" };
+    return { ok: false, error: "Not a member of any workspace" };
   if (me.role !== "manager") {
     return { ok: false, error: "Only managers can manage pricing" };
   }

--- a/src/app/dashboard/models/page.test.tsx
+++ b/src/app/dashboard/models/page.test.tsx
@@ -195,7 +195,7 @@ describe("dashboard/models /page", () => {
     const node = await render();
     const text = extractText(node);
     expect(text).toContain("Cost by Surface");
-    expect(text).toContain("Single-surface org");
+    expect(text).toContain("Single-surface workspace");
   });
 
   it("surface chart: all-unknown period falls back to the empty-state with the daemon-version unlock copy, not a single self-tautological bar (#210)", async () => {
@@ -213,6 +213,6 @@ describe("dashboard/models /page", () => {
     expect(text).toContain("Cost by Surface");
     expect(text).toContain("every row in this window is tagged Unknown");
     expect(text).toContain("v8.4.2");
-    expect(text).not.toContain("Single-surface org");
+    expect(text).not.toContain("Single-surface workspace");
   });
 });

--- a/src/app/dashboard/models/page.tsx
+++ b/src/app/dashboard/models/page.tsx
@@ -251,7 +251,7 @@ export default async function ModelsPage({
               isAllUnknownSurface(surfaceShare)
                 ? "Per-surface breakdown not available — every row in this window is tagged Unknown. Update local Budi to v8.4.2+ to start emitting surface tags."
                 : knownSurfaces.length <= 1
-                  ? "Single-surface org — break out per-surface spend after a second IDE / CLI starts syncing."
+                  ? "Single-surface workspace — break out per-surface spend after a second IDE / CLI starts syncing."
                   : `No surface ${valueWord.toLowerCase()} data for this period`
             }
             unit={unit}

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -358,7 +358,7 @@ describe("dashboard /page (Overview)", () => {
     const node = await render();
     const text = extractText(node);
     expect(text).toContain("Spend by Surface");
-    expect(text).toContain("Single-surface org");
+    expect(text).toContain("Single-surface workspace");
   });
 
   it("surface chart: all-unknown period falls back to the empty-state with the daemon-version unlock copy, not a single self-tautological bar (#210)", async () => {
@@ -379,7 +379,7 @@ describe("dashboard /page (Overview)", () => {
     // The single-surface copy is for "one *named* surface" — must not fire
     // here, otherwise a viewer is told to wait for a second IDE when the
     // real unlock is a daemon upgrade.
-    expect(text).not.toContain("Single-surface org");
+    expect(text).not.toContain("Single-surface workspace");
   });
 
   it("savings strip is removed: never appears regardless of price-list/cost state", async () => {
@@ -490,6 +490,6 @@ describe("dashboard /page (Overview)", () => {
     // Mixed window must NOT trigger the all-unknown empty-state copy —
     // managers want to see how much spend is untagged in absolute terms.
     expect(text).not.toContain("every row in this window is tagged Unknown");
-    expect(text).not.toContain("Single-surface org");
+    expect(text).not.toContain("Single-surface workspace");
   });
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -323,7 +323,7 @@ export default async function OverviewPage({
                 isAllUnknownSurface(surfaceShare)
                   ? "Per-surface breakdown not available — every row in this window is tagged Unknown. Update local Budi to v8.4.2+ to start emitting surface tags."
                   : knownSurfaces.length <= 1
-                    ? "Single-surface org — break out per-surface spend after a second IDE / CLI starts syncing."
+                    ? "Single-surface workspace — break out per-surface spend after a second IDE / CLI starts syncing."
                     : "No surface activity for this period"
               }
               unit={unit}

--- a/src/app/dashboard/settings/danger-zone.tsx
+++ b/src/app/dashboard/settings/danger-zone.tsx
@@ -32,8 +32,8 @@ export function DangerZone({
       <h2 className="text-sm font-semibold text-red-300">Danger zone</h2>
       <p className="mt-1 text-sm text-zinc-400">
         {isManager
-          ? "Deleting the organization removes every member, device, and synced rollup. This cannot be undone."
-          : "Leaving removes your devices and sync history from this organization. Your account itself stays intact so you can rejoin or create a new org later."}
+          ? "Deleting the workspace removes every member, device, and synced rollup. This cannot be undone."
+          : "Leaving removes your devices and sync history from this workspace. Your account itself stays intact so you can rejoin or create a new workspace later."}
       </p>
 
       <div className="mt-4">
@@ -79,12 +79,12 @@ function DeleteOrgButton({ orgName }: { orgName: string }) {
         onClick={() => setOpen(true)}
         className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm font-medium text-red-300 transition-colors hover:bg-red-500/20"
       >
-        Delete organization…
+        Delete workspace…
       </button>
 
       {open && (
         <ConfirmationModal
-          title="Delete organization"
+          title="Delete workspace"
           onClose={close}
           description={
             <>
@@ -129,7 +129,7 @@ function DeleteOrgButton({ orgName }: { orgName: string }) {
                     : "cursor-not-allowed bg-red-600/40 text-red-200/60"
                 )}
               >
-                {pending ? "Deleting…" : "Delete organization"}
+                {pending ? "Deleting…" : "Delete workspace"}
               </button>
             </div>
           </form>
@@ -165,18 +165,18 @@ function LeaveOrgButton({ orgName }: { orgName: string }) {
         onClick={() => setOpen(true)}
         className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm font-medium text-red-300 transition-colors hover:bg-red-500/20"
       >
-        Leave organization…
+        Leave workspace…
       </button>
 
       {open && (
         <ConfirmationModal
-          title="Leave organization"
+          title="Leave workspace"
           onClose={close}
           description={
             <>
               This removes your devices and sync history from{" "}
               <strong>{orgName}</strong>. Your sign-in account stays, so you can
-              rejoin or create a different org later.
+              rejoin or create a different workspace later.
             </>
           }
           error={error}
@@ -196,7 +196,7 @@ function LeaveOrgButton({ orgName }: { orgName: string }) {
               disabled={pending}
               className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
             >
-              {pending ? "Leaving…" : "Leave organization"}
+              {pending ? "Leaving…" : "Leave workspace"}
             </button>
           </div>
         </ConfirmationModal>

--- a/src/app/dashboard/settings/page.test.tsx
+++ b/src/app/dashboard/settings/page.test.tsx
@@ -76,12 +76,12 @@ async function render() {
 }
 
 describe("dashboard/settings /page", () => {
-  it("smoke: renders Organization, API Key, and Team Members sections with populated data", async () => {
+  it("smoke: renders Workspace, API Key, and Team Members sections with populated data", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("Settings");
-    expect(text).toContain("Organization");
+    expect(text).toContain("Workspace");
     expect(text).toContain("Acme");
     // The team members section header includes the count — pin it so a
     // refactor that drops the count or the header is caught.

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -54,7 +54,7 @@ export default async function SettingsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Organization</CardTitle>
+          <CardTitle>Workspace</CardTitle>
         </CardHeader>
         <CardContent>
           <dl className="space-y-3 text-sm">
@@ -63,10 +63,10 @@ export default async function SettingsPage() {
               <dd className="text-zinc-200">{org?.name ?? "-"}</dd>
             </div>
             <div className="flex items-center justify-between">
-              <dt className="text-zinc-400">Org ID</dt>
+              <dt className="text-zinc-400">Workspace ID</dt>
               <dd className="flex items-center gap-1 font-mono text-xs text-zinc-400">
                 <span>{user.org_id}</span>
-                <CopyButton value={user.org_id} label="Copy Org ID" />
+                <CopyButton value={user.org_id} label="Copy Workspace ID" />
               </dd>
             </div>
           </dl>

--- a/src/app/dashboard/settings/pricing/page.tsx
+++ b/src/app/dashboard/settings/pricing/page.tsx
@@ -125,7 +125,7 @@ export default async function PricingSettingsPage({
 
       <Card>
         <CardHeader>
-          <CardTitle>Org defaults</CardTitle>
+          <CardTitle>Workspace defaults</CardTitle>
         </CardHeader>
         <CardContent>
           <DefaultsForm

--- a/src/app/invite/[token]/cross-org-switch.tsx
+++ b/src/app/invite/[token]/cross-org-switch.tsx
@@ -50,7 +50,7 @@ export function CrossOrgSwitch({
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
       <div className="w-full max-w-md rounded-xl border border-white/10 bg-zinc-950 p-6 shadow-xl">
-        <h1 className="text-xl font-bold text-white">Switch organizations?</h1>
+        <h1 className="text-xl font-bold text-white">Switch workspaces?</h1>
         <div className="mt-4 space-y-3 text-sm text-zinc-300">
           <p>
             You&rsquo;re currently a member of{" "}

--- a/src/app/invite/[token]/page.test.tsx
+++ b/src/app/invite/[token]/page.test.tsx
@@ -298,10 +298,10 @@ describe("invite/[token] page — multi-use redemption (#68)", () => {
 
     expect(redirectMock).not.toHaveBeenCalled();
     const html = JSON.stringify(node);
-    expect(html).toContain("Already in an Organization");
+    expect(html).toContain("Already in a Workspace");
     // The switch CTA must not be rendered for a manager — they'd orphan their
     // current org. Copy nudges them toward delete/hand-off instead.
-    expect(html).not.toContain("Switch organizations?");
+    expect(html).not.toContain("Switch workspaces?");
     expect(html).toContain("Delete");
     expect(fake.rows("invite_redemptions")).toHaveLength(0);
   });

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -96,7 +96,7 @@ export default async function InvitePage({
         <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a] p-4">
           <div className="w-full max-w-md rounded-xl border border-white/10 bg-zinc-950 p-6 text-center shadow-xl">
             <h1 className="text-xl font-bold text-white">
-              Already in an Organization
+              Already in a Workspace
             </h1>
             <p className="mt-3 text-sm text-zinc-300">
               You manage <strong>{currentOrgName}</strong>, so you can&rsquo;t

--- a/src/app/setup/form.tsx
+++ b/src/app/setup/form.tsx
@@ -13,7 +13,7 @@ export function OrgSetupForm() {
           htmlFor="name"
           className="block text-sm font-medium text-zinc-300"
         >
-          Organization name
+          Workspace name
         </label>
         <input
           id="name"
@@ -30,7 +30,7 @@ export function OrgSetupForm() {
         disabled={pending}
         className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
       >
-        {pending ? "Creating..." : "Create organization"}
+        {pending ? "Creating..." : "Create workspace"}
       </button>
     </form>
   );

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -40,7 +40,7 @@ export default async function SetupPage({
         <div className="text-center">
           <h1 className="text-xl font-bold text-white">Create Your Team</h1>
           <p className="mt-1 text-sm text-zinc-400">
-            Set up an organization to start tracking team AI costs.
+            Set up a workspace to start tracking team AI costs.
           </p>
         </div>
         <OrgSetupForm />


### PR DESCRIPTION
## Summary

Closes #315.

Renames the user-facing tenant label from **"Organization"** to **"Workspace"** across UI copy, error messages returned to users, and the tests that assert on those strings. Industry convention (Slack, Notion, Linear) and pairs with #314's auto-created "Your workspace".

### What changed

- **Setup**: "Set up an organization…" → "Set up a workspace…"; "Organization name" → "Workspace name"; "Create organization" → "Create workspace"
- **Settings → Workspace card**: "Organization" → "Workspace"; "Org ID" → "Workspace ID" (+ Copy button label)
- **Settings → Pricing**: "Org defaults" → "Workspace defaults"
- **Danger zone**: Delete/Leave workspace buttons, dialog titles, and body copy
- **Invite flow**: "Already in an Organization" → "Already in a Workspace"; "Switch organizations?" → "Switch workspaces?"
- **Empty states**: "Single-surface org" → "Single-surface workspace" on Overview and Models
- **Server-action error messages** returned from `actions/org.ts` and `actions/pricing.ts` ("Type the workspace name…", "Only managers can delete the workspace", etc.)

### What deliberately did not change

Per the issue's explicit guidance:

- **Code identifiers** stay: `createOrg`, `deleteOrganization`, `leaveOrganization`, `switchOrganization`, `OrgSetupForm`, `DeleteOrgButton`, etc.
- **DB schema** stays: `orgs` table, `org_id` column, `delete_org_cascade` RPC
- **API & file paths** stay: `actions/org.ts`, `invite/[token]/cross-org-switch.tsx`, `org_cascade.ts`
- **URL paths**: no `/org/...` routes exist in the app, so the issue's open URL-strategy question is moot — nothing to redirect.

### Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 447/447 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Smoke check Setup → Settings → Danger Zone → Invite flows in the running dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)