### PR TITLE
feat: redesign landing + login pages for first-time visitors

### DIFF
--- a/src/app/_components/dashboard-preview.tsx
+++ b/src/app/_components/dashboard-preview.tsx
@@ -1,0 +1,96 @@
+export function DashboardPreview() {
+  return (
+    <div className="bg-[#0e0e0e] p-5 sm:p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <div className="h-2.5 w-2.5 rounded-full bg-red-500/60" />
+        <div className="h-2.5 w-2.5 rounded-full bg-yellow-500/60" />
+        <div className="h-2.5 w-2.5 rounded-full bg-green-500/60" />
+        <span className="ml-3 text-xs text-zinc-600">
+          app.getbudi.dev/dashboard
+        </span>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-baseline justify-between">
+          <p className="text-sm font-medium text-zinc-400">Overview</p>
+          <div className="flex gap-2">
+            {["7d", "30d", "All"].map((label) => (
+              <span
+                key={label}
+                className={`rounded px-2 py-0.5 text-xs ${
+                  label === "7d"
+                    ? "bg-blue-600/20 text-blue-400"
+                    : "text-zinc-600"
+                }`}
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <MockStatCard label="Total Cost" value="$1,247.82" delta="+12%" />
+          <MockStatCard label="Messages" value="34,891" delta="+8%" />
+          <MockStatCard label="Sessions" value="1,204" delta="+5%" />
+        </div>
+
+        <div className="rounded-lg border border-white/5 bg-white/[0.02] p-4">
+          <p className="mb-3 text-xs text-zinc-500">Daily Activity (Cost)</p>
+          <MockBarChart />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-lg border border-white/5 bg-white/[0.02] p-3">
+            <p className="text-xs text-zinc-500">Top model</p>
+            <p className="mt-1 text-sm font-medium text-white">
+              Claude Sonnet 4
+            </p>
+            <p className="text-xs text-zinc-600">62% of spend</p>
+          </div>
+          <div className="rounded-lg border border-white/5 bg-white/[0.02] p-3">
+            <p className="text-xs text-zinc-500">Top repo</p>
+            <p className="mt-1 text-sm font-medium text-white">acme/backend</p>
+            <p className="text-xs text-zinc-600">38% of spend</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MockStatCard({
+  label,
+  value,
+  delta,
+}: {
+  label: string;
+  value: string;
+  delta: string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/5 bg-white/[0.02] p-3">
+      <p className="text-xs text-zinc-500">{label}</p>
+      <p className="mt-1 text-lg font-semibold text-white sm:text-xl">
+        {value}
+      </p>
+      <p className="text-xs font-medium text-emerald-400/80">{delta}</p>
+    </div>
+  );
+}
+
+function MockBarChart() {
+  const bars = [35, 52, 48, 65, 42, 58, 72, 60, 45, 68, 55, 80, 62, 50];
+  const max = Math.max(...bars);
+  return (
+    <div className="flex h-20 items-end gap-1 sm:h-24">
+      {bars.map((h, i) => (
+        <div
+          key={i}
+          className="flex-1 rounded-sm bg-blue-500/30"
+          style={{ height: `${(h / max) * 100}%` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { buildAuthCallbackUrl } from "@/lib/auth-redirect";
 
@@ -10,9 +11,6 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Forward the `?next=<path>` query param through the auth round-trip so
-  // that an invite link (`/login?next=/invite/<token>`) lands the user back
-  // on the invite page after OAuth / magic-link, instead of `/dashboard`.
   function callbackUrl() {
     const next = new URLSearchParams(window.location.search).get("next");
     return buildAuthCallbackUrl(window.location.origin, next);
@@ -51,82 +49,144 @@ export default function LoginPage() {
   }
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
-      <div className="w-full max-w-sm space-y-6 rounded-xl border border-white/10 bg-white/[0.02] p-8">
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-white">Budi Cloud</h1>
-          <p className="mt-1 text-sm text-zinc-400">
-            Team-wide AI cost visibility
+    <main className="flex min-h-screen bg-[#0a0a0a]">
+      <div className="hidden w-1/2 flex-col justify-between border-r border-white/10 bg-white/[0.01] p-10 lg:flex">
+        <Link href="/" className="text-lg font-bold text-white">
+          Budi Cloud
+        </Link>
+        <div className="max-w-md">
+          <p className="text-2xl font-semibold leading-snug text-white">
+            Team-wide AI cost visibility for engineering managers.
           </p>
-          <p className="mt-3 text-sm text-zinc-300">
-            Free, self-hosted, no signup needed.{" "}
-            <a
-              href="https://getbudi.dev"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-400 underline-offset-2 hover:text-blue-300 hover:underline"
-            >
-              Learn more
-            </a>
-          </p>
+          <ul className="mt-6 space-y-3 text-sm text-zinc-400">
+            <li className="flex items-start gap-2">
+              <CheckIcon />
+              <span>
+                Track Claude Code, Cursor, Copilot & Windsurf spend in one
+                dashboard
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon />
+              <span>Set budgets and get alerts before costs spike</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon />
+              <span>
+                Drill into spend by model, repo, branch, and team member
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon />
+              <span>Open-source, self-hostable, free tier on Budi Cloud</span>
+            </li>
+          </ul>
         </div>
+        <p className="text-xs text-zinc-600">
+          Open-source under MIT &middot;{" "}
+          <a
+            href="https://github.com/siropkin/budi-cloud"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline-offset-2 hover:text-zinc-400 hover:underline"
+          >
+            GitHub
+          </a>
+        </p>
+      </div>
 
-        {error && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
-            {error}
+      <div className="flex flex-1 items-center justify-center p-6">
+        <div className="w-full max-w-sm space-y-6">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold text-white">Sign in</h1>
+            <p className="mt-1 text-sm text-zinc-400">
+              Free, self-hosted, no credit card needed.{" "}
+              <a
+                href="https://getbudi.dev"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 underline-offset-2 hover:text-blue-300 hover:underline"
+              >
+                Learn more
+              </a>
+            </p>
           </div>
-        )}
 
-        {magicLinkSent ? (
-          <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-400">
-            Check your email for a sign-in link.
-          </div>
-        ) : (
-          <>
-            <div className="space-y-3">
-              <button
-                onClick={() => signInWithProvider("github")}
-                className="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2.5 text-sm font-medium text-black transition-colors hover:bg-zinc-200"
-              >
-                <GitHubIcon />
-                Continue with GitHub
-              </button>
-              <button
-                onClick={() => signInWithProvider("google")}
-                className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-white/10"
-              >
-                <GoogleIcon />
-                Continue with Google
-              </button>
+          {error && (
+            <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+              {error}
             </div>
+          )}
 
-            <div className="flex items-center gap-3">
-              <div className="h-px flex-1 bg-white/10" />
-              <span className="text-xs text-zinc-500">or</span>
-              <div className="h-px flex-1 bg-white/10" />
+          {magicLinkSent ? (
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-400">
+              Check your email for a sign-in link.
             </div>
+          ) : (
+            <>
+              <div className="space-y-3">
+                <button
+                  onClick={() => signInWithProvider("github")}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2.5 text-sm font-medium text-black transition-colors hover:bg-zinc-200"
+                >
+                  <GitHubIcon />
+                  Continue with GitHub
+                </button>
+                <button
+                  onClick={() => signInWithProvider("google")}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-white/10"
+                >
+                  <GoogleIcon />
+                  Continue with Google
+                </button>
+              </div>
 
-            <div className="space-y-3">
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="Email address"
-                className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none"
-                onKeyDown={(e) => e.key === "Enter" && signInWithMagicLink()}
-              />
-              <button
-                onClick={signInWithMagicLink}
-                disabled={loading || !email}
-                className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {loading ? "Sending..." : "Send magic link"}
-              </button>
-            </div>
-          </>
-        )}
+              <div className="flex items-center gap-3">
+                <div className="h-px flex-1 bg-white/10" />
+                <span className="text-xs text-zinc-500">or</span>
+                <div className="h-px flex-1 bg-white/10" />
+              </div>
+
+              <div className="space-y-3">
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Email address"
+                  className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none"
+                  onKeyDown={(e) => e.key === "Enter" && signInWithMagicLink()}
+                />
+                <button
+                  onClick={signInWithMagicLink}
+                  disabled={loading || !email}
+                  className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loading ? "Sending..." : "Send magic link"}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </main>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      className="mt-0.5 h-4 w-4 shrink-0 text-blue-400"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m4.5 12.75 6 6 9-13.5"
+      />
+    </svg>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,36 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import Link from "next/link";
+import { DashboardPreview } from "./_components/dashboard-preview";
 
 export const dynamic = "force-dynamic";
+
+const VALUE_PROPS = [
+  {
+    title: "Unified AI spend view",
+    description:
+      "See every team member's Claude Code, Cursor, Copilot, and Windsurf usage in one dashboard.",
+    icon: ChartIcon,
+  },
+  {
+    title: "Budgets & alerts",
+    description:
+      "Set per-team or per-user budgets and get notified before costs spike.",
+    icon: BellIcon,
+  },
+  {
+    title: "Model & repo breakdown",
+    description:
+      "Drill into cost by model, repository, and branch to find what's driving spend.",
+    icon: LayersIcon,
+  },
+  {
+    title: "Open-source & self-hostable",
+    description:
+      "Run Budi entirely on your own infrastructure, or use Budi Cloud's free tier.",
+    icon: CodeIcon,
+  },
+];
 
 export default async function Home() {
   const supabase = await createClient();
@@ -13,19 +41,209 @@ export default async function Home() {
   if (user) redirect("/dashboard");
 
   return (
-    <main className="flex flex-1 items-center justify-center bg-[#0a0a0a]">
-      <div className="text-center">
-        <h1 className="text-3xl font-bold text-white">Budi Cloud</h1>
-        <p className="mt-2 text-zinc-400">
-          Team-wide AI cost visibility for engineering managers.
+    <main className="flex flex-1 flex-col bg-[#0a0a0a]">
+      <nav className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-5">
+        <span className="text-lg font-bold text-white">Budi Cloud</span>
+        <div className="flex items-center gap-4">
+          <a
+            href="https://github.com/siropkin/budi-cloud"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-zinc-400 transition-colors hover:text-white"
+          >
+            GitHub
+          </a>
+          <a
+            href="https://getbudi.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-zinc-400 transition-colors hover:text-white"
+          >
+            Docs
+          </a>
+          <Link
+            href="/login"
+            className="rounded-lg bg-white/10 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-white/15"
+          >
+            Sign in
+          </Link>
+        </div>
+      </nav>
+
+      <section className="mx-auto flex w-full max-w-6xl flex-col items-center px-6 pt-16 pb-20 text-center sm:pt-24 sm:pb-28">
+        <h1 className="max-w-2xl text-4xl font-bold tracking-tight text-white sm:text-5xl">
+          Team-wide AI cost visibility for engineering managers
+        </h1>
+        <p className="mt-5 max-w-xl text-lg text-zinc-400">
+          Track what your team spends on Claude Code, Cursor, Copilot, and
+          Windsurf — in one place. Set budgets, catch spikes early, and make
+          informed decisions about AI tooling.
+        </p>
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <Link
+            href="/login"
+            className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          >
+            Get started free
+          </Link>
+          <a
+            href="https://github.com/siropkin/budi-cloud"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-lg border border-white/10 bg-white/5 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-white/10"
+          >
+            View on GitHub
+          </a>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-5xl px-6 pb-20">
+        <div className="overflow-hidden rounded-xl border border-white/10 bg-white/[0.02] shadow-2xl shadow-blue-500/5">
+          <DashboardPreview />
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-24">
+        <div className="grid gap-6 sm:grid-cols-2">
+          {VALUE_PROPS.map((prop) => (
+            <div
+              key={prop.title}
+              className="rounded-xl border border-white/10 bg-white/[0.02] p-6"
+            >
+              <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-blue-600/10 text-blue-400">
+                <prop.icon />
+              </div>
+              <h3 className="text-base font-semibold text-white">
+                {prop.title}
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                {prop.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-24 text-center">
+        <h2 className="text-2xl font-bold text-white sm:text-3xl">
+          Ready to see where your AI budget goes?
+        </h2>
+        <p className="mt-3 text-zinc-400">
+          Free to use. Self-host or use Budi Cloud. No credit card required.
         </p>
         <Link
           href="/login"
-          className="mt-6 inline-block rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          className="mt-6 inline-block rounded-lg bg-blue-600 px-8 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-700"
         >
-          Sign in
+          Get started free
         </Link>
-      </div>
+      </section>
+
+      <footer className="border-t border-white/10 py-8">
+        <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-6 sm:flex-row">
+          <span className="text-sm text-zinc-500">
+            &copy; {new Date().getFullYear()} Budi. Open-source under MIT.
+          </span>
+          <div className="flex items-center gap-5">
+            <a
+              href="https://github.com/siropkin/budi-cloud"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-zinc-500 transition-colors hover:text-white"
+            >
+              GitHub
+            </a>
+            <a
+              href="https://getbudi.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-zinc-500 transition-colors hover:text-white"
+            >
+              Docs
+            </a>
+            <a
+              href="https://github.com/siropkin/budi-cloud/blob/main/CHANGELOG.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-zinc-500 transition-colors hover:text-white"
+            >
+              Changelog
+            </a>
+          </div>
+        </div>
+      </footer>
     </main>
+  );
+}
+
+function ChartIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+      />
+    </svg>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0"
+      />
+    </svg>
+  );
+}
+
+function LayersIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6.429 9.75 2.25 12l4.179 2.25m0-4.5 5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L12 12.75 6.429 9.75m11.142 0 4.179 2.25-9.75 5.25-9.75-5.25 4.179-2.25"
+      />
+    </svg>
+  );
+}
+
+function CodeIcon() {
+  return (
+    <svg
+      className="h-5 w-5"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+      />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary

Closes #327.

- **Landing page (`/`)**: Added hero section with tagline, dashboard preview mockup (styled SVG/HTML), 4 value-prop cards, bottom CTA, and footer with GitHub/Docs/Changelog links. Authed users still redirect to `/dashboard`.
- **Login page (`/login`)**: Redesigned as a split layout — left panel shows value props and branding (hidden on mobile for responsive layout), right panel keeps the existing OAuth + magic-link auth form unchanged.
- **Dashboard preview**: New `DashboardPreview` component renders a mock dashboard with stat cards, bar chart, and breakdown tiles so visitors see what the product looks like before signing in.

## Acceptance criteria

- [x] A first-time visitor understands what Budi does before signing in
- [x] Dashboard preview/visual is shown above the fold
- [x] Key value props visible (4 cards on landing, checklist on login)
- [x] CTA is prominent and leads to `/login`
- [x] Mobile-responsive (stacks on small screens, login left panel hidden on mobile)
- [x] Existing auth flow (OAuth + magic-link + `?next=` forwarding) is preserved
- [x] Authed users still redirect straight to `/dashboard`

## Test plan

- [ ] Visit `/` as unauthenticated user — see hero, preview, value props, CTA, footer
- [ ] Click "Get started free" → lands on `/login`
- [ ] Visit `/login` — see split layout on desktop, auth-only on mobile
- [ ] Sign in via GitHub/Google/magic-link — verify `?next=` forwarding still works
- [ ] Visit `/` as authenticated user — redirects to `/dashboard`
- [ ] Resize browser: verify mobile responsiveness on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)