### PR TITLE
fix: filter sessions by last activity instead of start time (closes #340)

### DIFF
--- a/src/app/api/v1/ingest/route.test.ts
+++ b/src/app/api/v1/ingest/route.test.ts
@@ -27,7 +27,7 @@ class FakeSupabase {
 
   from(name: string) {
     if (!this.tables.has(name)) this.tables.set(name, []);
-    return new FakeQuery(this.tables.get(name)!);
+    return new FakeQuery(this.tables.get(name)!, name);
   }
 
   /**
@@ -116,7 +116,10 @@ class FakeQuery {
   private _head = false;
   private _countMode: "exact" | null = null;
 
-  constructor(private readonly rows: Row[]) {}
+  constructor(
+    private readonly rows: Row[],
+    private readonly tableName: string = ""
+  ) {}
 
   select(_cols?: string, opts?: { count?: "exact"; head?: boolean }) {
     this._countMode = opts?.count ?? null;
@@ -237,6 +240,12 @@ class FakeQuery {
         this.rows[existingIdx] = { ...this.rows[existingIdx], ...incoming };
       } else {
         this.rows.push({ ...incoming });
+      }
+    }
+    // Simulate the GENERATED ALWAYS AS (COALESCE(ended_at, started_at)) column
+    if (this.tableName === "session_summaries") {
+      for (const r of this.rows) {
+        r.last_active_at = r.ended_at ?? r.started_at;
       }
     }
     return {

--- a/src/app/dashboard/sessions/page.test.tsx
+++ b/src/app/dashboard/sessions/page.test.tsx
@@ -133,7 +133,7 @@ describe("dashboard/sessions /page", () => {
       "Title",
       "Provider",
       "Model",
-      "Started",
+      "Last Active",
       "Duration",
       "Repo",
       "Branch",
@@ -166,7 +166,7 @@ describe("dashboard/sessions /page", () => {
     expect(text).not.toContain("Member");
     // Other column headers must still render — the suppression is scoped.
     expect(text).toContain("Provider");
-    expect(text).toContain("Started");
+    expect(text).toContain("Last Active");
   });
 
   it("units toggle: ?units=tokens flips the Cost column header to Tokens (#128)", async () => {

--- a/src/app/dashboard/sessions/page.tsx
+++ b/src/app/dashboard/sessions/page.tsx
@@ -165,18 +165,20 @@ export default async function SessionsPage({
       ),
     },
     {
-      key: "started",
-      header: "Started",
+      key: "last-active",
+      header: "Last Active",
       headerClassName: headerCellClass,
       cellClassName: "text-zinc-400",
       cellTitle: (s) =>
-        s.started_at ? new Date(s.started_at).toLocaleString() : undefined,
+        s.last_active_at
+          ? new Date(s.last_active_at).toLocaleString()
+          : undefined,
       render: (s) => (
         <Link
           href={hrefForSession(s)}
           className="block max-w-[14ch] truncate py-2 pr-3 whitespace-nowrap"
         >
-          {formatTimestamp(s.started_at)}
+          {formatTimestamp(s.last_active_at)}
         </Link>
       ),
     },
@@ -352,7 +354,7 @@ export default async function SessionsPage({
                         </span>
                       )}
                       <span className="shrink-0 text-xs text-zinc-500">
-                        {formatTimestamp(s.started_at)}
+                        {formatTimestamp(s.last_active_at)}
                       </span>
                     </div>
                     {s.title && (

--- a/src/lib/dal.test.ts
+++ b/src/lib/dal.test.ts
@@ -1828,24 +1828,28 @@ describe("getSessions cursor pagination (#85)", () => {
     fake.seed("users", [{ ...manager }]);
     fake.seed("devices", [{ id: deviceId, user_id: manager.id }]);
     // Newest first when we paginate. Index 0 == newest.
-    const rows = Array.from({ length: n }, (_, i) => ({
-      device_id: deviceId,
-      session_id: `sess_${String(n - i).padStart(4, "0")}`,
-      provider: "claude_code",
-      started_at: new Date(
+    const rows = Array.from({ length: n }, (_, i) => {
+      const started_at = new Date(
         Date.UTC(2026, 3, 1, 0, 0, 0) + i * 60_000
-      ).toISOString(),
-      ended_at: null,
-      duration_ms: null,
-      repo_id: "repo_x",
-      git_branch: "refs/heads/main",
-      ticket: null,
-      message_count: 1,
-      total_input_tokens: 0,
-      total_output_tokens: 0,
-      total_cost_cents_effective: 0,
-      total_cost_cents_ingested: 0,
-    }));
+      ).toISOString();
+      return {
+        device_id: deviceId,
+        session_id: `sess_${String(n - i).padStart(4, "0")}`,
+        provider: "claude_code",
+        started_at,
+        ended_at: null,
+        last_active_at: started_at,
+        duration_ms: null,
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        ticket: null,
+        message_count: 1,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_cost_cents_effective: 0,
+        total_cost_cents_ingested: 0,
+      };
+    });
     fake.seed("session_summaries", rows);
     return rows;
   }
@@ -1859,10 +1863,10 @@ describe("getSessions cursor pagination (#85)", () => {
 
     expect(page.rows).toHaveLength(2);
     expect(page.nextCursor).not.toBeNull();
-    // Newest first: index 0 = newest started_at = "2026-04-01T00:04:00Z".
-    expect(page.rows[0].started_at).toBe("2026-04-01T00:04:00.000Z");
-    expect(page.rows[1].started_at).toBe("2026-04-01T00:03:00.000Z");
-    expect(page.nextCursor?.startedAt).toBe("2026-04-01T00:03:00.000Z");
+    // Newest first: index 0 = newest last_active_at = "2026-04-01T00:04:00Z".
+    expect(page.rows[0].last_active_at).toBe("2026-04-01T00:04:00.000Z");
+    expect(page.rows[1].last_active_at).toBe("2026-04-01T00:03:00.000Z");
+    expect(page.nextCursor?.lastActiveAt).toBe("2026-04-01T00:03:00.000Z");
   });
 
   it("walks the entire history across pages without skipping or duplicating rows", async () => {
@@ -1904,7 +1908,7 @@ describe("getSessions cursor pagination (#85)", () => {
     expect(page.nextCursor).toBeNull();
   });
 
-  it("breaks ties on session_id when two rows share the same started_at", async () => {
+  it("breaks ties on session_id when two rows share the same last_active_at", async () => {
     // Composite cursor must keep tied rows in a deterministic order so the
     // walk neither skips one nor returns the same row twice.
     fake.seed("workspaces", [{ id: "org_team", name: "team" }]);
@@ -1918,6 +1922,7 @@ describe("getSessions cursor pagination (#85)", () => {
         provider: "claude_code",
         started_at: ts,
         ended_at: null,
+        last_active_at: ts,
         duration_ms: null,
         repo_id: "repo_x",
         git_branch: "refs/heads/main",
@@ -1934,6 +1939,7 @@ describe("getSessions cursor pagination (#85)", () => {
         provider: "claude_code",
         started_at: ts,
         ended_at: null,
+        last_active_at: ts,
         duration_ms: null,
         repo_id: "repo_x",
         git_branch: "refs/heads/main",
@@ -1952,7 +1958,7 @@ describe("getSessions cursor pagination (#85)", () => {
     });
     expect(first.rows.map((r) => r.session_id)).toEqual(["sess_b"]);
     expect(first.nextCursor).toEqual({
-      startedAt: ts,
+      lastActiveAt: ts,
       sessionId: "sess_b",
     });
 
@@ -1990,6 +1996,7 @@ describe("getSessions cursor pagination (#85)", () => {
         provider: "claude_code",
         started_at: "2026-04-15T10:00:00.000Z",
         ended_at: null,
+        last_active_at: "2026-04-15T10:00:00.000Z",
         duration_ms: null,
         repo_id: "repo_x",
         git_branch: "refs/heads/main",
@@ -2006,6 +2013,7 @@ describe("getSessions cursor pagination (#85)", () => {
         provider: "claude_code",
         started_at: "2026-04-15T11:00:00.000Z",
         ended_at: null,
+        last_active_at: "2026-04-15T11:00:00.000Z",
         duration_ms: null,
         repo_id: "repo_x",
         git_branch: "refs/heads/main",
@@ -2029,6 +2037,55 @@ describe("getSessions cursor pagination (#85)", () => {
     };
     const page = await getSessions(jane, wideRange);
     expect(page.rows.map((r) => r.session_id)).toEqual(["sess_jane"]);
+  });
+
+  it("includes sessions with old started_at but recent ended_at in a narrow range (#340)", async () => {
+    fake.seed("workspaces", [{ id: "org_team", name: "team" }]);
+    fake.seed("users", [{ ...manager }]);
+    fake.seed("devices", [{ id: "dev_ivan", user_id: manager.id }]);
+    fake.seed("session_summaries", [
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_old_start_recent_activity",
+        provider: "copilot_chat",
+        started_at: "2025-10-17T08:00:00.000Z",
+        ended_at: "2026-05-19T12:00:00.000Z",
+        last_active_at: "2026-05-19T12:00:00.000Z",
+        duration_ms: null,
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        ticket: null,
+        message_count: 5,
+        total_input_tokens: 100,
+        total_output_tokens: 50,
+        total_cost_cents_effective: 10,
+        total_cost_cents_ingested: 10,
+      },
+      {
+        device_id: "dev_ivan",
+        session_id: "sess_recent",
+        provider: "claude_code",
+        started_at: "2026-05-19T09:00:00.000Z",
+        ended_at: "2026-05-19T10:00:00.000Z",
+        last_active_at: "2026-05-19T10:00:00.000Z",
+        duration_ms: 3_600_000,
+        repo_id: "repo_x",
+        git_branch: "refs/heads/main",
+        ticket: null,
+        message_count: 10,
+        total_input_tokens: 200,
+        total_output_tokens: 100,
+        total_cost_cents_effective: 20,
+        total_cost_cents_ingested: 20,
+      },
+    ]);
+
+    const { getSessions } = await loadDal();
+    const todayRange = utcRange("2026-05-18", "2026-05-19");
+    const page = await getSessions(manager, todayRange);
+
+    const ids = page.rows.map((r) => r.session_id).sort();
+    expect(ids).toEqual(["sess_old_start_recent_activity", "sess_recent"]);
   });
 });
 
@@ -2072,6 +2129,7 @@ describe("getSessions multi-provider visibility (#202)", () => {
         session_id: "sess_cc",
         provider: "claude_code",
         started_at: "2026-04-15T10:00:00.000Z",
+        last_active_at: "2026-04-15T10:00:00.000Z",
         surface: "terminal",
       },
       {
@@ -2079,6 +2137,7 @@ describe("getSessions multi-provider visibility (#202)", () => {
         session_id: "sess_copilot",
         provider: "copilot_chat",
         started_at: "2026-04-15T11:00:00.000Z",
+        last_active_at: "2026-04-15T11:00:00.000Z",
         surface: "vscode",
       },
       {
@@ -2086,6 +2145,7 @@ describe("getSessions multi-provider visibility (#202)", () => {
         session_id: "sess_cursor",
         provider: "cursor",
         started_at: "2026-04-15T12:00:00.000Z",
+        last_active_at: "2026-04-15T12:00:00.000Z",
         surface: "cursor",
       },
       {
@@ -2093,6 +2153,7 @@ describe("getSessions multi-provider visibility (#202)", () => {
         session_id: "sess_codex",
         provider: "codex",
         started_at: "2026-04-15T13:00:00.000Z",
+        last_active_at: "2026-04-15T13:00:00.000Z",
         surface: "terminal",
       },
       {
@@ -2100,6 +2161,7 @@ describe("getSessions multi-provider visibility (#202)", () => {
         session_id: "sess_copilot_cli",
         provider: "copilot_cli",
         started_at: "2026-04-15T14:00:00.000Z",
+        last_active_at: "2026-04-15T14:00:00.000Z",
         surface: "terminal",
       },
     ]);

--- a/src/lib/dal/sessions.ts
+++ b/src/lib/dal/sessions.ts
@@ -12,17 +12,22 @@ import {
 
 /**
  * Cursor for `getSessions` pagination — encodes the row at the boundary of the
- * current page. The composite `(started_at, session_id)` shape gives a stable
- * walk even when two sessions share a `started_at` (rare but real once cursor
- * sync re-emits a batch with the same instant): the SQL filter
- * `(started_at, session_id) < cursor` keeps the strict ordering and never
+ * current page. The composite `(last_active_at, session_id)` shape gives a
+ * stable walk even when two sessions share a `last_active_at` (rare but real
+ * once cursor sync re-emits a batch with the same instant): the SQL filter
+ * `(last_active_at, session_id) < cursor` keeps the strict ordering and never
  * skips or duplicates a tied row.
  *
  * The dashboard URL serializes this as `?cursor=<base64url(JSON)>` so a
  * session_id containing punctuation never collides with a delimiter (#85).
+ *
+ * History: prior to #340 this used `started_at` as the sort/cursor key. That
+ * meant sessions started months ago but active today were invisible in the 1d /
+ * 7d views. `last_active_at` = `COALESCE(ended_at, started_at)` matches the
+ * local statusline's cost computation which uses message timestamps.
  */
 export interface SessionsCursor {
-  startedAt: string;
+  lastActiveAt: string;
   sessionId: string;
 }
 
@@ -30,15 +35,20 @@ export interface SessionsCursor {
 export const SESSIONS_PAGE_SIZE = 50;
 
 /**
- * Get a single page of sessions ordered by `(started_at desc, session_id desc)`.
+ * Get a single page of sessions ordered by `(last_active_at desc, session_id desc)`.
  * Manager sees full org; member sees own devices only (ADR-0083 §6).
  * `options.scopedUserId` further narrows a manager view to a single teammate.
  *
- * Pagination is cursor-based on `(started_at, session_id)`. Sessions are
- * immutable once written so the cursor is stable across reloads — no offset
- * skew under concurrent writes, no expensive count query required to know if
- * another page exists. We fetch `pageSize + 1` rows so `hasMore` falls out of
- * the result-set size; the extra row is dropped before returning.
+ * Pagination is cursor-based on `(last_active_at, session_id)`.
+ * `last_active_at` is the generated column `COALESCE(ended_at, started_at)`
+ * added in migration 026 (#340), so sessions sort by most-recent activity —
+ * a JetBrains session started 7 months ago but active today appears at the
+ * top of a 1d view rather than being invisible.
+ *
+ * Sessions are immutable once written so the cursor is stable across reloads —
+ * no offset skew under concurrent writes, no expensive count query required to
+ * know if another page exists. We fetch `pageSize + 1` rows so `hasMore` falls
+ * out of the result-set size; the extra row is dropped before returning.
  *
  * History: prior to #85 this returned the most recent 100 rows with no
  * pagination, silently truncating the visible Sessions history to whatever
@@ -64,19 +74,20 @@ export async function getSessions(
     .from("session_summaries")
     .select("*")
     .in("device_id", deviceIds)
-    .gte("started_at", range.startedAtFrom)
-    .lte("started_at", range.startedAtTo)
-    .order("started_at", { ascending: false })
+    .gte("last_active_at", range.startedAtFrom)
+    .lte("last_active_at", range.startedAtTo)
+    .order("last_active_at", { ascending: false })
     // Tie-breaker: without a secondary sort key, two rows with the same
-    // `started_at` could appear on either side of a cursor boundary across
-    // requests, causing rows to skip or duplicate as the user paginates.
+    // `last_active_at` could appear on either side of a cursor boundary
+    // across requests, causing rows to skip or duplicate as the user
+    // paginates.
     .order("session_id", { ascending: false })
     .limit(pageSize + 1);
 
   if (surfaces) query = query.in("surface", surfaces);
 
   if (cursor) {
-    // Composite tuple compare: (started_at, session_id) < cursor.
+    // Composite tuple compare: (last_active_at, session_id) < cursor.
     // PostgREST has no native row-constructor compare, so we expand to the
     // logically-equivalent disjunction.
     //
@@ -85,10 +96,10 @@ export async function getSessions(
     // `(`, `)`) would inject extra top-level conditions into the disjunction,
     // breaking the cursor invariant. Decoding already rejects those shapes
     // (#176), but we quote here too so a direct DAL caller can't bypass it.
-    const startedAt = postgrestQuoteLiteral(cursor.startedAt);
+    const lastActiveAt = postgrestQuoteLiteral(cursor.lastActiveAt);
     const sessionId = postgrestQuoteLiteral(cursor.sessionId);
     query = query.or(
-      `started_at.lt.${startedAt},and(started_at.eq.${startedAt},session_id.lt.${sessionId})`
+      `last_active_at.lt.${lastActiveAt},and(last_active_at.eq.${lastActiveAt},session_id.lt.${sessionId})`
     );
   }
 
@@ -100,7 +111,7 @@ export async function getSessions(
   const tail = rows[rows.length - 1];
   const nextCursor =
     hasMore && tail
-      ? { startedAt: tail.started_at, sessionId: tail.session_id }
+      ? { lastActiveAt: tail.last_active_at, sessionId: tail.session_id }
       : null;
 
   return { rows, nextCursor };
@@ -164,6 +175,9 @@ export interface SessionRow {
   provider: string;
   started_at: string;
   ended_at: string | null;
+  // Generated column: COALESCE(ended_at, started_at). Used for filtering and
+  // sorting by most-recent activity (#340).
+  last_active_at: string;
   duration_ms: number | null;
   repo_id: string | null;
   git_branch: string | null;

--- a/src/lib/sessions-cursor.test.ts
+++ b/src/lib/sessions-cursor.test.ts
@@ -16,7 +16,7 @@ import {
 describe("decodeSessionsCursor (#176)", () => {
   it("round-trips a well-formed cursor", () => {
     const original = {
-      startedAt: "2026-04-15T10:00:00.000Z",
+      lastActiveAt: "2026-04-15T10:00:00.000Z",
       sessionId: "sess_0001",
     };
     const decoded = decodeSessionsCursor(encodeSessionsCursor(original));
@@ -38,18 +38,18 @@ describe("decodeSessionsCursor (#176)", () => {
     expect(decodeSessionsCursor(toBase64Url(JSON.stringify({})))).toBeNull();
     expect(
       decodeSessionsCursor(
-        toBase64Url(JSON.stringify({ startedAt: 123, sessionId: "x" }))
+        toBase64Url(JSON.stringify({ lastActiveAt: 123, sessionId: "x" }))
       )
     ).toBeNull();
     expect(
       decodeSessionsCursor(
-        toBase64Url(JSON.stringify({ startedAt: "x", sessionId: null }))
+        toBase64Url(JSON.stringify({ lastActiveAt: "x", sessionId: null }))
       )
     ).toBeNull();
   });
 
-  it("rejects startedAt values that aren't a real ISO-8601 instant", () => {
-    for (const startedAt of [
+  it("rejects lastActiveAt values that aren't a real ISO-8601 instant", () => {
+    for (const lastActiveAt of [
       "not-a-date",
       "2026-13-45T99:99:99.000Z",
       "2026", // Date.parse accepts this; we don't.
@@ -58,7 +58,7 @@ describe("decodeSessionsCursor (#176)", () => {
       "2026-04-15T10:00:00Z", // No milliseconds → toISOString won't match.
     ]) {
       const raw = toBase64Url(
-        JSON.stringify({ startedAt, sessionId: "sess_0001" })
+        JSON.stringify({ lastActiveAt, sessionId: "sess_0001" })
       );
       expect(decodeSessionsCursor(raw)).toBeNull();
     }
@@ -68,18 +68,18 @@ describe("decodeSessionsCursor (#176)", () => {
     // The bug report's exact crafted shape: a `,` lifts the trailing fragment
     // up to a top-level term in the .or() disjunction, breaking the cursor
     // invariant. Same risk for `(` and `)` opening / closing a nested group.
-    const startedAt = "2026-01-01T00:00:00.000Z";
+    const lastActiveAt = "2026-01-01T00:00:00.000Z";
     for (const sessionId of [
       "x,y",
       "x)or(true",
-      "a),or(started_at.gt.1900-01-01,and(true",
+      "a),or(last_active_at.gt.1900-01-01,and(true",
       "x(",
       "x)",
       "(",
       ")",
       ",",
     ]) {
-      const raw = toBase64Url(JSON.stringify({ startedAt, sessionId }));
+      const raw = toBase64Url(JSON.stringify({ lastActiveAt, sessionId }));
       expect(decodeSessionsCursor(raw)).toBeNull();
     }
   });
@@ -96,7 +96,7 @@ describe("decodeSessionsCursor (#176)", () => {
       "sess-with-dashes",
     ]) {
       const original = {
-        startedAt: "2026-04-15T10:00:00.000Z",
+        lastActiveAt: "2026-04-15T10:00:00.000Z",
         sessionId,
       };
       const decoded = decodeSessionsCursor(encodeSessionsCursor(original));
@@ -112,12 +112,12 @@ describe("decodeSessionsCursor (#176)", () => {
     const canonical = "2026-05-08T02:02:02.469Z";
     const decoded = decodeSessionsCursor(
       encodeSessionsCursor({
-        startedAt: postgrestShape,
+        lastActiveAt: postgrestShape,
         sessionId: "sess_0001",
       })
     );
     expect(decoded).toEqual({
-      startedAt: canonical,
+      lastActiveAt: canonical,
       sessionId: "sess_0001",
     });
   });
@@ -131,9 +131,12 @@ describe("decodeSessionsCursor (#176)", () => {
     ];
     for (const [input, expected] of inputs) {
       const decoded = decodeSessionsCursor(
-        encodeSessionsCursor({ startedAt: input, sessionId: "sess_x" })
+        encodeSessionsCursor({ lastActiveAt: input, sessionId: "sess_x" })
       );
-      expect(decoded).toEqual({ startedAt: expected, sessionId: "sess_x" });
+      expect(decoded).toEqual({
+        lastActiveAt: expected,
+        sessionId: "sess_x",
+      });
     }
   });
 
@@ -145,7 +148,7 @@ describe("decodeSessionsCursor (#176)", () => {
       decodeSessionsCursor(
         toBase64Url(
           JSON.stringify({
-            startedAt: "2026-04-15T10:00:00.000Z",
+            lastActiveAt: "2026-04-15T10:00:00.000Z",
             sessionId: big,
           })
         )
@@ -155,7 +158,7 @@ describe("decodeSessionsCursor (#176)", () => {
       decodeSessionsCursor(
         toBase64Url(
           JSON.stringify({
-            startedAt: big,
+            lastActiveAt: big,
             sessionId: "sess_0001",
           })
         )

--- a/src/lib/sessions-cursor.ts
+++ b/src/lib/sessions-cursor.ts
@@ -4,15 +4,18 @@ import type { SessionsCursor } from "@/lib/dal";
  * URL serialization for the Sessions page cursor.
  *
  * `session_id` is daemon-provided TEXT, so we don't trust it to be free of
- * URL-meaningful characters. Encoding the `(started_at, session_id)` tuple as
- * base64url JSON keeps the cursor opaque to the browser/router and avoids any
- * delimiter collision the daemon could trip on. A malformed cursor decodes to
- * `null` so a hand-edited URL silently falls back to "first page" rather than
- * 500ing — same defensive posture as the user filter in #80.
+ * URL-meaningful characters. Encoding the `(last_active_at, session_id)` tuple
+ * as base64url JSON keeps the cursor opaque to the browser/router and avoids
+ * any delimiter collision the daemon could trip on. A malformed cursor decodes
+ * to `null` so a hand-edited URL silently falls back to "first page" rather
+ * than 500ing — same defensive posture as the user filter in #80.
+ *
+ * History: prior to #340 this encoded `startedAt`. Old cursors decode to `null`
+ * (missing `lastActiveAt` field) and silently reset to page 1.
  */
 export function encodeSessionsCursor(cursor: SessionsCursor): string {
   const json = JSON.stringify({
-    startedAt: normalizeIsoInstant(cursor.startedAt),
+    lastActiveAt: normalizeIsoInstant(cursor.lastActiveAt),
     sessionId: cursor.sessionId,
   });
   return base64UrlEncode(json);
@@ -45,9 +48,10 @@ function normalizeIsoInstant(value: string): string {
  * crafted URL falls back cleanly to "first page" instead of producing a 500
  * deeper in the query path.
  *
- * - `startedAt` must round-trip through `Date` and reproduce the same string,
- *   pinning it to a real ISO-8601 instant (e.g. `2026-04-15T10:00:00.000Z`).
- *   This rejects free-form strings the cursor was never meant to carry.
+ * - `lastActiveAt` must round-trip through `Date` and reproduce the same
+ *   string, pinning it to a real ISO-8601 instant (e.g.
+ *   `2026-04-15T10:00:00.000Z`). This rejects free-form strings the cursor
+ *   was never meant to carry.
  * - `sessionId` must not contain `,` `(` `)` — the PostgREST filter-tree
  *   delimiters that drove the original injection report. Real daemons emit
  *   opaque token-shaped ids; these characters never legitimately appear.
@@ -65,20 +69,20 @@ export function decodeSessionsCursor(
     const json = base64UrlDecode(raw);
     const parsed = JSON.parse(json) as Partial<SessionsCursor>;
     if (
-      typeof parsed.startedAt !== "string" ||
+      typeof parsed.lastActiveAt !== "string" ||
       typeof parsed.sessionId !== "string"
     ) {
       return null;
     }
     if (
-      parsed.startedAt.length > MAX_CURSOR_FIELD_LEN ||
+      parsed.lastActiveAt.length > MAX_CURSOR_FIELD_LEN ||
       parsed.sessionId.length > MAX_CURSOR_FIELD_LEN
     ) {
       return null;
     }
-    if (!isIsoInstant(parsed.startedAt)) return null;
+    if (!isIsoInstant(parsed.lastActiveAt)) return null;
     if (SESSION_ID_DISALLOWED.test(parsed.sessionId)) return null;
-    return { startedAt: parsed.startedAt, sessionId: parsed.sessionId };
+    return { lastActiveAt: parsed.lastActiveAt, sessionId: parsed.sessionId };
   } catch {
     return null;
   }

--- a/supabase/migrations/026_session_last_active_at.sql
+++ b/supabase/migrations/026_session_last_active_at.sql
@@ -1,0 +1,15 @@
+-- #340: Cloud sessions filter should include sessions with recent activity
+--
+-- The Sessions page previously filtered on `started_at`, so a session that
+-- started months ago but has new turns today was invisible in the 1d / 7d
+-- views.  Fix: a stored generated column `last_active_at` that both the
+-- time-period filter and the cursor-based sort can target.  This matches the
+-- local statusline's cost_1d / cost_7d / cost_30d computation which uses
+-- message timestamps, not session creation time.
+
+ALTER TABLE session_summaries
+  ADD COLUMN last_active_at TIMESTAMPTZ
+  GENERATED ALWAYS AS (COALESCE(ended_at, started_at)) STORED;
+
+CREATE INDEX idx_session_summaries_last_active_at
+    ON session_summaries (last_active_at);


### PR DESCRIPTION
## Summary

- Adds a Postgres generated column `last_active_at = COALESCE(ended_at, started_at)` to `session_summaries` (migration 026)
- Sessions page now filters and sorts by `last_active_at` instead of `started_at`, so long-lived sessions with recent activity (e.g. JetBrains Copilot Chat started 7 months ago) appear in 1d/7d/30d views
- Renames the "Started" column to "Last Active" and updates cursor pagination to use the new column

## Test plan

- [x] All 448 existing tests pass (including updated cursor, page, and ingest tests)
- [x] New regression test: session with `started_at` 7 months ago but `ended_at` today appears in a 1-day range
- [x] TypeScript compiles cleanly
- [ ] Verify migration runs on Supabase staging
- [ ] Manual: open `/dashboard/sessions?days=1` and confirm a long-lived session with today's activity appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)