### PR TITLE
feat: rate-limit window charts and team analytics (closes #339)

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -87,6 +87,7 @@ All dashboard pages live under `/dashboard`:
 - `/dashboard/models` — breakdown by model / provider
 - `/dashboard/repos` — breakdown by repo / branch / ticket
 - `/dashboard/sessions` — session list with health signals; `/dashboard/sessions/[id]` for a single-session drill-down
+- `/dashboard/rate-limits` — rate-limit window charts: usage timeline, throttle events, burn rate trends, and (managers) team throttle impact
 - `/dashboard/settings` — workspace info, the viewer's API key, members list, and (managers) invite link generation; nested `/dashboard/settings/pricing` for the workspace's price-list overrides
 
 ## Window contract and local→cloud linking

--- a/src/app/api/v1/ingest/route.ts
+++ b/src/app/api/v1/ingest/route.ts
@@ -9,10 +9,12 @@ import {
 import {
   buildRollupRows,
   buildSessionRows,
+  buildWindowRows,
   summarizeEnvelope,
   validateIngestMetrics,
   type IngestDailyRollup,
   type IngestSessionSummary,
+  type IngestWindowSummary,
 } from "@/app/api/v1/ingest/rows";
 
 // ADR-0083 §7: Max body size 1 MiB
@@ -24,13 +26,12 @@ const MAX_BODY_BYTES = 1024 * 1024;
 // the daily_rollups insert pressure, not just a one-line edit.
 const RATE_LIMIT = { limit: 60, windowSeconds: 60 } as const;
 
-// Accept v1 (pre-#741 daemons), v2 (v8.4.3+ daemons that added `surface`), and
-// v3 (v8.5.0+ daemons that added session `title` per siropkin/budi#779). Each
-// bump is a strict superset of the previous one: every new field is optional
-// in the row builders, so older payloads remain valid. See siropkin/budi#749 —
-// bumping the daemon's schema_version without widening the server's accepted
-// set broke cloud sync for every v8.4.3 upgrader.
-const SUPPORTED_SCHEMA_VERSIONS = new Set([1, 2, 3]);
+// Accept v1 (pre-#741 daemons), v2 (v8.4.3+ daemons that added `surface`),
+// v3 (v8.5.0+ daemons that added session `title` per siropkin/budi#779), and
+// v4 (v8.5.4+ daemons that added `window_summaries` per #339). Each bump is a
+// strict superset of the previous one: every new field is optional in the row
+// builders, so older payloads remain valid.
+const SUPPORTED_SCHEMA_VERSIONS = new Set([1, 2, 3, 4]);
 
 // Cap the stored label so a malformed envelope can't flood the devices table.
 // 128 chars is comfortably above any sane hostname or user-chosen nickname.
@@ -63,6 +64,7 @@ interface SyncEnvelope {
   payload: {
     daily_rollups: IngestDailyRollup[];
     session_summaries: IngestSessionSummary[];
+    window_summaries?: IngestWindowSummary[];
   };
 }
 
@@ -152,12 +154,19 @@ function validateEnvelope(body: SyncEnvelope): string | null {
   if (!Array.isArray(body.payload.session_summaries)) {
     return "payload.session_summaries must be an array";
   }
+  if (
+    body.payload.window_summaries !== undefined &&
+    !Array.isArray(body.payload.window_summaries)
+  ) {
+    return "payload.window_summaries must be an array";
+  }
   // #178: reject the whole envelope on non-finite or negative numeric metrics
   // so a misbehaving daemon pauses (ADR-0083 §7) instead of silently
   // poisoning every aggregate that touches the row for the 90-day window.
   const metricError = validateIngestMetrics(
     body.payload.daily_rollups,
-    body.payload.session_summaries
+    body.payload.session_summaries,
+    body.payload.window_summaries
   );
   if (metricError) return metricError;
   return null;
@@ -332,6 +341,14 @@ export async function POST(request: NextRequest) {
           body.payload.session_summaries
         )
       : [];
+  const windowRows =
+    body.payload.window_summaries && body.payload.window_summaries.length > 0
+      ? buildWindowRows(
+          body.device_id,
+          body.synced_at,
+          body.payload.window_summaries
+        )
+      : [];
 
   if (rollupRows.length > 0) {
     const { error: rollupError, count } = await supabase
@@ -376,6 +393,26 @@ export async function POST(request: NextRequest) {
     sessionSummariesUpserted = count ?? sessionRows.length;
   }
 
+  // --- UPSERT window summaries (#339) ---
+  let windowSummariesUpserted = 0;
+  if (windowRows.length > 0) {
+    const { error: windowError, count } = await supabase
+      .from("window_summaries")
+      .upsert(windowRows, {
+        onConflict: "device_id,started_at",
+        count: "exact",
+      });
+
+    if (windowError) {
+      console.error("Failed to upsert window_summaries:", windowError);
+      return Response.json(
+        { error: "Failed to store window summaries" },
+        { status: 500 }
+      );
+    }
+    windowSummariesUpserted = count ?? windowRows.length;
+  }
+
   // --- Compute watermark: latest fully-synced bucket_day ---
   const { data: watermarkRow } = await supabase
     .from("daily_rollups")
@@ -400,9 +437,11 @@ export async function POST(request: NextRequest) {
   return Response.json({
     accepted: true,
     watermark,
-    records_upserted: dailyRollupsUpserted + sessionSummariesUpserted,
+    records_upserted:
+      dailyRollupsUpserted + sessionSummariesUpserted + windowSummariesUpserted,
     daily_rollups_upserted: dailyRollupsUpserted,
     session_summaries_upserted: sessionSummariesUpserted,
+    window_summaries_upserted: windowSummariesUpserted,
     surfaces_seen,
     providers_seen,
   });

--- a/src/app/api/v1/ingest/rows.test.ts
+++ b/src/app/api/v1/ingest/rows.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildWindowRows,
+  validateIngestMetrics,
+  type IngestWindowSummary,
+} from "./rows";
+
+const baseWindow: IngestWindowSummary = {
+  started_at: "2026-05-14T10:00:00Z",
+  ended_at: "2026-05-14T15:00:00Z",
+  duration_minutes: 300,
+  is_active: false,
+  message_count: 42,
+  input_tokens: 5000,
+  output_tokens: 2000,
+  cache_creation_tokens: 100,
+  cache_read_tokens: 300,
+  cost_cents: 150,
+  burn_rate_cents_per_minute: 0.5,
+  hit_rate_limit: true,
+  provider: "claude_code",
+  surface: "terminal",
+};
+
+describe("buildWindowRows", () => {
+  it("maps all fields to the database row shape", () => {
+    const rows = buildWindowRows("dev_1", "2026-05-15T00:00:00Z", [baseWindow]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      device_id: "dev_1",
+      started_at: "2026-05-14T10:00:00Z",
+      ended_at: "2026-05-14T15:00:00Z",
+      duration_minutes: 300,
+      is_active: false,
+      message_count: 42,
+      input_tokens: 5000,
+      output_tokens: 2000,
+      cache_creation_tokens: 100,
+      cache_read_tokens: 300,
+      cost_cents: 150,
+      burn_rate_cents_per_minute: 0.5,
+      hit_rate_limit: true,
+      provider: "claude_code",
+      surface: "terminal",
+      synced_at: "2026-05-15T00:00:00Z",
+    });
+  });
+
+  it("defaults optional booleans to false when missing", () => {
+    const { is_active, hit_rate_limit, ...rest } = baseWindow;
+    void is_active;
+    void hit_rate_limit;
+    const rows = buildWindowRows("dev_1", "2026-05-15T00:00:00Z", [
+      rest as IngestWindowSummary,
+    ]);
+
+    expect(rows[0].is_active).toBe(false);
+    expect(rows[0].hit_rate_limit).toBe(false);
+  });
+
+  it("normalizes missing surface and provider to 'unknown'", () => {
+    const rows = buildWindowRows("dev_1", "2026-05-15T00:00:00Z", [
+      { ...baseWindow, provider: null, surface: null },
+    ]);
+
+    expect(rows[0].provider).toBe("unknown");
+    expect(rows[0].surface).toBe("unknown");
+  });
+
+  it("clamps negative metrics to zero", () => {
+    const rows = buildWindowRows("dev_1", "2026-05-15T00:00:00Z", [
+      {
+        ...baseWindow,
+        cost_cents: -10,
+        input_tokens: -5,
+      } as IngestWindowSummary,
+    ]);
+
+    expect(rows[0].cost_cents).toBe(0);
+    expect(rows[0].input_tokens).toBe(0);
+  });
+
+  it("caps metrics at their configured max", () => {
+    const rows = buildWindowRows("dev_1", "2026-05-15T00:00:00Z", [
+      { ...baseWindow, cost_cents: 1e12, duration_minutes: 9999 },
+    ]);
+
+    expect(rows[0].cost_cents).toBe(1e8);
+    expect(rows[0].duration_minutes).toBe(600);
+  });
+});
+
+describe("validateIngestMetrics — window_summaries", () => {
+  it("returns null for valid window summaries", () => {
+    const result = validateIngestMetrics([], [], [baseWindow]);
+    expect(result).toBeNull();
+  });
+
+  it("rejects NaN in message_count", () => {
+    const result = validateIngestMetrics(
+      [],
+      [],
+      [{ ...baseWindow, message_count: NaN }]
+    );
+    expect(result).toMatch(/window_summaries\[0\].message_count/);
+  });
+
+  it("rejects negative cost_cents", () => {
+    const result = validateIngestMetrics(
+      [],
+      [],
+      [{ ...baseWindow, cost_cents: -1 }]
+    );
+    expect(result).toMatch(/window_summaries\[0\].cost_cents/);
+  });
+
+  it("rejects Infinity in duration_minutes", () => {
+    const result = validateIngestMetrics(
+      [],
+      [],
+      [{ ...baseWindow, duration_minutes: Infinity }]
+    );
+    expect(result).toMatch(/window_summaries\[0\].duration_minutes/);
+  });
+
+  it("rejects negative burn_rate_cents_per_minute", () => {
+    const result = validateIngestMetrics(
+      [],
+      [],
+      [{ ...baseWindow, burn_rate_cents_per_minute: -0.5 }]
+    );
+    expect(result).toMatch(/window_summaries\[0\].burn_rate_cents_per_minute/);
+  });
+
+  it("skips validation when windows array is undefined", () => {
+    const result = validateIngestMetrics([], [], undefined);
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/api/v1/ingest/rows.ts
+++ b/src/app/api/v1/ingest/rows.ts
@@ -110,6 +110,8 @@ export const METRIC_CAPS = {
   total_input_tokens: 1e10,
   total_output_tokens: 1e10,
   total_cost_cents: 1e8,
+  duration_minutes: 600,
+  burn_rate_cents_per_minute: 1e6,
 } as const;
 
 /**
@@ -148,6 +150,15 @@ const SESSION_METRIC_FIELDS = [
   "total_cost_cents",
 ] as const satisfies ReadonlyArray<keyof IngestSessionSummary>;
 
+const WINDOW_METRIC_FIELDS = [
+  "message_count",
+  "input_tokens",
+  "output_tokens",
+  "cache_creation_tokens",
+  "cache_read_tokens",
+  "cost_cents",
+] as const satisfies ReadonlyArray<keyof IngestWindowSummary>;
+
 /**
  * Walks the envelope's rollups and session summaries, returning a 422-style
  * error message on the first non-finite or negative numeric metric.
@@ -159,7 +170,8 @@ const SESSION_METRIC_FIELDS = [
  */
 export function validateIngestMetrics(
   rollups: IngestDailyRollup[],
-  sessions: IngestSessionSummary[]
+  sessions: IngestSessionSummary[],
+  windows?: IngestWindowSummary[]
 ): string | null {
   for (let i = 0; i < rollups.length; i++) {
     const r = rollups[i];
@@ -187,6 +199,22 @@ export function validateIngestMetrics(
     for (const f of SESSION_METRIC_FIELDS) {
       if (!isValidNonNegativeNumber(s[f])) {
         return `session_summaries[${i}].${f} must be a finite, non-negative number`;
+      }
+    }
+  }
+  if (windows) {
+    for (let i = 0; i < windows.length; i++) {
+      const w = windows[i];
+      for (const f of WINDOW_METRIC_FIELDS) {
+        if (!isValidNonNegativeNumber(w[f])) {
+          return `window_summaries[${i}].${f} must be a finite, non-negative number`;
+        }
+      }
+      if (!isValidNonNegativeNumber(w.duration_minutes)) {
+        return `window_summaries[${i}].duration_minutes must be a finite, non-negative number`;
+      }
+      if (!isValidNonNegativeNumber(w.burn_rate_cents_per_minute)) {
+        return `window_summaries[${i}].burn_rate_cents_per_minute must be a finite, non-negative number`;
       }
     }
   }
@@ -472,6 +500,69 @@ export function buildSessionRows(
     ),
     vital_overall_state: normalizeVitalState(s.vital_overall_state),
     surface: normalizeSurface(s.surface),
+    synced_at: syncedAt,
+  }));
+}
+
+export interface IngestWindowSummary {
+  started_at: string;
+  ended_at: string;
+  duration_minutes: number;
+  is_active?: boolean;
+  message_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  cost_cents: number;
+  burn_rate_cents_per_minute: number;
+  hit_rate_limit?: boolean;
+  provider?: string | null;
+  surface?: string | null;
+}
+
+export function buildWindowRows(
+  deviceId: string,
+  syncedAt: string,
+  windows: IngestWindowSummary[]
+) {
+  return windows.map((w) => ({
+    device_id: deviceId,
+    started_at: w.started_at,
+    ended_at: w.ended_at,
+    duration_minutes: safeNonNegativeNumber(
+      w.duration_minutes,
+      METRIC_CAPS.duration_minutes
+    ),
+    is_active: w.is_active ?? false,
+    message_count: safeNonNegativeNumber(
+      w.message_count,
+      METRIC_CAPS.message_count
+    ),
+    input_tokens: safeNonNegativeNumber(
+      w.input_tokens,
+      METRIC_CAPS.input_tokens
+    ),
+    output_tokens: safeNonNegativeNumber(
+      w.output_tokens,
+      METRIC_CAPS.output_tokens
+    ),
+    cache_creation_tokens: safeNonNegativeNumber(
+      w.cache_creation_tokens,
+      METRIC_CAPS.cache_creation_tokens
+    ),
+    cache_read_tokens: safeNonNegativeNumber(
+      w.cache_read_tokens,
+      METRIC_CAPS.cache_read_tokens
+    ),
+    cost_cents: safeNonNegativeNumber(w.cost_cents, METRIC_CAPS.cost_cents),
+    burn_rate_cents_per_minute: safeNonNegativeNumber(
+      w.burn_rate_cents_per_minute,
+      METRIC_CAPS.burn_rate_cents_per_minute
+    ),
+    hit_rate_limit: w.hit_rate_limit ?? false,
+    provider: normalizeSurface(w.provider),
+    surface: normalizeSurface(w.surface),
     synced_at: syncedAt,
   }));
 }

--- a/src/app/dashboard/rate-limits/_components/burn-rate-chart.tsx
+++ b/src/app/dashboard/rate-limits/_components/burn-rate-chart.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtCost, fmtDate, fmtFullDate } from "@/lib/format";
+
+interface BurnRateDatum {
+  bucket_day: string;
+  avg_burn_rate: number;
+}
+
+export function BurnRateChart({ data }: { data: BurnRateDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No burn rate data for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={{ left: 16, right: 8, top: 8, bottom: 8 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => fmtCost(v)}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={64}
+          label={{
+            value: "Burn rate (¢/min)",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(l) => fmtFullDate(String(l))}
+          formatter={(value) => [
+            `${fmtCost(Number(value))}/min`,
+            "Avg burn rate",
+          ]}
+        />
+        <Line
+          type="monotone"
+          dataKey="avg_burn_rate"
+          stroke="#f59e0b"
+          strokeWidth={2}
+          dot={{ fill: "#f59e0b", r: 3 }}
+          activeDot={{ r: 5 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/dashboard/rate-limits/_components/team-throttle-chart.tsx
+++ b/src/app/dashboard/rate-limits/_components/team-throttle-chart.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+
+interface TeamThrottleDatum {
+  bucket_day: string;
+  users_hitting_limit: number;
+  total_throttle_windows: number;
+  total_windows: number;
+}
+
+export function TeamThrottleChart({ data }: { data: TeamThrottleDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No team rate limit data for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ left: 16, right: 8, top: 8, bottom: 8 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tickFormatter={fmtNum}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={48}
+          label={{
+            value: "Users throttled",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(l) => fmtFullDate(String(l))}
+          formatter={(value, name) => {
+            if (name === "users_hitting_limit")
+              return [fmtNum(Number(value)), "Users throttled"];
+            return [fmtNum(Number(value)), String(name)];
+          }}
+        />
+        <Bar
+          dataKey="users_hitting_limit"
+          fill="#ef4444"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/dashboard/rate-limits/_components/throttle-events-chart.tsx
+++ b/src/app/dashboard/rate-limits/_components/throttle-events-chart.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+
+interface ThrottleDatum {
+  bucket_day: string;
+  users_hitting_limit: number;
+  total_throttle_windows: number;
+}
+
+export function ThrottleEventsChart({ data }: { data: ThrottleDatum[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No throttle events for this period
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} margin={{ left: 16, right: 8, top: 8, bottom: 8 }}>
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tickFormatter={fmtNum}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={48}
+          label={{
+            value: "Throttle events",
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(l) => fmtFullDate(String(l))}
+          formatter={(value, name) => {
+            if (name === "total_throttle_windows")
+              return [fmtNum(Number(value)), "Throttle events"];
+            return [fmtNum(Number(value)), "Users hit limit"];
+          }}
+        />
+        <Bar
+          dataKey="total_throttle_windows"
+          fill="#ef4444"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/dashboard/rate-limits/_components/window-usage-chart.tsx
+++ b/src/app/dashboard/rate-limits/_components/window-usage-chart.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { fmtCost, fmtDate, fmtFullDate, fmtNum } from "@/lib/format";
+
+interface WindowUsageDatum {
+  bucket_day: string;
+  window_count: number;
+  cost_cents: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+export function WindowUsageChart({
+  data,
+  unit,
+}: {
+  data: WindowUsageDatum[];
+  unit: "dollars" | "tokens";
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+        No window data for this period
+      </div>
+    );
+  }
+
+  const isTokens = unit === "tokens";
+  const dataKey = isTokens ? "tokens" : "cost_cents";
+  const label = isTokens ? "Tokens" : "Cost";
+
+  const chartData = data.map((d) => ({
+    ...d,
+    tokens: d.input_tokens + d.output_tokens,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={chartData}
+        margin={{ left: 16, right: 8, top: 8, bottom: 8 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="rgba(255,255,255,0.06)"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="bucket_day"
+          tickFormatter={fmtDate}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tickFormatter={(v) => (isTokens ? fmtNum(v) : fmtCost(v))}
+          tick={{ fill: "#71717a", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+          width={64}
+          label={{
+            value: label,
+            angle: -90,
+            position: "insideLeft",
+            offset: 0,
+            dx: -8,
+            style: { fill: "#71717a", fontSize: 12, textAnchor: "middle" },
+          }}
+        />
+        <Tooltip
+          cursor={{ fill: "rgba(255,255,255,0.05)" }}
+          contentStyle={{
+            background: "#18181b",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: "8px",
+            fontSize: "13px",
+          }}
+          labelFormatter={(l) => fmtFullDate(String(l))}
+          formatter={(value, name) => {
+            if (name === "cost_cents") return [fmtCost(Number(value)), "Cost"];
+            return [fmtNum(Number(value)), "Tokens"];
+          }}
+        />
+        <Bar
+          dataKey={dataKey}
+          fill="#3b82f6"
+          maxBarSize={28}
+          radius={[4, 4, 0, 0]}
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/app/dashboard/rate-limits/page.test.tsx
+++ b/src/app/dashboard/rate-limits/page.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { containsSuspense, extractText } from "@/test-utils/page-tree";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/viewer-timezone", () => ({
+  getViewerTimeZone: async () => "UTC",
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (to: string) => {
+    throw new Error(`__REDIRECT__:${to}`);
+  },
+  notFound: () => {
+    throw new Error("__NOT_FOUND__");
+  },
+}));
+
+const dal = {
+  getCurrentUser: vi.fn(),
+  getEarliestActivity: vi.fn(),
+  getKnownSurfaces: vi.fn(),
+  getWorkspaceMembers: vi.fn(),
+  getWindowTimeline: vi.fn(),
+  getThrottleEvents: vi.fn(),
+  getTeamRateLimitStats: vi.fn(),
+};
+vi.mock("@/lib/dal", () => dal);
+
+const MANAGER = {
+  id: "usr_ivan",
+  workspace_id: "org_team",
+  role: "manager",
+  api_key: "budi_i",
+  display_name: "Ivan",
+  email: "ivan@example.com",
+};
+
+const MEMBER = {
+  ...MANAGER,
+  role: "member",
+};
+
+beforeEach(() => {
+  dal.getCurrentUser.mockReset().mockResolvedValue(MANAGER);
+  dal.getEarliestActivity.mockReset().mockResolvedValue("2026-04-01");
+  dal.getKnownSurfaces.mockReset().mockResolvedValue(["terminal"]);
+  dal.getWorkspaceMembers.mockReset().mockResolvedValue([]);
+  dal.getWindowTimeline.mockReset().mockResolvedValue([
+    {
+      bucket_day: "2026-05-14",
+      window_count: 3,
+      message_count: 42,
+      input_tokens: 5000,
+      output_tokens: 2000,
+      cost_cents: 150,
+      avg_burn_rate: 0.5,
+    },
+  ]);
+  dal.getThrottleEvents.mockReset().mockResolvedValue([
+    {
+      started_at: "2026-05-14T10:00:00Z",
+      ended_at: "2026-05-14T15:00:00Z",
+      duration_minutes: 300,
+      message_count: 42,
+      input_tokens: 5000,
+      output_tokens: 2000,
+      cost_cents: 150,
+      burn_rate: 0.5,
+      device_id: "dev_1",
+      provider: "claude_code",
+      surface: "terminal",
+    },
+  ]);
+  dal.getTeamRateLimitStats.mockReset().mockResolvedValue([
+    {
+      bucket_day: "2026-05-14",
+      users_hitting_limit: 1,
+      total_throttle_windows: 1,
+      total_windows: 3,
+    },
+  ]);
+});
+
+async function render(searchParams: Record<string, string> = {}) {
+  const mod = await import("./page");
+  return mod.default({ searchParams: Promise.resolve(searchParams) });
+}
+
+describe("dashboard/rate-limits /page", () => {
+  it("smoke: renders Rate Limits headline and stat cards", async () => {
+    const node = await render();
+    expect(node).toBeTruthy();
+    const text = extractText(node);
+    expect(text).toContain("Rate Limits");
+    expect(text).toContain("Windows");
+    expect(text).toContain("Throttle events");
+    expect(text).toContain("Avg burn rate");
+  });
+
+  it("shows throttle event details in the table", async () => {
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Claude Code");
+    expect(text).toMatch(/300\s*m/);
+  });
+
+  it("renders team rate limit impact card for managers", async () => {
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("Team Rate Limit Impact");
+  });
+
+  it("hides team rate limit card for members", async () => {
+    dal.getCurrentUser.mockResolvedValue(MEMBER);
+    const node = await render();
+    const text = extractText(node);
+    expect(text).not.toContain("Team Rate Limit Impact");
+  });
+
+  it("renders empty state when no window data exists", async () => {
+    dal.getWindowTimeline.mockResolvedValue([]);
+    dal.getThrottleEvents.mockResolvedValue([]);
+    dal.getTeamRateLimitStats.mockResolvedValue([]);
+    const node = await render();
+    const text = extractText(node);
+    expect(text).toContain("No window data for this period");
+    expect(text).toContain("No throttle events for this period");
+  });
+
+  it("wraps filters in a Suspense boundary", async () => {
+    const node = await render();
+    expect(containsSuspense(node)).toBe(true);
+  });
+
+  it("returns null when the viewer has no workspace_id", async () => {
+    dal.getCurrentUser.mockResolvedValue({ ...MANAGER, workspace_id: null });
+    const node = await render();
+    expect(node).toBeNull();
+  });
+
+  it("switches to tokens unit when ?units=tokens is set", async () => {
+    const node = await render({ units: "tokens" });
+    const text = extractText(node);
+    expect(text).toContain("Total tokens");
+    expect(text).toMatch(/Tokens\s+per Window Period/);
+  });
+});

--- a/src/app/dashboard/rate-limits/page.tsx
+++ b/src/app/dashboard/rate-limits/page.tsx
@@ -209,9 +209,7 @@ export default async function RateLimitsPage({
   );
 }
 
-function aggregateThrottlesByDay(
-  events: { started_at: string }[]
-): {
+function aggregateThrottlesByDay(events: { started_at: string }[]): {
   bucket_day: string;
   total_throttle_windows: number;
   users_hitting_limit: number;

--- a/src/app/dashboard/rate-limits/page.tsx
+++ b/src/app/dashboard/rate-limits/page.tsx
@@ -1,0 +1,231 @@
+import { Suspense } from "react";
+import {
+  getCurrentUser,
+  getEarliestActivity,
+  getKnownSurfaces,
+  getWorkspaceMembers,
+  getWindowTimeline,
+  getThrottleEvents,
+  getTeamRateLimitStats,
+} from "@/lib/dal";
+import { dateRangeFromDays } from "@/lib/date-range";
+import { getViewerTimeZone } from "@/lib/viewer-timezone";
+import { ALL_PERIOD_VALUE } from "@/lib/periods";
+import { parseUnit } from "@/lib/units";
+import { fmtCost, fmtNum, formatProvider } from "@/lib/format";
+import { PageHeader } from "@/components/page-header";
+import { PeriodSelector } from "@/components/filters/period-selector";
+import { UnitsSelector } from "@/components/filters/units-selector";
+import { UserFilter } from "@/components/filters/user-filter";
+import { SurfaceFilter } from "@/components/filters/surface-filter";
+import { parseSurfaceParam } from "@/lib/surface";
+import { StatCard } from "@/components/stat-card";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { WindowUsageChart } from "./_components/window-usage-chart";
+import { ThrottleEventsChart } from "./_components/throttle-events-chart";
+import { BurnRateChart } from "./_components/burn-rate-chart";
+import { TeamThrottleChart } from "./_components/team-throttle-chart";
+
+export default async function RateLimitsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    days?: string;
+    user?: string;
+    units?: string;
+    surface?: string;
+  }>;
+}) {
+  const params = await searchParams;
+  const user = await getCurrentUser();
+  if (!user?.workspace_id) return null;
+
+  const unit = parseUnit(params.units);
+  const surfaces = parseSurfaceParam(params.surface);
+  const scope = { scopedUserId: params.user || null, surfaces };
+  const earliestActivity =
+    params.days === ALL_PERIOD_VALUE
+      ? await getEarliestActivity(user, scope)
+      : null;
+  const tz = await getViewerTimeZone();
+  const range = dateRangeFromDays(params.days, earliestActivity, tz);
+
+  const [windowTimeline, throttleEvents, teamStats, members, knownSurfaces] =
+    await Promise.all([
+      getWindowTimeline(user, range, scope),
+      getThrottleEvents(user, range, scope),
+      user.role === "manager"
+        ? getTeamRateLimitStats(user, range, scope)
+        : Promise.resolve([]),
+      user.role === "manager"
+        ? getWorkspaceMembers(user.workspace_id)
+        : Promise.resolve([]),
+      getKnownSurfaces(user, { scopedUserId: scope.scopedUserId }),
+    ]);
+
+  const isTokens = unit === "tokens";
+
+  const totalWindows = windowTimeline.reduce((s, d) => s + d.window_count, 0);
+  const totalThrottles = throttleEvents.length;
+  const totalCostCents = windowTimeline.reduce((s, d) => s + d.cost_cents, 0);
+  const totalTokens = windowTimeline.reduce(
+    (s, d) => s + d.input_tokens + d.output_tokens,
+    0
+  );
+  const avgBurnRate =
+    windowTimeline.length > 0
+      ? windowTimeline.reduce((s, d) => s + d.avg_burn_rate, 0) /
+        windowTimeline.length
+      : 0;
+
+  const throttlePct =
+    totalWindows > 0 ? ((totalThrottles / totalWindows) * 100).toFixed(1) : "0";
+
+  const isManager = user.role === "manager";
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Rate Limits">
+        <Suspense>
+          <div className="flex flex-wrap items-center gap-3">
+            <UserFilter members={members} role={user.role} />
+            <SurfaceFilter surfaces={knownSurfaces} />
+            <UnitsSelector />
+            <PeriodSelector />
+          </div>
+        </Suspense>
+      </PageHeader>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Windows" value={fmtNum(totalWindows)} />
+        <StatCard
+          title="Throttle events"
+          value={fmtNum(totalThrottles)}
+          subtitle={`${throttlePct}% of windows`}
+        />
+        <StatCard
+          title={isTokens ? "Total tokens" : "Total cost"}
+          value={isTokens ? fmtNum(totalTokens) : fmtCost(totalCostCents)}
+        />
+        <StatCard title="Avg burn rate" value={`${fmtCost(avgBurnRate)}/min`} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {isTokens ? "Tokens" : "Cost"} per Window Period
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <WindowUsageChart data={windowTimeline} unit={unit} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Throttle Events</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {throttleEvents.length === 0 ? (
+            <div className="flex h-64 items-center justify-center text-sm text-zinc-500">
+              No throttle events for this period
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <ThrottleEventsChart
+                data={
+                  teamStats.length > 0
+                    ? teamStats
+                    : aggregateThrottlesByDay(throttleEvents)
+                }
+              />
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-white/10 text-left text-zinc-400">
+                      <th className="pb-2 font-medium">Time</th>
+                      <th className="pb-2 text-right font-medium">Duration</th>
+                      <th className="pb-2 text-right font-medium">Messages</th>
+                      <th className="pb-2 text-right font-medium">
+                        {isTokens ? "Tokens" : "Cost"}
+                      </th>
+                      <th className="pb-2 text-right font-medium">Burn rate</th>
+                      <th className="pb-2 font-medium">Provider</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {throttleEvents.slice(0, 50).map((e, i) => (
+                      <tr key={i} className="border-b border-white/5">
+                        <td className="py-2 text-zinc-200">
+                          {new Date(e.started_at).toLocaleString()}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {Math.round(e.duration_minutes)}m
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {fmtNum(e.message_count)}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {isTokens
+                            ? fmtNum(e.input_tokens + e.output_tokens)
+                            : fmtCost(e.cost_cents)}
+                        </td>
+                        <td className="py-2 text-right tabular-nums text-zinc-300">
+                          {fmtCost(e.burn_rate)}/min
+                        </td>
+                        <td className="py-2 text-zinc-300">
+                          {formatProvider(e.provider)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Burn Rate Trend</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BurnRateChart data={windowTimeline} />
+        </CardContent>
+      </Card>
+
+      {isManager && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Team Rate Limit Impact</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <TeamThrottleChart data={teamStats} />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function aggregateThrottlesByDay(
+  events: { started_at: string }[]
+): {
+  bucket_day: string;
+  total_throttle_windows: number;
+  users_hitting_limit: number;
+}[] {
+  const byDay = new Map<string, number>();
+  for (const e of events) {
+    const day = e.started_at.slice(0, 10);
+    byDay.set(day, (byDay.get(day) ?? 0) + 1);
+  }
+  return Array.from(byDay.entries())
+    .map(([bucket_day, total_throttle_windows]) => ({
+      bucket_day,
+      total_throttle_windows,
+      users_hitting_limit: 0,
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import { clsx } from "clsx";
 import type { MouseEventHandler } from "react";
 import {
   BarChart3,
+  Gauge,
   GitBranch,
   LayoutDashboard,
   Cpu,
@@ -52,6 +53,7 @@ const NAV_ITEMS = [
   { href: "/dashboard/models", label: "Models", icon: Cpu },
   { href: "/dashboard/repos", label: "Repos", icon: GitBranch },
   { href: "/dashboard/sessions", label: "Sessions", icon: Timer },
+  { href: "/dashboard/rate-limits", label: "Rate Limits", icon: Gauge },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
 ] as const;
 

--- a/src/lib/dal/index.ts
+++ b/src/lib/dal/index.ts
@@ -62,3 +62,14 @@ export {
   getWorkspaceHasActivePriceList,
   getRecalculationRuns,
 } from "./pricing";
+
+export {
+  type WindowTimelineDay,
+  type ThrottleEvent,
+  type BurnRatePoint,
+  type TeamRateLimitDay,
+  getWindowTimeline,
+  getThrottleEvents,
+  getBurnRateTrend,
+  getTeamRateLimitStats,
+} from "./windows";

--- a/src/lib/dal/windows.ts
+++ b/src/lib/dal/windows.ts
@@ -1,0 +1,199 @@
+import "server-only";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  type BudiUser,
+  type DateRange,
+  type ScopeOptions,
+  getVisibleDeviceIds,
+  normalizeSurfaces,
+} from "./types";
+
+export interface WindowTimelineDay {
+  bucket_day: string;
+  window_count: number;
+  message_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_cents: number;
+  avg_burn_rate: number;
+}
+
+export async function getWindowTimeline(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<WindowTimelineDay[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_window_timeline", {
+    p_device_ids: deviceIds,
+    p_started_from: range.startedAtFrom,
+    p_started_to: range.startedAtTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as WindowTimelineRow[])
+    .map((r) => ({
+      bucket_day: r.bucket_day,
+      window_count: Number(r.window_count),
+      message_count: Number(r.message_count),
+      input_tokens: Number(r.input_tokens),
+      output_tokens: Number(r.output_tokens),
+      cost_cents: Number(r.cost_cents),
+      avg_burn_rate: Number(r.avg_burn_rate),
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}
+
+interface WindowTimelineRow {
+  bucket_day: string;
+  window_count: number | string;
+  message_count: number | string;
+  input_tokens: number | string;
+  output_tokens: number | string;
+  cost_cents: number | string;
+  avg_burn_rate: number | string;
+}
+
+export interface ThrottleEvent {
+  started_at: string;
+  ended_at: string;
+  duration_minutes: number;
+  message_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_cents: number;
+  burn_rate: number;
+  device_id: string;
+  provider: string;
+  surface: string;
+}
+
+export async function getThrottleEvents(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<ThrottleEvent[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_throttle_events", {
+    p_device_ids: deviceIds,
+    p_started_from: range.startedAtFrom,
+    p_started_to: range.startedAtTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as ThrottleEventRow[]).map((r) => ({
+    started_at: r.started_at,
+    ended_at: r.ended_at,
+    duration_minutes: Number(r.duration_minutes),
+    message_count: Number(r.message_count),
+    input_tokens: Number(r.input_tokens),
+    output_tokens: Number(r.output_tokens),
+    cost_cents: Number(r.cost_cents),
+    burn_rate: Number(r.burn_rate),
+    device_id: r.device_id,
+    provider: r.provider,
+    surface: r.surface,
+  }));
+}
+
+interface ThrottleEventRow {
+  started_at: string;
+  ended_at: string;
+  duration_minutes: number | string;
+  message_count: number | string;
+  input_tokens: number | string;
+  output_tokens: number | string;
+  cost_cents: number | string;
+  burn_rate: number | string;
+  device_id: string;
+  provider: string;
+  surface: string;
+}
+
+export interface BurnRatePoint {
+  started_at: string;
+  burn_rate: number;
+  cost_cents: number;
+  device_id: string;
+}
+
+export async function getBurnRateTrend(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<BurnRatePoint[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_burn_rate_trend", {
+    p_device_ids: deviceIds,
+    p_started_from: range.startedAtFrom,
+    p_started_to: range.startedAtTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as BurnRateRow[]).map((r) => ({
+    started_at: r.started_at,
+    burn_rate: Number(r.burn_rate),
+    cost_cents: Number(r.cost_cents),
+    device_id: r.device_id,
+  }));
+}
+
+interface BurnRateRow {
+  started_at: string;
+  burn_rate: number | string;
+  cost_cents: number | string;
+  device_id: string;
+}
+
+export interface TeamRateLimitDay {
+  bucket_day: string;
+  users_hitting_limit: number;
+  total_throttle_windows: number;
+  total_windows: number;
+}
+
+export async function getTeamRateLimitStats(
+  user: BudiUser,
+  range: DateRange,
+  options?: ScopeOptions
+): Promise<TeamRateLimitDay[]> {
+  const admin = createAdminClient();
+  const deviceIds = await getVisibleDeviceIds(admin, user, options);
+  if (deviceIds.length === 0) return [];
+
+  const { data, error } = await admin.rpc("dashboard_team_rate_limit_stats", {
+    p_device_ids: deviceIds,
+    p_started_from: range.startedAtFrom,
+    p_started_to: range.startedAtTo,
+    p_surfaces: normalizeSurfaces(options?.surfaces),
+  });
+  if (error) throw error;
+
+  return ((data ?? []) as TeamRateLimitRow[])
+    .map((r) => ({
+      bucket_day: r.bucket_day,
+      users_hitting_limit: Number(r.users_hitting_limit),
+      total_throttle_windows: Number(r.total_throttle_windows),
+      total_windows: Number(r.total_windows),
+    }))
+    .sort((a, b) => a.bucket_day.localeCompare(b.bucket_day));
+}
+
+interface TeamRateLimitRow {
+  bucket_day: string;
+  users_hitting_limit: number | string;
+  total_throttle_windows: number | string;
+  total_windows: number | string;
+}

--- a/supabase/migrations/027_window_summaries.sql
+++ b/supabase/migrations/027_window_summaries.sql
@@ -7,7 +7,7 @@
 -- dashboard needs for per-window, throttle-event, and burn-rate charts.
 
 CREATE TABLE public.window_summaries (
-  device_id       UUID           NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  device_id       TEXT           NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
   started_at      TIMESTAMPTZ    NOT NULL,
   ended_at        TIMESTAMPTZ    NOT NULL,
   duration_minutes DOUBLE PRECISION NOT NULL DEFAULT 0,
@@ -57,7 +57,7 @@ CREATE INDEX idx_window_summaries_hit_rate_limit
 
 -- Window usage timeline: tokens/cost per calendar day, aggregated from windows.
 CREATE OR REPLACE FUNCTION dashboard_window_timeline(
-  p_device_ids UUID[],
+  p_device_ids TEXT[],
   p_started_from TIMESTAMPTZ,
   p_started_to   TIMESTAMPTZ,
   p_surfaces     TEXT[] DEFAULT NULL
@@ -90,7 +90,7 @@ $$;
 
 -- Throttle events: windows where the user hit the rate limit.
 CREATE OR REPLACE FUNCTION dashboard_throttle_events(
-  p_device_ids UUID[],
+  p_device_ids TEXT[],
   p_started_from TIMESTAMPTZ,
   p_started_to   TIMESTAMPTZ,
   p_surfaces     TEXT[] DEFAULT NULL
@@ -104,7 +104,7 @@ RETURNS TABLE (
   output_tokens    BIGINT,
   cost_cents       NUMERIC,
   burn_rate        DOUBLE PRECISION,
-  device_id        UUID,
+  device_id        TEXT,
   provider         TEXT,
   surface          TEXT
 ) LANGUAGE sql STABLE AS $$
@@ -131,7 +131,7 @@ $$;
 
 -- Burn rate trend: per-window burn rate ordered by time.
 CREATE OR REPLACE FUNCTION dashboard_burn_rate_trend(
-  p_device_ids UUID[],
+  p_device_ids TEXT[],
   p_started_from TIMESTAMPTZ,
   p_started_to   TIMESTAMPTZ,
   p_surfaces     TEXT[] DEFAULT NULL
@@ -140,7 +140,7 @@ RETURNS TABLE (
   started_at  TIMESTAMPTZ,
   burn_rate   DOUBLE PRECISION,
   cost_cents  NUMERIC,
-  device_id   UUID
+  device_id   TEXT
 ) LANGUAGE sql STABLE AS $$
   SELECT
     w.started_at,
@@ -157,7 +157,7 @@ $$;
 
 -- Team rate-limit stats: count of distinct users who hit rate limits per day.
 CREATE OR REPLACE FUNCTION dashboard_team_rate_limit_stats(
-  p_device_ids UUID[],
+  p_device_ids TEXT[],
   p_started_from TIMESTAMPTZ,
   p_started_to   TIMESTAMPTZ,
   p_surfaces     TEXT[] DEFAULT NULL

--- a/supabase/migrations/027_window_summaries.sql
+++ b/supabase/migrations/027_window_summaries.sql
@@ -27,6 +27,22 @@ CREATE TABLE public.window_summaries (
   PRIMARY KEY (device_id, started_at)
 );
 
+-- Supabase projects ship with anon / authenticated / service_role roles.
+-- The CI migrations job runs against a bare Postgres that lacks them. Stub
+-- them idempotently so the GRANTs below succeed in both environments — on a
+-- real Supabase project these are no-ops.
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+    CREATE ROLE anon NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+    CREATE ROLE authenticated NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+    CREATE ROLE service_role NOLOGIN;
+  END IF;
+END $$;
+
 -- #306: explicit GRANTs for forward compatibility with Supabase's upcoming
 -- Data API default change (2026-10-30).
 GRANT SELECT ON public.window_summaries TO anon;

--- a/supabase/migrations/027_window_summaries.sql
+++ b/supabase/migrations/027_window_summaries.sql
@@ -1,0 +1,184 @@
+-- #339: Rate-limit window summaries — ingest, storage, and dashboard RPCs
+--
+-- The budi daemon (v8.5.4+) computes 5-hour rate-limit windows on-the-fly
+-- from messages and the `rate_limit_resets` table. This migration adds the
+-- cloud-side table to receive pre-aggregated, privacy-safe window summaries
+-- via the sync envelope (approach B from the issue), plus the RPCs the
+-- dashboard needs for per-window, throttle-event, and burn-rate charts.
+
+CREATE TABLE public.window_summaries (
+  device_id       UUID           NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+  started_at      TIMESTAMPTZ    NOT NULL,
+  ended_at        TIMESTAMPTZ    NOT NULL,
+  duration_minutes DOUBLE PRECISION NOT NULL DEFAULT 0,
+  is_active       BOOLEAN        NOT NULL DEFAULT FALSE,
+  message_count   BIGINT         NOT NULL DEFAULT 0,
+  input_tokens    BIGINT         NOT NULL DEFAULT 0,
+  output_tokens   BIGINT         NOT NULL DEFAULT 0,
+  cache_creation_tokens BIGINT   NOT NULL DEFAULT 0,
+  cache_read_tokens     BIGINT   NOT NULL DEFAULT 0,
+  cost_cents      NUMERIC(12,4)  NOT NULL DEFAULT 0,
+  burn_rate_cents_per_minute DOUBLE PRECISION NOT NULL DEFAULT 0,
+  hit_rate_limit  BOOLEAN        NOT NULL DEFAULT FALSE,
+  provider        TEXT           NOT NULL DEFAULT 'unknown',
+  surface         TEXT           NOT NULL DEFAULT 'unknown',
+  synced_at       TIMESTAMPTZ    NOT NULL DEFAULT now(),
+
+  PRIMARY KEY (device_id, started_at)
+);
+
+-- #306: explicit GRANTs for forward compatibility with Supabase's upcoming
+-- Data API default change (2026-10-30).
+GRANT SELECT ON public.window_summaries TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.window_summaries TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.window_summaries TO service_role;
+
+ALTER TABLE public.window_summaries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role has full access to window_summaries"
+  ON public.window_summaries
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Index for time-range scans (the dashboard always filters by device_id + time).
+CREATE INDEX idx_window_summaries_started_at
+  ON window_summaries (started_at);
+
+-- Index for throttle-event queries (Phase 2/3: "who hit their rate limit?").
+CREATE INDEX idx_window_summaries_hit_rate_limit
+  ON window_summaries (hit_rate_limit)
+  WHERE hit_rate_limit = TRUE;
+
+-- ---------------------------------------------------------------------------
+-- Dashboard RPCs
+-- ---------------------------------------------------------------------------
+
+-- Window usage timeline: tokens/cost per calendar day, aggregated from windows.
+CREATE OR REPLACE FUNCTION dashboard_window_timeline(
+  p_device_ids UUID[],
+  p_started_from TIMESTAMPTZ,
+  p_started_to   TIMESTAMPTZ,
+  p_surfaces     TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  bucket_day       DATE,
+  window_count     BIGINT,
+  message_count    BIGINT,
+  input_tokens     BIGINT,
+  output_tokens    BIGINT,
+  cost_cents       NUMERIC,
+  avg_burn_rate    DOUBLE PRECISION
+) LANGUAGE sql STABLE AS $$
+  SELECT
+    (w.started_at AT TIME ZONE 'UTC')::DATE AS bucket_day,
+    COUNT(*)                                AS window_count,
+    SUM(w.message_count)                    AS message_count,
+    SUM(w.input_tokens)                     AS input_tokens,
+    SUM(w.output_tokens)                    AS output_tokens,
+    SUM(w.cost_cents)                       AS cost_cents,
+    AVG(w.burn_rate_cents_per_minute)        AS avg_burn_rate
+  FROM window_summaries w
+  WHERE w.device_id = ANY(p_device_ids)
+    AND w.started_at >= p_started_from
+    AND w.started_at <= p_started_to
+    AND (p_surfaces IS NULL OR w.surface = ANY(p_surfaces))
+  GROUP BY 1
+  ORDER BY 1;
+$$;
+
+-- Throttle events: windows where the user hit the rate limit.
+CREATE OR REPLACE FUNCTION dashboard_throttle_events(
+  p_device_ids UUID[],
+  p_started_from TIMESTAMPTZ,
+  p_started_to   TIMESTAMPTZ,
+  p_surfaces     TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  started_at       TIMESTAMPTZ,
+  ended_at         TIMESTAMPTZ,
+  duration_minutes DOUBLE PRECISION,
+  message_count    BIGINT,
+  input_tokens     BIGINT,
+  output_tokens    BIGINT,
+  cost_cents       NUMERIC,
+  burn_rate        DOUBLE PRECISION,
+  device_id        UUID,
+  provider         TEXT,
+  surface          TEXT
+) LANGUAGE sql STABLE AS $$
+  SELECT
+    w.started_at,
+    w.ended_at,
+    w.duration_minutes,
+    w.message_count,
+    w.input_tokens,
+    w.output_tokens,
+    w.cost_cents,
+    w.burn_rate_cents_per_minute AS burn_rate,
+    w.device_id,
+    w.provider,
+    w.surface
+  FROM window_summaries w
+  WHERE w.device_id = ANY(p_device_ids)
+    AND w.started_at >= p_started_from
+    AND w.started_at <= p_started_to
+    AND w.hit_rate_limit = TRUE
+    AND (p_surfaces IS NULL OR w.surface = ANY(p_surfaces))
+  ORDER BY w.started_at DESC;
+$$;
+
+-- Burn rate trend: per-window burn rate ordered by time.
+CREATE OR REPLACE FUNCTION dashboard_burn_rate_trend(
+  p_device_ids UUID[],
+  p_started_from TIMESTAMPTZ,
+  p_started_to   TIMESTAMPTZ,
+  p_surfaces     TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  started_at  TIMESTAMPTZ,
+  burn_rate   DOUBLE PRECISION,
+  cost_cents  NUMERIC,
+  device_id   UUID
+) LANGUAGE sql STABLE AS $$
+  SELECT
+    w.started_at,
+    w.burn_rate_cents_per_minute AS burn_rate,
+    w.cost_cents,
+    w.device_id
+  FROM window_summaries w
+  WHERE w.device_id = ANY(p_device_ids)
+    AND w.started_at >= p_started_from
+    AND w.started_at <= p_started_to
+    AND (p_surfaces IS NULL OR w.surface = ANY(p_surfaces))
+  ORDER BY w.started_at;
+$$;
+
+-- Team rate-limit stats: count of distinct users who hit rate limits per day.
+CREATE OR REPLACE FUNCTION dashboard_team_rate_limit_stats(
+  p_device_ids UUID[],
+  p_started_from TIMESTAMPTZ,
+  p_started_to   TIMESTAMPTZ,
+  p_surfaces     TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  bucket_day              DATE,
+  users_hitting_limit     BIGINT,
+  total_throttle_windows  BIGINT,
+  total_windows           BIGINT
+) LANGUAGE sql STABLE AS $$
+  SELECT
+    (w.started_at AT TIME ZONE 'UTC')::DATE AS bucket_day,
+    COUNT(DISTINCT d.user_id) FILTER (WHERE w.hit_rate_limit = TRUE) AS users_hitting_limit,
+    COUNT(*) FILTER (WHERE w.hit_rate_limit = TRUE)                  AS total_throttle_windows,
+    COUNT(*)                                                          AS total_windows
+  FROM window_summaries w
+  JOIN devices d ON d.id = w.device_id
+  WHERE w.device_id = ANY(p_device_ids)
+    AND w.started_at >= p_started_from
+    AND w.started_at <= p_started_to
+    AND (p_surfaces IS NULL OR w.surface = ANY(p_surfaces))
+  GROUP BY 1
+  ORDER BY 1;
+$$;


### PR DESCRIPTION
## Summary

- **Phase 1 — Ingest**: New `window_summaries` table (migration 027) with UPSERT support in the ingest route. Adds `IngestWindowSummary` type, `buildWindowRows` builder, and metric validation. Schema version 4 accepted for daemons shipping window data.
- **Phase 2 — Individual charts**: New `/dashboard/rate-limits` page with four cards (window count, throttle events, total cost/tokens, avg burn rate) and three charts: window usage timeline (bar), throttle events (bar), and burn rate trend (line).
- **Phase 3 — Team dashboard**: Manager-only "Team Rate Limit Impact" chart showing per-day count of users hitting rate limits, powered by the `dashboard_team_rate_limit_stats` RPC that joins `window_summaries` with `devices` to resolve user attribution.

Four new Postgres RPCs: `dashboard_window_timeline`, `dashboard_throttle_events`, `dashboard_burn_rate_trend`, `dashboard_team_rate_limit_stats`. DAL module `src/lib/dal/windows.ts` follows the established pattern. Sidebar updated with a "Rate Limits" (Gauge icon) nav item.

## Test plan

- [ ] `npm test` — all 448 existing tests pass (no regressions)
- [ ] `npx tsc --noEmit` — clean type check
- [ ] `npm run lint` + `npm run format:check` — no drift
- [ ] Migration 027 applies cleanly on a fresh `supabase db reset`
- [ ] POST `/v1/ingest` with schema_version 4 and `window_summaries` payload stores rows correctly
- [ ] POST `/v1/ingest` with schema_version ≤ 3 (no `window_summaries`) still works without regressions
- [ ] `/dashboard/rate-limits` renders stat cards and charts (empty state when no window data)
- [ ] Manager sees "Team Rate Limit Impact" card; member does not
- [ ] Period / unit / surface / user filters work on the Rate Limits page

🤖 Generated with [Claude Code](https://claude.com/claude-code)