### PR TITLE
copy: fix inconsistent "Back to login" on auth error page

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -49,7 +49,7 @@ export default function AuthErrorPage() {
             href="/login"
             className="block w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-white/10"
           >
-            Back to login
+            Back to sign in
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Changes "Back to login" → "Back to sign in" on the auth error page to match the rest of the codebase's consistent use of "sign in" / "sign out" terminology.

Closes #334

## Test plan
- [ ] Visit `/auth/error` and confirm the link now reads "Back to sign in"
- [ ] Verify no other copy on the page was affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)