### PR TITLE
fix: always render bar chart value labels outside the bar

### DIFF
--- a/src/components/charts/cost-bar-chart.test.tsx
+++ b/src/components/charts/cost-bar-chart.test.tsx
@@ -98,7 +98,7 @@ describe("CostBarChart", () => {
     expect((outside.props as { textAnchor: string }).textAnchor).toBe("start");
   });
 
-  it("flips the value label inside the bar when it nears the right edge (#261)", () => {
+  it("always renders value labels outside the bar (#330)", () => {
     const saturating = [
       { label: "leader", cost_cents: 1000, tokens: 0 },
       { label: "tiny", cost_cents: 10, tokens: 0 },
@@ -112,17 +112,13 @@ describe("CostBarChart", () => {
       }
     ).content;
 
-    // Leader is 100% of the max — ratio 1.0 >= 0.85 — render inside the bar
-    // (white text, end-anchored at the right edge).
-    const inside = content({ x: 0, y: 0, width: 200, height: 20, value: 1000 });
-    expect((inside.props as { textAnchor: string }).textAnchor).toBe("end");
-    expect((inside.props as { fill: string }).fill).toBe("#ffffff");
+    const leader = content({ x: 0, y: 0, width: 200, height: 20, value: 1000 });
+    expect((leader.props as { textAnchor: string }).textAnchor).toBe("start");
+    expect((leader.props as { fill: string }).fill).toBe("#71717a");
 
-    // Tiny is 1% of the max — render outside the bar (gray text, start-anchored
-    // just past the bar's right edge).
-    const outside = content({ x: 0, y: 0, width: 2, height: 20, value: 10 });
-    expect((outside.props as { textAnchor: string }).textAnchor).toBe("start");
-    expect((outside.props as { fill: string }).fill).toBe("#71717a");
+    const tiny = content({ x: 0, y: 0, width: 2, height: 20, value: 10 });
+    expect((tiny.props as { textAnchor: string }).textAnchor).toBe("start");
+    expect((tiny.props as { fill: string }).fill).toBe("#71717a");
   });
 
   it("renders token totals when unit='tokens' (#128)", () => {
@@ -140,9 +136,7 @@ describe("CostBarChart", () => {
         content: (props: Record<string, unknown>) => ReactElement;
       }
     ).content;
-    // Token mode formats with fmtNum (no $). Exercise the outside-the-bar
-    // branch on the smaller of the two rows so the assertion isn't sensitive
-    // to the flip-inside threshold.
+    // Token mode formats with fmtNum (no $).
     const tinyLabel = content({
       x: 0,
       y: 0,

--- a/src/components/charts/cost-bar-chart.tsx
+++ b/src/components/charts/cost-bar-chart.tsx
@@ -123,14 +123,6 @@ export function CostBarChart({
   }));
 
   const height = barChartHeight(sorted.length);
-  // Largest bar drives the "should we flip the value label inside?" decision
-  // (#261). Comparing per-bar value to maxValue is a stable proxy for the
-  // pixel-width ratio because recharts maps value→pixel linearly across the
-  // plot area. Bars at ≥ FLIP_INSIDE_RATIO of the max would otherwise push
-  // their value label past the chart's right edge (visibly clipped on 390px
-  // viewports).
-  const maxValue = sorted[0]?.value ?? 0;
-  const FLIP_INSIDE_RATIO = 0.85;
 
   return (
     <ResponsiveContainer width="100%" height={height}>
@@ -175,6 +167,7 @@ export function CostBarChart({
         <XAxis
           dataKey="value"
           type="number"
+          domain={[0, (max: number) => max * 1.1]}
           tickFormatter={(v) => fmt(Number(v))}
           axisLine={false}
           tickLine={false}
@@ -230,25 +223,6 @@ export function CostBarChart({
                 typeof p.height === "number" ? p.height : Number(p.height ?? 0);
               const value = Number(p.value ?? 0);
               const text = fmt(value);
-              const flipInside =
-                maxValue > 0 && value / maxValue >= FLIP_INSIDE_RATIO;
-              if (flipInside) {
-                // Anchor inside the bar at the right edge so the label stays
-                // visible even when the bar saturates the plot area. White
-                // sits cleanly on the blue fill (`#3b82f6`).
-                return (
-                  <text
-                    x={x + width - 6}
-                    y={y + height / 2}
-                    dy={4}
-                    textAnchor="end"
-                    fill="#ffffff"
-                    fontSize={12}
-                  >
-                    {text}
-                  </text>
-                );
-              }
               return (
                 <text
                   x={x + width + 4}


### PR DESCRIPTION
## Summary
- Remove the `flipInside` logic that rendered the tallest bar's value label inside (white text on blue) while shorter bars rendered labels outside — all labels now render consistently outside in gray
- Add XAxis `domain` padding to 110% of max value so labels aren't clipped on narrow viewports, addressing the original concern from #261

Closes #330

## Test plan
- [ ] Verify all bar chart labels render outside the bars (gray text to the right)
- [ ] Check on a narrow (390px) viewport that the tallest bar's label is not clipped
- [ ] Confirm tooltip still works on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)