### PR TITLE
style: sync primary accent color with getbudi.dev (blue → green)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,11 +3,13 @@
 :root {
   --background: #0a0a0a;
   --foreground: #ededed;
+  --accent: #22c55e;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-accent: var(--accent);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -105,7 +105,7 @@ export default function LoginPage() {
                 href="https://getbudi.dev"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-400 underline-offset-2 hover:text-blue-300 hover:underline"
+                className="text-green-400 underline-offset-2 hover:text-green-300 hover:underline"
               >
                 Learn more
               </a>
@@ -153,13 +153,13 @@ export default function LoginPage() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="Email address"
-                  className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-blue-500 focus:outline-none"
+                  className="w-full rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder:text-zinc-500 focus:border-accent focus:outline-none"
                   onKeyDown={(e) => e.key === "Enter" && signInWithMagicLink()}
                 />
                 <button
                   onClick={signInWithMagicLink}
                   disabled={loading || !email}
-                  className="w-full rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="w-full rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-green-600 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {loading ? "Sending..." : "Send magic link"}
                 </button>
@@ -175,7 +175,7 @@ export default function LoginPage() {
 function CheckIcon() {
   return (
     <svg
-      className="mt-0.5 h-4 w-4 shrink-0 text-blue-400"
+      className="mt-0.5 h-4 w-4 shrink-0 text-green-400"
       fill="none"
       viewBox="0 0 24 24"
       strokeWidth={2}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ export default async function Home() {
           </a>
           <Link
             href="/login"
-            className="rounded-lg bg-white/10 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-white/15"
+            className="rounded-lg bg-accent px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-green-600"
           >
             Sign in
           </Link>
@@ -81,7 +81,7 @@ export default async function Home() {
         <div className="mt-8 flex flex-col gap-3 sm:flex-row">
           <Link
             href="/login"
-            className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+            className="rounded-lg bg-accent px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-green-600"
           >
             Get started free
           </Link>
@@ -97,7 +97,7 @@ export default async function Home() {
       </section>
 
       <section className="mx-auto w-full max-w-5xl px-6 pb-20">
-        <div className="overflow-hidden rounded-xl border border-white/10 bg-white/[0.02] shadow-2xl shadow-blue-500/5">
+        <div className="overflow-hidden rounded-xl border border-white/10 bg-white/[0.02] shadow-2xl shadow-green-500/5">
           <DashboardPreview />
         </div>
       </section>
@@ -109,7 +109,7 @@ export default async function Home() {
               key={prop.title}
               className="rounded-xl border border-white/10 bg-white/[0.02] p-6"
             >
-              <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-blue-600/10 text-blue-400">
+              <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-lg bg-accent/10 text-green-400">
                 <prop.icon />
               </div>
               <h3 className="text-base font-semibold text-white">
@@ -132,7 +132,7 @@ export default async function Home() {
         </p>
         <Link
           href="/login"
-          className="mt-6 inline-block rounded-lg bg-blue-600 px-8 py-3 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+          className="mt-6 inline-block rounded-lg bg-accent px-8 py-3 text-sm font-medium text-white transition-colors hover:bg-green-600"
         >
           Get started free
         </Link>


### PR DESCRIPTION
## Summary
- Define a shared `--accent` CSS variable (`#22c55e` / green-500) in `globals.css` and register it as a Tailwind `accent` color via `@theme inline`, so both repos can stay in sync through a single token
- Replace all `bg-blue-600` / `bg-white/10` primary CTAs on the landing page and login page with `bg-accent`
- Update value-prop icon tints, dashboard preview shadow, focus rings, and "Learn more" link to match the green accent

Closes #336

## Test plan
- [ ] Landing page: nav "Sign in" button renders green
- [ ] Landing page: both "Get started free" buttons render green
- [ ] Landing page: value-prop icons use green tint
- [ ] Login page: "Send magic link" button renders green
- [ ] Login page: email input focus ring is green
- [ ] Login page: check-mark icons and "Learn more" link are green
- [ ] Hover states darken to green-600 on all buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)