### PR TITLE
cleanup: drop #321 dual-emit org_id (closes #325)

### DIFF
--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -54,11 +54,6 @@ interface SyncEnvelope {
   schema_version: number;
   device_id: string;
   workspace_id: string;
-  // Legacy alias accepted during the #321 rename dual-emit window. Daemons
-  // predating the rename still send `org_id`; normalize() copies it into
-  // `workspace_id` before validation. Drops out once the daemon ships the
-  // workspace-aware build and ingest stops seeing the legacy field.
-  org_id?: string;
   synced_at: string;
   // User-controlled display name for this device. Daemon default is the OS
   // hostname, but the user can override (or blank) via `cloud.toml` — so this
@@ -69,23 +64,6 @@ interface SyncEnvelope {
     daily_rollups: IngestDailyRollup[];
     session_summaries: IngestSessionSummary[];
   };
-}
-
-/**
- * Accept the legacy `org_id` envelope field as a synonym for `workspace_id`
- * during the #321 rename window. If both are sent they must agree — a daemon
- * that disagrees with itself is a bug, not a compat case, so reject loudly
- * rather than silently picking one.
- */
-function normalizeWorkspaceField(body: SyncEnvelope): string | null {
-  const legacy = typeof body.org_id === "string" ? body.org_id : undefined;
-  const current =
-    typeof body.workspace_id === "string" ? body.workspace_id : undefined;
-  if (legacy && current && legacy !== current) {
-    return "Envelope sent both org_id and workspace_id with different values";
-  }
-  if (!current && legacy) body.workspace_id = legacy;
-  return null;
 }
 
 /**
@@ -240,12 +218,6 @@ export async function POST(request: NextRequest) {
     body = JSON.parse(text);
   } catch {
     return Response.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-
-  // --- Normalize org_id → workspace_id (#321 dual-emit window) ---
-  const normalizeError = normalizeWorkspaceField(body);
-  if (normalizeError) {
-    return Response.json({ error: normalizeError }, { status: 422 });
   }
 
   // --- Validate envelope ---

--- a/src/app/api/v1/whoami/route.ts
+++ b/src/app/api/v1/whoami/route.ts
@@ -63,13 +63,8 @@ async function authenticateApiKey(
  * the CLI side.
  *
  * Auth: Authorization: Bearer budi_<key>
- * Response (200): { "workspace_id": string, "org_id": string }
+ * Response (200): { "workspace_id": string }
  * Response (401): { "error": "Unauthorized" }
- *
- * Dual-emit window (#321): `org_id` is the legacy field name kept for one
- * release cycle so daemons predating the rename keep parsing the response.
- * Both fields carry the same value; the legacy alias goes away after the
- * daemon's workspace-aware build has soaked.
  */
 export async function GET(request: NextRequest) {
   // --- Pre-auth IP rate limit (#179) ---
@@ -92,6 +87,5 @@ export async function GET(request: NextRequest) {
 
   return Response.json({
     workspace_id: user.workspace_id,
-    org_id: user.workspace_id,
   });
 }


### PR DESCRIPTION
Closes #325.

Schema rename to \`workspace_id\` landed in #322. The API kept a dual-emit window so daemons predating the rename could still parse responses and keep ingesting. The workspace-aware daemon has shipped, so the legacy halves come out.

## Changes

- **\`src/app/api/v1/whoami/route.ts\`**: response body drops the duplicate \`org_id\` field. Docstring updated.
- **\`src/app/api/v1/ingest/route.ts\`**: \`SyncEnvelope.org_id\` removed; \`normalizeWorkspaceField\` helper and its call site removed.

No migration needed — schema has been on \`workspace_id\` since #322.

## Test plan

- [x] \`format\` / \`lint\` / \`typecheck\` / \`test\` — 447 tests pass.
- [x] \`grep -rn "org_id" src --include="*.ts"\` returns only test fixture strings (\`"org_test"\`, \`"org_xEvtA"\`), which are opaque workspace IDs — those legitimately exist and the system must keep handling them as IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)