### PR TITLE
copy: soften team-centric language for solo developers

### DIFF
--- a/src/app/dashboard/settings/invite-section.tsx
+++ b/src/app/dashboard/settings/invite-section.tsx
@@ -26,11 +26,11 @@ export function InviteSection() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Invite Team Members</CardTitle>
+        <CardTitle>Invite Members</CardTitle>
       </CardHeader>
       <CardContent>
         <p className="mb-3 text-sm text-zinc-400">
-          Generate an invite link to share with your team. Links expire in 7
+          Generate an invite link to share with others. Links expire in 7
           days.
         </p>
 

--- a/src/app/dashboard/settings/invite-section.tsx
+++ b/src/app/dashboard/settings/invite-section.tsx
@@ -30,8 +30,7 @@ export function InviteSection() {
       </CardHeader>
       <CardContent>
         <p className="mb-3 text-sm text-zinc-400">
-          Generate an invite link to share with others. Links expire in 7
-          days.
+          Generate an invite link to share with others. Links expire in 7 days.
         </p>
 
         {error && <p className="mb-3 text-sm text-red-400">{error}</p>}

--- a/src/app/dashboard/settings/page.test.tsx
+++ b/src/app/dashboard/settings/page.test.tsx
@@ -76,16 +76,16 @@ async function render() {
 }
 
 describe("dashboard/settings /page", () => {
-  it("smoke: renders Workspace, API Key, and Team Members sections with populated data", async () => {
+  it("smoke: renders Workspace, API Key, and Members sections with populated data", async () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
     expect(text).toContain("Settings");
     expect(text).toContain("Workspace");
     expect(text).toContain("Acme");
-    // The team members section header includes the count — pin it so a
+    // The members section header includes the count — pin it so a
     // refactor that drops the count or the header is caught.
-    expect(text).toContain("Team Members");
+    expect(text).toContain("Members");
     expect(text).toContain("2");
     expect(text).toContain("Ivan");
     expect(text).toContain("Jane");
@@ -96,7 +96,7 @@ describe("dashboard/settings /page", () => {
     const node = await render();
     expect(node).toBeTruthy();
     const text = extractText(node);
-    expect(text).toContain("Team Members");
+    expect(text).toContain("Members");
     expect(text).toContain("0");
     expect(text).toContain("No members yet");
   });

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -122,8 +122,8 @@ export default async function SettingsPage() {
           </CardHeader>
           <CardContent>
             <p className="mb-3 text-sm text-zinc-400">
-              Upload and manage your negotiated price lists. The
-              active list overrides the daemon&apos;s ingested costs.
+              Upload and manage your negotiated price lists. The active list
+              overrides the daemon&apos;s ingested costs.
             </p>
             <Link
               href="/dashboard/settings/pricing"

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -80,7 +80,7 @@ export default async function SettingsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Team Members ({members.length})</CardTitle>
+          <CardTitle>Members ({members.length})</CardTitle>
         </CardHeader>
         <CardContent>
           {members.length === 0 ? (
@@ -122,7 +122,7 @@ export default async function SettingsPage() {
           </CardHeader>
           <CardContent>
             <p className="mb-3 text-sm text-zinc-400">
-              Upload and manage your team&apos;s negotiated price lists. The
+              Upload and manage your negotiated price lists. The
               active list overrides the daemon&apos;s ingested costs.
             </p>
             <Link

--- a/src/app/dashboard/settings/pricing/page.tsx
+++ b/src/app/dashboard/settings/pricing/page.tsx
@@ -118,8 +118,8 @@ export default async function PricingSettingsPage({
         </Link>
         <h1 className="mt-2 text-xl font-bold">Pricing</h1>
         <p className="mt-1 text-sm text-zinc-400">
-          Manage your negotiated price lists. Recalculations use the
-          active list to override the daemon&apos;s ingested costs.
+          Manage your negotiated price lists. Recalculations use the active list
+          to override the daemon&apos;s ingested costs.
         </p>
       </div>
 

--- a/src/app/dashboard/settings/pricing/page.tsx
+++ b/src/app/dashboard/settings/pricing/page.tsx
@@ -118,7 +118,7 @@ export default async function PricingSettingsPage({
         </Link>
         <h1 className="mt-2 text-xl font-bold">Pricing</h1>
         <p className="mt-1 text-sm text-zinc-400">
-          Manage your team&apos;s negotiated price lists. Recalculations use the
+          Manage your negotiated price lists. Recalculations use the
           active list to override the daemon&apos;s ingested costs.
         </p>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Budi Cloud",
-  description: "Team-wide AI cost visibility for engineering managers",
+  description: "AI cost visibility for developers and teams",
 };
 
 export default function RootLayout({

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -56,7 +56,7 @@ export default function LoginPage() {
         </Link>
         <div className="max-w-md">
           <p className="text-2xl font-semibold leading-snug text-white">
-            Team-wide AI cost visibility for engineering managers.
+            AI cost visibility for developers and teams.
           </p>
           <ul className="mt-6 space-y-3 text-sm text-zinc-400">
             <li className="flex items-start gap-2">
@@ -73,7 +73,7 @@ export default function LoginPage() {
             <li className="flex items-start gap-2">
               <CheckIcon />
               <span>
-                Drill into spend by model, repo, branch, and team member
+                Drill into spend by model, repo, branch, and contributor
               </span>
             </li>
             <li className="flex items-start gap-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,13 +9,13 @@ const VALUE_PROPS = [
   {
     title: "Unified AI spend view",
     description:
-      "See every team member's Claude Code, Cursor, Copilot, and Windsurf usage in one dashboard.",
+      "See all your Claude Code, Cursor, Copilot, and Windsurf usage in one dashboard.",
     icon: ChartIcon,
   },
   {
     title: "Budgets & alerts",
     description:
-      "Set per-team or per-user budgets and get notified before costs spike.",
+      "Set budgets and get notified before costs spike.",
     icon: BellIcon,
   },
   {
@@ -72,10 +72,10 @@ export default async function Home() {
 
       <section className="mx-auto flex w-full max-w-6xl flex-col items-center px-6 pt-16 pb-20 text-center sm:pt-24 sm:pb-28">
         <h1 className="max-w-2xl text-4xl font-bold tracking-tight text-white sm:text-5xl">
-          Team-wide AI cost visibility for engineering managers
+          AI cost visibility for developers and teams
         </h1>
         <p className="mt-5 max-w-xl text-lg text-zinc-400">
-          Track what your team spends on Claude Code, Cursor, Copilot, and
+          Track what you spend on Claude Code, Cursor, Copilot, and
           Windsurf — in one place. Set budgets, catch spikes early, and make
           informed decisions about AI tooling.
         </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,8 +14,7 @@ const VALUE_PROPS = [
   },
   {
     title: "Budgets & alerts",
-    description:
-      "Set budgets and get notified before costs spike.",
+    description: "Set budgets and get notified before costs spike.",
     icon: BellIcon,
   },
   {
@@ -75,9 +74,9 @@ export default async function Home() {
           AI cost visibility for developers and teams
         </h1>
         <p className="mt-5 max-w-xl text-lg text-zinc-400">
-          Track what you spend on Claude Code, Cursor, Copilot, and
-          Windsurf — in one place. Set budgets, catch spikes early, and make
-          informed decisions about AI tooling.
+          Track what you spend on Claude Code, Cursor, Copilot, and Windsurf —
+          in one place. Set budgets, catch spikes early, and make informed
+          decisions about AI tooling.
         </p>
         <div className="mt-8 flex flex-col gap-3 sm:flex-row">
           <Link

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -38,9 +38,9 @@ export default async function SetupPage({
     <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
       <div className="w-full max-w-sm space-y-6 rounded-xl border border-white/10 bg-white/[0.02] p-8">
         <div className="text-center">
-          <h1 className="text-xl font-bold text-white">Create Your Team</h1>
+          <h1 className="text-xl font-bold text-white">Create Your Workspace</h1>
           <p className="mt-1 text-sm text-zinc-400">
-            Set up a workspace to start tracking team AI costs.
+            Set up a workspace to start tracking AI costs.
           </p>
         </div>
         <WorkspaceSetupForm />

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -38,7 +38,9 @@ export default async function SetupPage({
     <main className="flex min-h-screen items-center justify-center bg-[#0a0a0a]">
       <div className="w-full max-w-sm space-y-6 rounded-xl border border-white/10 bg-white/[0.02] p-8">
         <div className="text-center">
-          <h1 className="text-xl font-bold text-white">Create Your Workspace</h1>
+          <h1 className="text-xl font-bold text-white">
+            Create Your Workspace
+          </h1>
           <p className="mt-1 text-sm text-zinc-400">
             Set up a workspace to start tracking AI costs.
           </p>


### PR DESCRIPTION
## Summary
- Replaces team-centric copy ("Team-wide AI cost visibility for engineering managers") with inclusive "you/your" voice across landing, login, setup, settings, and pricing pages — closes #329
- Renames "Team Members" → "Members", "Invite Team Members" → "Invite Members", "Create Your Team" → "Create Your Workspace"
- Updates test assertions to match the new headings

## Test plan
- [x] All 447 existing tests pass
- [ ] Visually verify landing page hero + value props
- [ ] Visually verify login page left panel copy
- [ ] Visually verify setup page heading
- [ ] Visually verify settings > Members and Invite sections
- [ ] Visually verify settings > Pricing description

🤖 Generated with [Claude Code](https://claude.com/claude-code)